### PR TITLE
fix(transliterate): handle Cyrillic back and forth

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "steenbergen"
   ],
   "authors": [
-    "Jan van Steenbergen <ijzeren.jan@gmail.com>",
+    "Jan van Steenbergen",
+    "Sergey Cherebedov",
+    "Denis Shabalin",
     "Yaroslav Serhieiev <noomorph@gmail.com>"
   ],
   "license": "MIT",

--- a/src/transliterate/__snapshots__/index.test.ts.snap
+++ b/src/transliterate/__snapshots__/index.test.ts.snap
@@ -1,150 +1,297 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`abcd transliterate(text, "art-Cyrl-x-interslv") 1`] = `
+exports[`transliterate to "art-Cyrl-x-interslv" a cyrillic text 1`] = `
 "На возвышености овца, ктора не имєла волну, увидєла коњев. Првы тегал тежкы воз, вторы носил велико брєме, третји брзо возил мужа.
 Овца рєкла коњам: «Боли мнє срдце, когда виджу, како чловєк владаје коњами.»
 Коњи рєкли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да бы имєл дља себе тепло палто. А овца јест без волны.»
 Услышавши то, овца избєгла в равнину. | Одјезд."
 `;
 
-exports[`abcd transliterate(text, "art-Cyrl-x-interslv-etym") 1`] = `
+exports[`transliterate to "art-Cyrl-x-interslv" a latin text 1`] = `
+"На возвышености овца, ктора не имєла волну, увидєла коњев. Првы тегал тежкы воз, вторы носил велико брєме, третји брзо возил мужа.
+Овца рєкла коњам: «Боли мнє срдце, когда виджу, како чловєк владаје коњами.»
+Коњи рєкли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да бы имєл дља себе тепло палто. А овца јест без волны.»
+Услышавши то, овца избєгла в равнину. | Одјезд."
+`;
+
+exports[`transliterate to "art-Cyrl-x-interslv-etym" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Првы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третји брзо возил мѫжа.
+Овца рѣкла коњам: «Боли мнѣ срдце, къгда виджу, како чловѣк владаје коњами.»
+Коњи рѣкли: «Слушај, овцо, нам боли срдце, къгда видимо ово: мѫж, господарь, бере твојѫ вълнѫ, да бы имѣл дља себе тепло пальто. А овца јесть без вълны.»
+Услышавши то, овца избѣгла в рӑвнину. | Одјезд."
+`;
+
+exports[`transliterate to "art-Cyrl-x-interslv-etym" a latin text 1`] = `
 "На възвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Првы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третји брзо возил мѫжа.
 Овца рѣкла коњам: «Боли мнѣ срдце, къгда виђѫ, како чловѣк владаје коњами.»
 Коњи рѣкли: «Слушај, овцо, нам боли срдце, къгда видимо ово: мѫж, господарь, бере твојѫ вълнѫ, да бы имѣл дља себе тепло пальто. А овца јест без вълны.»
 Услышавши то, овца избѣгла в рӑвнинѫ. | Одјезд."
 `;
 
-exports[`abcd transliterate(text, "art-Cyrl-x-interslv-iotated") 1`] = `
+exports[`transliterate to "art-Cyrl-x-interslv-iotated" a cyrillic text 1`] = `
 "На возвышености овца, ктора не имела волну, увидела коньев. Првы тегал тежкы воз, вторы носил велико бреме, третьи брзо возил мужа.
 Овца рекла коням: «Боли мне срдце, когда виджу, како чловек владае конями.»
 Коньи рекли: «Слушай, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твою волну, да бы имел для себе тепло палто. А овца ест без волны.»
 Услышавши то, овца избегла в равнину. | Од’езд."
 `;
 
-exports[`abcd transliterate(text, "art-Cyrl-x-interslv-iotated-ext") 1`] = `
+exports[`transliterate to "art-Cyrl-x-interslv-iotated" a latin text 1`] = `
+"На возвышености овца, ктора не имела волну, увидела коньев. Првы тегал тежкы воз, вторы носил велико бреме, третьи брзо возил мужа.
+Овца рекла коням: «Боли мне срдце, когда виджу, како чловек владае конями.»
+Коньи рекли: «Слушай, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твою волну, да бы имел для себе тепло палто. А овца ест без волны.»
+Услышавши то, овца избегла в равнину. | Од’езд."
+`;
+
+exports[`transliterate to "art-Cyrl-x-interslv-iotated-ext" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имѣла вълнѫ, увидѣла конѥв. Пьрвы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третӥ бързо возил мѫжа.
+Овца рѣкла коням: «Боли мнѣ сьрдце, къгда виджу, како чловѣк владаѥ конями.»
+Конӥ рѣкли: «Слушай, овцо, нам боли сьрдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл для себе тепло пальто. А овца ѥсть без вълны.»
+Услышавши то, овца избѣгла в рӑвнину. | Од’ѥзд."
+`;
+
+exports[`transliterate to "art-Cyrl-x-interslv-iotated-ext" a latin text 1`] = `
 "На възвышености овца, ктора не имѣла вълнѫ, увидѣла конѥв. Пьрвы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третӥ бързо возил мѫжа.
 Овца рѣкла коням: «Боли мнѣ сьрдце, къгда виђѫ, како чловѣк владаѥ конями.»
 Конӥ рѣкли: «Слушай, овцо, нам боли сьрдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл для себе тепло пальто. А овца ѥст без вълны.»
 Услышавши то, овца избѣгла в рӑвнинѫ. | Од’ѥзд."
 `;
 
-exports[`abcd transliterate(text, "art-Cyrl-x-interslv-northern") 1`] = `
+exports[`transliterate to "art-Cyrl-x-interslv-northern" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имєла волну, увидєла коњев. Первы тјагал тјажки воз, вторы носил велико брємја, третји борзо возил мужа.
+Овца рєкла коњам: «Боли мнє сердце, когда виджу, како чловєк владаје коњами.»
+Коњи рєкли: «Слушај, овцо, нам боли сердце, когда видимо ово: муж, господарь, бере твоју волну, да бы имєл дља себе тепло пальто. А овца јесть без волны.»
+Услышавши то, овца избєгла в ровнину. | Одјезд."
+`;
+
+exports[`transliterate to "art-Cyrl-x-interslv-northern" a latin text 1`] = `
 "На возвышености овца, ктора не имєла волну, увидєла коњев. Первы тјагал тјажки воз, вторы носил велико брємја, третји борзо возил мужа.
 Овца рєкла коњам: «Боли мнє сердце, когда виджу, како чловєк владаје коњами.»
 Коњи рєкли: «Слушај, овцо, нам боли сердце, когда видимо ово: муж, господарь, бере твоју волну, да бы имєл дља себе тепло пальто. А овца јест без волны.»
 Услышавши то, овца избєгла в ровнину. | Одјезд."
 `;
 
-exports[`abcd transliterate(text, "art-Cyrl-x-interslv-sloviant") 1`] = `
+exports[`transliterate to "art-Cyrl-x-interslv-sloviant" a cyrillic text 1`] = `
 "На возвишености овца, ктора не имела волну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
 Овца рекла коњам: «Боли мне срдце, когда виджу, како чловек владаје коњами.»
 Коњи рекли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да би имел дља себе тепло палто. А овца јест без волни.»
 Услишавши то, овца избегла в равнину. | Одјезд."
 `;
 
-exports[`abcd transliterate(text, "art-Cyrl-x-interslv-southern") 1`] = `
+exports[`transliterate to "art-Cyrl-x-interslv-sloviant" a latin text 1`] = `
+"На возвишености овца, ктора не имела волну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
+Овца рекла коњам: «Боли мне срдце, когда виджу, како чловек владаје коњами.»
+Коњи рекли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да би имел дља себе тепло палто. А овца јест без волни.»
+Услишавши то, овца избегла в равнину. | Одјезд."
+`;
+
+exports[`transliterate to "art-Cyrl-x-interslv-southern" a cyrillic text 1`] = `
+"На возвишености овца, ктора не имела вълну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
+Овца рекла коњам: «Боли мне срдце, къгда виджу, како чловек владаје коњами.»
+Коњи рекли: «Слушај, овцо, нам боли срдце, къгда видимо ово: муж, господар, бере твоју вълну, да би имел дља себе тепло палто. А овца јест без вълни.»
+Услишавши то, овца избегла в равнину. | Одјезд."
+`;
+
+exports[`transliterate to "art-Cyrl-x-interslv-southern" a latin text 1`] = `
 "На възвишености овца, ктора не имела вълну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
 Овца рекла коњам: «Боли мне срдце, къгда виђу, како чловек владаје коњами.»
 Коњи рекли: «Слушај, овцо, нам боли срдце, къгда видимо ово: муж, господар, бере твоју вълну, да би имел дља себе тепло палто. А овца јест без вълни.»
 Услишавши то, овца избегла в равнину. | Одјезд."
 `;
 
-exports[`abcd transliterate(text, "art-Glag-x-interslv") 1`] = `
+exports[`transliterate to "art-Glag-x-interslv" a cyrillic text 1`] = `
 "Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⱐⰹ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
 Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
 Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
 Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
 `;
 
-exports[`abcd transliterate(text, "art-Glag-x-interslv-etym") 1`] = `
+exports[`transliterate to "art-Glag-x-interslv" a latin text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⱐⰹ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
+`;
+
+exports[`transliterate to "art-Glag-x-interslv-etym" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱏⰾⱀⱘ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⱐⰲⱐⰹ ⱅⱔⰳⰰⰾ ⱅⱔⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱔ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱘⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱘⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱙ ⰲⱏⰾⱀⱘ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅⱐ ⰱⰵⰸ ⰲⱏⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱉⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
+`;
+
+exports[`transliterate to "art-Glag-x-interslv-etym" a latin text 1`] = `
 "Ⱀⰰ ⰲⱏⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱏⰾⱀⱘ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⱐⰲⱐⰹ ⱅⱔⰳⰰⰾ ⱅⱔⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱔ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱘⰶⰰ.
 Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰼⱘ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
 Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱘⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱙ ⰲⱏⰾⱀⱘ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱏⰾⱀⱐⰹ.»
 Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱉⰲⱀⰻⱀⱘ. | Ⱁⰴⱏⰹⰵⰸⰴ."
 `;
 
-exports[`abcd transliterate(text, "art-Glag-x-interslv-northern") 1`] = `
+exports[`transliterate to "art-Glag-x-interslv-northern" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⰵⱃⰲⱐⰹ ⱅⱝⰳⰰⰾ ⱅⱝⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱝ, ⱅⱃⰵⱅⰹⰻ ⰱⱁⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅⱐ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱁⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
+`;
+
+exports[`transliterate to "art-Glag-x-interslv-northern" a latin text 1`] = `
 "Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⰵⱃⰲⱐⰹ ⱅⱝⰳⰰⰾ ⱅⱝⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱝ, ⱅⱃⰵⱅⰹⰻ ⰱⱁⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
 Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
 Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
 Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱁⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
 `;
 
-exports[`abcd transliterate(text, "art-Glag-x-interslv-sloviant") 1`] = `
+exports[`transliterate to "art-Glag-x-interslv-sloviant" a cyrillic text 1`] = `
 "Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
 Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
 Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
 Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
 `;
 
-exports[`abcd transliterate(text, "art-Glag-x-interslv-southern") 1`] = `
+exports[`transliterate to "art-Glag-x-interslv-sloviant" a latin text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
+Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
+`;
+
+exports[`transliterate to "art-Glag-x-interslv-southern" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
+Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
+`;
+
+exports[`transliterate to "art-Glag-x-interslv-southern" a latin text 1`] = `
 "Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
 Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰼⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
 Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
 Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ."
 `;
 
-exports[`abcd transliterate(text, "art-Latn-PL-x-interslv") 1`] = `
+exports[`transliterate to "art-Latn-PL-x-interslv" a cyrillic text 1`] = `
+"Na wozwyszenosti owca, ktora ne imieła wołną, uwidieła koniew. Perwy tęgał tężki woz, wtory nosił weliko briemę, treti borzo woził mąża.
+Owca riekła koniam: «Boli mnie serdce, kogda widżu, kako człowiek władaje koniami.»
+Koni riekli: «Słuszaj, owco, nam boli serdce, kogda widimo owo: mąż, gospodaŕ, bere twoją wołną, da by imieł dla sebe tepło palto. A owca jesť bez wołny.»
+Usłyszawszi to, owca izbiegła w rawninu. | Odjezd."
+`;
+
+exports[`transliterate to "art-Latn-PL-x-interslv" a latin text 1`] = `
 "Na wozwyszenosti owca, ktora ne imieła wołną, uwidieła koniew. Perwy tęgał tężki woz, wtory nosił weliko briemę, treti borzo woził mąża.
 Owca riekła koniam: «Boli mnie serdce, kogda widzią, kako człowiek władaje koniami.»
 Koni riekli: «Słuszaj, owco, nam boli serdce, kogda widimo owo: mąż, gospodaŕ, bere twoją wołną, da by imieł dla sebe tepło palto. A owca jest bez wołny.»
 Usłyszawszi to, owca izbiegła w rawniną. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-Latn-x-interslv") 1`] = `
+exports[`transliterate to "art-Latn-x-interslv" a cyrillic text 1`] = `
 "Na vozvyšenosti ovca, ktora ne iměla volnu, uviděla konjev. Prvy tegal težky voz, vtory nosil veliko brěme, tretji brzo vozil muža.
 Ovca rěkla konjam: «Boli mně srdce, kogda vidžu, kako člověk vladaje konjami.»
 Konji rěkli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da by iměl dlja sebe teplo palto. A ovca jest bez volny.»
 Uslyšavši to, ovca izběgla v ravninu. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-Latn-x-interslv-ascii") 1`] = `
+exports[`transliterate to "art-Latn-x-interslv" a latin text 1`] = `
+"Na vozvyšenosti ovca, ktora ne iměla volnu, uviděla konjev. Prvy tegal težky voz, vtory nosil veliko brěme, tretji brzo vozil muža.
+Ovca rěkla konjam: «Boli mně srdce, kogda vidžu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da by iměl dlja sebe teplo palto. A ovca jest bez volny.»
+Uslyšavši to, ovca izběgla v ravninu. | Odjezd."
+`;
+
+exports[`transliterate to "art-Latn-x-interslv-ascii" a cyrillic text 1`] = `
 "Na vozvyszenosti ovca, ktora ne imjela volnu, uvidjela konjev. Prvy tegal tezsky voz, vtory nosil veliko brjeme, tretji brzo vozil muzsa.
 Ovca rjekla konjam: «Boli mnje srdce, kogda vidzsu, kako czlovjek vladaje konjami.»
 Konji rjekli: «Sluszaj, ovco, nam boli srdce, kogda vidimo ovo: muzs, gospodar, bere tvoju volnu, da by imjel dlja sebe teplo palto. A ovca jest bez volny.»
 Uslyszavszi to, ovca izbjegla v ravninu. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-Latn-x-interslv-etym") 1`] = `
+exports[`transliterate to "art-Latn-x-interslv-ascii" a latin text 1`] = `
+"Na vozvyszenosti ovca, ktora ne imjela volnu, uvidjela konjev. Prvy tegal tezsky voz, vtory nosil veliko brjeme, tretji brzo vozil muzsa.
+Ovca rjekla konjam: «Boli mnje srdce, kogda vidzsu, kako czlovjek vladaje konjami.»
+Konji rjekli: «Sluszaj, ovco, nam boli srdce, kogda vidimo ovo: muzs, gospodar, bere tvoju volnu, da by imjel dlja sebe teplo palto. A ovca jest bez volny.»
+Uslyszavszi to, ovca izbjegla v ravninu. | Odjezd."
+`;
+
+exports[`transliterate to "art-Latn-x-interslv-etym" a cyrillic text 1`] = `
+"Na vozvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
+Ovca rěkla konjam: «Boli mně sŕdce, kȯgda vidžu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest́ bez vȯlny.»
+Uslyšavši to, ovca izběgla v råvninu. | Odjezd."
+`;
+
+exports[`transliterate to "art-Latn-x-interslv-etym" a latin text 1`] = `
 "Na vȯzvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
 Ovca rěkla konjam: «Boli mně sŕdce, kȯgda viđų, kako člověk vladaje konjami.»
 Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest bez vȯlny.»
 Uslyšavši to, ovca izběgla v råvninų. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-Latn-x-interslv-northern") 1`] = `
+exports[`transliterate to "art-Latn-x-interslv-northern" a cyrillic text 1`] = `
+"Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
+Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
+Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paĺto. A ovca jesť bez volny.»
+Uslyšavši to, ovca izbiegla v rovninu. | Odjezd."
+`;
+
+exports[`transliterate to "art-Latn-x-interslv-northern" a latin text 1`] = `
 "Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
 Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
 Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paĺto. A ovca jest bez volny.»
 Uslyšavši to, ovca izbiegla v rovninu. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-Latn-x-interslv-sloviant") 1`] = `
+exports[`transliterate to "art-Latn-x-interslv-sloviant" a cyrillic text 1`] = `
 "Na vozvišenosti ovca, ktora ne imela volnu, uvidela konjev. Prvi tegal težki voz, vtori nosil veliko breme, tretji brzo vozil muža.
 Ovca rekla konjam: «Boli mne srdce, kogda vidžu, kako človek vladaje konjami.»
 Konji rekli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da bi imel dlja sebe teplo palto. A ovca jest bez volni.»
 Uslišavši to, ovca izbegla v ravninu. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-Latn-x-interslv-southern") 1`] = `
+exports[`transliterate to "art-Latn-x-interslv-sloviant" a latin text 1`] = `
+"Na vozvišenosti ovca, ktora ne imela volnu, uvidela konjev. Prvi tegal težki voz, vtori nosil veliko breme, tretji brzo vozil muža.
+Ovca rekla konjam: «Boli mne srdce, kogda vidžu, kako človek vladaje konjami.»
+Konji rekli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da bi imel dlja sebe teplo palto. A ovca jest bez volni.»
+Uslišavši to, ovca izbegla v ravninu. | Odjezd."
+`;
+
+exports[`transliterate to "art-Latn-x-interslv-southern" a cyrillic text 1`] = `
+"Na vozvišenosti ovca, ktora ne iměla vălnu, uviděla konjev. Prvi tegal težki voz, vtori nosil veliko brěme, tretji brzo vozil muža.
+Ovca rěkla konjam: «Boli mně srdce, kăgda vidžu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli srdce, kăgda vidimo ovo: muž, gospodar, bere tvoju vălnu, da bi iměl dlja sebe teplo palto. A ovca jest bez vălni.»
+Uslišavši to, ovca izběgla v ravninu. | Odjezd."
+`;
+
+exports[`transliterate to "art-Latn-x-interslv-southern" a latin text 1`] = `
 "Na văzvišenosti ovca, ktora ne iměla vălnu, uviděla konjev. Prvi tegal težki voz, vtori nosil veliko brěme, tretji brzo vozil muža.
 Ovca rěkla konjam: «Boli mně srdce, kăgda viđu, kako člověk vladaje konjami.»
 Konji rěkli: «Slušaj, ovco, nam boli srdce, kăgda vidimo ovo: muž, gospodar, bere tvoju vălnu, da bi iměl dlja sebe teplo palto. A ovca jest bez vălni.»
 Uslišavši to, ovca izběgla v ravninu. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-x-interslv") 1`] = `
+exports[`transliterate to "art-x-interslv" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Прьвы тѧгал тѧжкы воз, вторы носил велико брємѧ, третји брзо возил мѫжа.
+Овца рѣкла коням: «Боли мнє срьдце, къгда виџу, како чловѣк владаје коньами.»
+Конји рѣкли: «Слушай, овцо, нам боли срьдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл дља себе тепло пальто. А овца ѥсть без вълны.»
+Услышавши то, овца избѣгла в рӑвнинѹ. | Одјезд."
+`;
+
+exports[`transliterate to "art-x-interslv" a latin text 1`] = `
 "Na vȯzvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
 Ovca rěkla konjam: «Boli mně sŕdce, kȯgda viđų, kako člověk vladaje konjami.»
 Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest bez vȯlny.»
 Uslyšavši to, ovca izběgla v råvninų. | Odjezd."
 `;
 
-exports[`abcd transliterate(text, "art-x-interslv-fonipa") 1`] = `
+exports[`transliterate to "art-x-interslv-fonipa" a cyrillic text 1`] = `
+"na vɔzvɪʃɛnɔsti ɔvt͡sa, ktɔra nɛ imjɛɫa vəɫnʊ, uvidʲɛɫa kɔɲɛv. pjǝrvɪ tʲægaɫ tʲæʒkɪ vɔz, vtɔrɪ nɔsiɫ vɛlikɔ brʲɛmjæ, trɛtji bərzɔ vɔziɫ mʊʒa.
+ɔvt͡sa rʲɛkɫa kɔɲam: «bɔli mɲɛ sʲǝrdt͡sɛ, kəgda vid͡ʒu, kakɔ t͡ʃɫɔvjɛk vɫadajɛ kɔɲami.»
+kɔɲi rʲɛkli: «sɫuʃaj, ɔvt͡sɔ, nam bɔli sʲǝrdt͡sɛ, kəgda vidimɔ ɔvɔ: mʊʒ, gɔspɔdarʲ, bɛrɛ tvɔjʊ vəɫnʊ, da bɪ imjɛɫ dʎa sɛbɛ tɛpɫɔ paʎtɔ. a ɔvt͡sa jɛsʲtʲ bɛz vəɫnɪ.»
+usɫɪʃavʃi tɔ, ɔvt͡sa izbjɛgɫa v rɒvninu. | ɔdjɛzd."
+`;
+
+exports[`transliterate to "art-x-interslv-fonipa" a latin text 1`] = `
 "na vəzvɪʃɛnɔsti ɔvt͡sa, ktɔra nɛ imjɛɫa vəɫnʊ, uvidʲɛɫa kɔɲɛv. pjǝrvɪ tʲægaɫ tʲæʒkɪ vɔz, vtɔrɪ nɔsiɫ vɛlikɔ brʲɛmjæ, trɛtji bərzɔ vɔziɫ mʊʒa.
 ɔvt͡sa rʲɛkɫa kɔɲam: «bɔli mɲɛ sʲǝrdt͡sɛ, kəgda vid͡ʑʊ, kakɔ t͡ʃɫɔvjɛk vɫadajɛ kɔɲami.»
 kɔɲi rʲɛkli: «sɫuʃaj, ɔvt͡sɔ, nam bɔli sʲǝrdt͡sɛ, kəgda vidimɔ ɔvɔ: mʊʒ, gɔspɔdarʲ, bɛrɛ tvɔjʊ vəɫnʊ, da bɪ imjɛɫ dʎa sɛbɛ tɛpɫɔ paʎtɔ. a ɔvt͡sa jɛst bɛz vəɫnɪ.»
 usɫɪʃavʃi tɔ, ɔvt͡sa izbjɛgɫa v rɒvninʊ. | ɔdjɛzd."
 `;
 
-exports[`abcd unknown code 1`] = `"Unsupported IETF BCP47 tag: en"`;
+exports[`transliterate to unknown code 1`] = `"Unsupported IETF BCP47 tag: en"`;

--- a/src/transliterate/index.test.ts
+++ b/src/transliterate/index.test.ts
@@ -1,13 +1,19 @@
 import { transliterate } from './index';
 
-const source = `\
+const latin = `\
 Na vȯzvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
 Ovca rěkla konjam: «Boli mně sŕdce, kȯgda viđų, kako člověk vladaje konjami.»
 Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest bez vȯlny.»
 Uslyšavši to, ovca izběgla v råvninų. | Odjezd.`;
 
-describe('abcd', () => {
-  test.each([
+const cyrillic = `\
+На возвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Прьвы тѧгал тѧжкы воз, вторы носил велико брємѧ, третји брзо возил мѫжа.
+Овца рѣкла коням: «Боли мнє срьдце, къгда виџу, како чловѣк владаје коньами.»
+Конји рѣкли: «Слушай, овцо, нам боли срьдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл дља себе тепло пальто. А овца ѥсть без вълны.»
+Услышавши то, овца избѣгла в рӑвнинѹ. | Одјезд.`;
+
+describe('transliterate to', () => {
+  describe.each([
     ['art-Cyrl-x-interslv'],
     ['art-Cyrl-x-interslv-etym'],
     ['art-Cyrl-x-interslv-iotated'],
@@ -29,13 +35,31 @@ describe('abcd', () => {
     ['art-Latn-x-interslv-southern'],
     ['art-x-interslv-fonipa'],
     ['art-x-interslv'],
-  ] as const)('transliterate(text, %j)', (bcp47) => {
-    expect(transliterate(source, bcp47)).toMatchSnapshot();
+  ] as const)('%j', (bcp47) => {
+    test('a latin text', () => {
+      expect(transliterate(latin, bcp47)).toMatchSnapshot();
+    });
+
+    test('a cyrillic text', () => {
+      expect(transliterate(cyrillic, bcp47)).toMatchSnapshot();
+    });
   });
 
+  test.each([
+    ['art-Latn-x-interslv'],
+    ['art-Cyrl-x-interslv'],
+    ['art-Glag-x-interslv'],
+  ] as const)(
+    'should work equally from Latin and Cyrillic scripts to %j',
+    (bcp47) => {
+      const latn = transliterate(latin, bcp47);
+      const cyrl = transliterate(cyrillic, bcp47);
+
+      expect(latn).toEqual(cyrl);
+    },
+  );
+
   test('unknown code', () => {
-    expect(() =>
-      transliterate(source, 'en' as any),
-    ).toThrowErrorMatchingSnapshot();
+    expect(() => transliterate('', 'en' as any)).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/transliterate/transliterate.ts
+++ b/src/transliterate/transliterate.ts
@@ -45,7 +45,7 @@ function transliterateWord(
   //symbol % marks the borders of the %word%
   iW = '%' + iW + '%';
   let OrigW = iW;
-  iW = iW.toLowerCase();
+  iW = nmsify(iW.toLowerCase());
   iW = iW.replace(/ľ/g, 'ĺ');
   iW = iW.replace(/ň/g, 'ń');
   // 'ŕ' remains between two consonants, in other cases is replaced by 'ř'
@@ -604,4 +604,128 @@ function jgedoe(iW: string) {
     result += resC;
   }
   return result;
+}
+
+function nmsify(iW: string) {
+  return (
+    iW
+      .replace(/[яꙗ]/g, '#a')
+      .replace(/ьа/g, '#a')
+      .replace(/ѥ/g, '#e')
+      .replace(/ье/g, '#e')
+      .replace(/ї/g, '#i')
+      .replace(/ьи/g, '#i')
+      .replace(/ё/g, '#o')
+      .replace(/ьо/g, '#o')
+      .replace(/ю/g, '#u')
+      .replace(/ьу/g, '#u')
+      .replace(/ѩ/g, '#ę')
+      .replace(/ьѧ/g, '#ę')
+      .replace(/ѭ/g, '#ų')
+      .replace(/ьѫ/g, '#ų')
+      .replace(/нь/g, 'ń')
+      .replace(/н#/g, 'nj')
+      .replace(/њ/g, 'nj')
+      .replace(/ль/g, 'ĺ')
+      .replace(/л#/g, 'lj')
+      .replace(/љ/g, 'lj')
+      .replace(/рь/g, 'ŕ')
+      .replace(/р#/g, 'ŕ')
+      .replace(/ть/g, 'ť')
+      .replace(/т#/g, 'ť')
+      .replace(/дь/g, 'ď')
+      .replace(/д#/g, 'ď')
+      .replace(/сь/g, 'ś')
+      .replace(/с#/g, 'ś')
+      .replace(/зь/g, 'ź')
+      .replace(/з#/g, 'ź')
+      .replace(/ь%/g, '%')
+      .replace(/[ђѓ]/g, 'đ')
+      .replace(/[ћќ]/g, 'ć')
+      .replace(/ѕ/g, 'dz')
+      .replace(/џ/g, 'dž')
+      .replace(/а/g, 'a')
+      .replace(/б/g, 'b')
+      .replace(/в/g, 'v')
+      .replace(/[гґ]/g, 'g')
+      .replace(/д/g, 'd')
+      .replace(/[еэ]/g, 'e')
+      .replace(/[єѣ]/g, 'ě')
+      .replace(/ж/g, 'ž')
+      .replace(/[зꙁꙀ]/g, 'z')
+      .replace(/[иіѵѷ]/g, 'i')
+      .replace(/[йјь#]/g, 'j')
+      .replace(/к/g, 'k')
+      .replace(/л/g, 'l')
+      .replace(/м/g, 'm')
+      .replace(/н/g, 'n')
+      .replace(/[оѡ]/g, 'o')
+      .replace(/п/g, 'p')
+      .replace(/р/g, 'r')
+      .replace(/с/g, 's')
+      .replace(/[тѳ]/g, 't')
+      .replace(/[уȣѹ]/g, 'u')
+      .replace(/ф/g, 'f')
+      .replace(/х/g, 'h')
+      .replace(/ц/g, 'c')
+      .replace(/ч/g, 'č')
+      .replace(/ш/g, 'š')
+      .replace(/щ/g, 'šč')
+      .replace(/[ыꙑ]/g, 'y')
+      .replace(/ъ/g, 'ȯ') // Fixed by Denis Šabalin
+      .replace(/ў/g, 'ŭ')
+      .replace(/ѧ/g, 'ę')
+      .replace(/ѫ/g, 'ų')
+      .replace(/ѱ/g, 'ps')
+      .replace(/ѯ/g, 'ks')
+      .replace(/ӑ/g, 'å') // Added by Denis Šabalin
+      // ...
+      .replace(/⁙/g, '.')
+      // ...
+      .replace(/zsk/g, 'z#sk')
+      .replace(/zst/g, 'z#st')
+      .replace(/%izs/g, '%iz#s')
+      .replace(/%bezs/g, '%bez#s')
+      .replace(/%razs/g, '%raz#s')
+      .replace(/%råzs/g, '%råz#s')
+      .replace(/konjug/g, 'kon#jug')
+      .replace(/konjun/g, 'kon#jun')
+      .replace(/injek/g, 'in#jek')
+      // ...
+      .replace(/s[xz]/g, 'š')
+      .replace(/c[xz]/g, 'č')
+      .replace(/z[xs]/g, 'ž')
+      .replace(/ż/g, 'ž')
+      .replace(/ye/g, 'ě')
+      // ...
+      .replace(/qu/g, 'kv')
+      .replace(/ŀ/g, 'ȯl')
+      .replace(/[ăq`]/g, '’')
+      .replace(/ch/g, 'h')
+      .replace(/w/g, 'v')
+      .replace(/x/g, 'ks')
+      // ...
+      .replace(/[áàâā]/g, 'a')
+      .replace(/[íìîīĭı]/g, 'i')
+      .replace(/[úûůū]/g, 'u')
+      .replace(/[ąǫũ]/g, 'ų')
+      .replace(/ù/g, 'ŭ')
+      .replace(/[éē]/g, 'e')
+      .replace(/[ĕëè]/g, 'ė')
+      .replace(/[œóô]/g, 'o')
+      .replace(/[ŏöò]/g, 'ȯ')
+      .replace(/ý/g, 'y')
+      .replace(/ł/g, 'l')
+      .replace(/ç/g, 'c')
+      .replace(/ʒ/g, 'z')
+      .replace(/ĵ/g, 'j')
+      .replace(/[ĺļǉ]/g, 'ľ')
+      .replace(/[ňñņǌ]/g, 'ń')
+      .replace(/ř/g, 'ŕ')
+      .replace(/t́/g, 'ť')
+      .replace(/d́/g, 'ď')
+      // ...
+      .replace(/([jćđšžč])y/g, '$1i')
+      .replace(/jj/g, 'j')
+  );
 }


### PR DESCRIPTION
Fixes reverse transliteration from the non-Latin-etymological alphabet, e.g. Cyrillic → Latin:

```plain
На возвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Прьвы тѧгал тѧжкы воз, вторы носил велико брємѧ, третји брзо возил мѫжа.
 Овца рѣкла коням: «Боли мнє срьдце, къгда виџу, како чловѣк владаје коньами.»
 Конји рѣкли: «Слушай, овцо, нам боли срьдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл дља себе тепло пальто. А овца ѥсть без вълны.»
 Услышавши то, овца избѣгла в рӑвнинѹ. | Одјезд.
 ```