### PR TITLE
fix(transliterate): northern flavorisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "Jan van Steenbergen",
     "Sergey Cherebedov",
     "Denis Shabalin",
+    "Rafail Gasparyan",
     "Yaroslav Serhieiev <noomorph@gmail.com>"
   ],
   "license": "MIT",

--- a/src/transliterate/__snapshots__/index.test.ts.snap
+++ b/src/transliterate/__snapshots__/index.test.ts.snap
@@ -227,14 +227,14 @@ Uslyšavši to, ovca izběgla v råvninų. | Odjezd."
 exports[`transliterate to "art-Latn-x-interslv-northern" a cyrillic text 1`] = `
 "Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
 Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
-Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paĺto. A ovca jesť bez volny.»
+Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paľto. A ovca jesť bez volny.»
 Uslyšavši to, ovca izbiegla v rovninu. | Odjezd."
 `;
 
 exports[`transliterate to "art-Latn-x-interslv-northern" a latin text 1`] = `
 "Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
 Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
-Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paĺto. A ovca jest bez volny.»
+Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paľto. A ovca jest bez volny.»
 Uslyšavši to, ovca izbiegla v rovninu. | Odjezd."
 `;
 

--- a/src/transliterate/transliterate.ts
+++ b/src/transliterate/transliterate.ts
@@ -35,28 +35,25 @@ export function transliterate(
     .replace(/\p{Letter}+/gu, (w) => transliterateWord(w, type, flav));
 }
 
+const VOWEL = /[aeiouyąęųåėȯèòěê]/;
+
 function transliterateWord(
   iW: string,
   type: string | number,
   flav: string | number,
 ) {
-  let vowel;
-
   //symbol % marks the borders of the %word%
   iW = '%' + iW + '%';
   let OrigW = iW;
   iW = nmsify(iW.toLowerCase());
-  iW = iW.replace(/ľ/g, 'ĺ');
-  iW = iW.replace(/ň/g, 'ń');
   // 'ŕ' remains between two consonants, in other cases is replaced by 'ř'
   iW = iW.replace(/ŕ/g, 'ř');
   const aPos = iW.indexOf('ř');
-  vowel = /[aeiouyąęųåėȯèòěê]/;
   if (
     aPos > 1 &&
     iW.charAt(aPos - 1) != '%' &&
-    vowel.test(iW.charAt(aPos - 1)) == false &&
-    vowel.test(iW.charAt(aPos + 1)) == false
+    VOWEL.test(iW.charAt(aPos - 1)) == false &&
+    VOWEL.test(iW.charAt(aPos + 1)) == false
   ) {
     iW = iW.substring(0, aPos) + 'ŕ' + iW.substring(aPos + 1, iW.length);
   }
@@ -65,12 +62,11 @@ function transliterateWord(
   iW = iW.replace(/rj/g, 'Rj');
   iW = iW.replace(/jr/g, 'jR');
   const rPos = iW.indexOf('r');
-  vowel = /[aeiouyąęųåėȯèòěê]/;
   if (
     rPos > 1 &&
     iW.charAt(rPos - 1) != '%' &&
-    vowel.test(iW.charAt(rPos - 1)) == false &&
-    vowel.test(iW.charAt(rPos + 1)) == false
+    VOWEL.test(iW.charAt(rPos - 1)) == false &&
+    VOWEL.test(iW.charAt(rPos + 1)) == false
   ) {
     iW = iW.substring(0, rPos) + 'ṙ' + iW.substring(rPos + 1, iW.length);
     // iW = iW.replace (/’ṙ/, "ṙ");
@@ -81,7 +77,7 @@ function transliterateWord(
   // 'x' is replaced by 'ks'
   iW = iW.replace(/x/g, 'ks');
   // inserting auxiliary symbol 'ı' after soft consonants
-  iW = iW.replace(/([ńĺřťďśź])j/g, '$1ıj');
+  iW = iW.replace(/([ńľřťďśź])j/g, '$1ıj');
   // interting delimiter # in some cases
   iW = iW.replace(/([dsz])j/g, '$1#j');
   iW = iW.replace(/%obj/g, 'ob#j');
@@ -108,7 +104,7 @@ function transliterateWord(
     iW = iW.replace(/ć/g, 'č');
     iW = iW.replace(/đ/g, 'dž');
     iW = iW.replace(/ř/g, 'r');
-    iW = iW.replace(/ĺ/g, 'l');
+    iW = iW.replace(/ľ/g, 'l');
     iW = iW.replace(/ń/g, 'n');
     iW = iW.replace(/ť/g, 't');
     iW = iW.replace(/ď/g, 'd');
@@ -143,7 +139,7 @@ function transliterateWord(
   else if (flav == 'J') {
     iW = iW.replace(/ų/g, 'u');
     iW = iW.replace(/ŭ/g, 'v');
-    iW = iW.replace(/ĺ/g, 'l');
+    iW = iW.replace(/ľ/g, 'l');
     iW = iW.replace(/ř/g, 'r');
     iW = iW.replace(/ń/g, 'n');
     iW = iW.replace(/ť/g, 't');
@@ -170,7 +166,7 @@ function transliterateWord(
     if (flav == '2') {
       iW = iW.replace(/ṙ/g, 'r');
       iW = iW.replace(/ř/g, 'ŕ');
-      iW = iW.replace(/ĺ/g, 'ĺ');
+      iW = iW.replace(/ľ/g, 'ĺ');
       iW = iW.replace(/ť/g, 't́');
       iW = iW.replace(/ď/g, 'd́');
       iW = iW.replace(/([čšžj])ŕ/g, '$1r');
@@ -195,7 +191,7 @@ function transliterateWord(
       iW = iW.replace (/łi/g,"l");
       iW = iW.replace (/łЬ/g,"l"); */
       iW = iW.replace(/h/g, 'ch');
-      iW = iW.replace(/lЬ/g, 'ĺ');
+      iW = iW.replace(/lЬ/g, 'ľ');
       iW = iW.replace(/nЬ/g, 'ń');
       iW = iW.replace(/rЬ/g, 'ŕ');
       iW = iW.replace(/tЬ/g, 'ť');
@@ -298,7 +294,7 @@ function transliterateWord(
     iW = iW.replace(/j/g, 'ј');
     iW = iW.replace(/k/g, 'к');
     iW = iW.replace(/l/g, 'л');
-    iW = iW.replace(/ĺ/g, 'ль');
+    iW = iW.replace(/ľ/g, 'ль');
     iW = iW.replace(/m/g, 'м');
     iW = iW.replace(/n/g, 'н');
     iW = iW.replace(/ń/g, 'нь');
@@ -379,6 +375,7 @@ function transliterateWord(
       iW = iW.replace(/#/g, '’');
     }
   } else if (type == 7) {
+    /* Glagolitic alphabet by Rafail Gasparyan */
     iW = iW.replace(/ı/g, '');
     iW = iW.replace(/ṙ/g, 'r');
     iW = iW.replace(/ř/g, 'ŕ');
@@ -394,7 +391,7 @@ function transliterateWord(
       iW = iW.replace(/ě/g, 'e');
     }
     iW = iW.replace(/ń/g, 'nь');
-    iW = iW.replace(/ĺ/g, 'lь');
+    iW = iW.replace(/ľ/g, 'lь');
     iW = iW.replace(/ŕ/g, 'rь');
     iW = iW.replace(/ť/g, 'tь');
     iW = iW.replace(/ď/g, 'dь');
@@ -474,7 +471,7 @@ function transliterateWord(
   } else if (type == 10) {
     /* IPA */
     iW = iW.replace(/nads([eę])/g, 'nac$1');
-    iW = iW.replace(/([ĺńřťďśź])ıj/g, '$1i̯');
+    iW = iW.replace(/([ľńřťďśź])ıj/g, '$1i̯');
     iW = iW.replace(/e/g, 'ɛ');
     iW = iW.replace(/ė/g, 'ɜ');
     iW = iW.replace(/ě/g, 'ьɛ');
@@ -513,7 +510,7 @@ function transliterateWord(
     iW = iW.replace(/r[ьj]/g, 'rʲ');
     iW = iW.replace(/ń/g, 'ɲ');
     iW = iW.replace(/n[ьj]/g, 'ɲ');
-    iW = iW.replace(/ĺ/g, 'ʎ');
+    iW = iW.replace(/ľ/g, 'ʎ');
     iW = iW.replace(/l[ьj]/g, 'ʎ');
     iW = iW.replace(/ь/g, 'j');
     iW = iW.replace(/l/g, 'ɫ');
@@ -527,7 +524,7 @@ function transliterateWord(
   iW = iW.replace(/[#ı%]/g, '');
   OrigW = OrigW.replace(/%/g, '');
 
-  /** Hoofdletters maken **/
+  /** Restore the original case (lower, upperFirst, upper) **/
   const iW_first = iW.charAt(0);
   const iW_rest = iW.substring(1);
 
@@ -542,7 +539,6 @@ function transliterateWord(
     iW = iW.toUpperCase();
   }
 
-  iW = iW.replace(/℅/g, '%');
   return iW;
 }
 
@@ -553,7 +549,7 @@ function jgedoe(iW: string) {
 
   iW = iW.replace(/ć/g, 'cj');
   iW = iW.replace(/đ/g, 'dzj');
-  iW = iW.replace(/ĺ/g, 'lj');
+  iW = iW.replace(/ľ/g, 'lj');
   iW = iW.replace(/ń/g, 'nj');
   iW = iW.replace(/ř/g, 'rj');
   iW = iW.replace(/ď/g, 'dj');
@@ -570,7 +566,6 @@ function jgedoe(iW: string) {
   while (i < wLength) {
     nextChar = iW.charAt(i);
     resC = nextChar;
-    const vowel = /[aäåeęěėioȯuųyъ]/;
 
     switch (nextChar) {
       case 'j':
@@ -584,14 +579,14 @@ function jgedoe(iW: string) {
           resC = 'j';
           break;
         } else if (
-          vowel.test(iW.charAt(i - 1)) == false &&
-          vowel.test(iW.charAt(i + 1)) == true
+          VOWEL.test(iW.charAt(i - 1)) == false &&
+          VOWEL.test(iW.charAt(i + 1)) == true
         ) {
           resC = 'ь';
           break;
         } else if (
-          vowel.test(iW.charAt(i - 1)) == false &&
-          vowel.test(iW.charAt(i + 1)) == false
+          VOWEL.test(iW.charAt(i - 1)) == false &&
+          VOWEL.test(iW.charAt(i + 1)) == false
         ) {
           resC = 'Ь';
           break;


### PR DESCRIPTION
1. Reverts ad-hoc ĺ – now using ľ until the last replacement.
2. Reverts Northern flavorisation behavior: ľ is used.
3. Adds authorship for Glagolitic transliteration (Rafail Gasparyan).
4. Minor optimization (vowels regexp turned into a constant).