### PR TITLE
fix(pronouns): declension of sam and ono

### DIFF
--- a/src/pronoun/declensionPronoun.ts
+++ b/src/pronoun/declensionPronoun.ts
@@ -1,6 +1,14 @@
 import { declensionAdjective } from '../adjective';
 import { stripDiacritics } from '../common';
 import transliterate from '../transliterate';
+import {
+  ALONE,
+  FIRST_PERSON,
+  POSSESSIVE,
+  REFLEXIVE,
+  SECOND_PERSON,
+  THIRD_PERSON,
+} from './lookups';
 
 /** @deprecated */
 export interface SteenPronounParadigm {
@@ -59,20 +67,7 @@ export function declensionPronoun(
 
   const word = stripDiacritics(transliterate(rawWord, 'art-Latn-x-interslv'));
   if (pronounType === 'personal' || pronounType === 'reflexive') {
-    if (
-      [
-        'ja',
-        'mene',
-        'me',
-        'mne',
-        'mi',
-        'mnoju',
-        'my',
-        'nas',
-        'nam',
-        'nami',
-      ].includes(word)
-    ) {
+    if (FIRST_PERSON.includes(word)) {
       return {
         type: 'noun',
         columns: ['singular', 'plural'],
@@ -85,20 +80,7 @@ export function declensionPronoun(
           ins: ['mnojų', 'nami'],
         },
       };
-    } else if (
-      [
-        'ty',
-        'tebe',
-        'te',
-        'tobe',
-        'ti',
-        'toboju',
-        'vy',
-        'vas',
-        'vam',
-        'vami',
-      ].includes(word)
-    ) {
+    } else if (SECOND_PERSON.includes(word)) {
       return {
         type: 'noun',
         columns: ['singular', 'plural'],
@@ -111,27 +93,7 @@ export function declensionPronoun(
           ins: ['tobojų', 'vami'],
         },
       };
-    } else if (
-      [
-        'on',
-        'jego',
-        'go',
-        'je',
-        'jemu',
-        'mu',
-        'njim',
-        'ona',
-        'ju',
-        'jej',
-        'jeju',
-        'njeju',
-        'oni',
-        'one',
-        'jih',
-        'jim',
-        'njimi',
-      ].includes(word)
-    ) {
+    } else if (THIRD_PERSON.includes(word)) {
       return {
         type: 'adjective',
         casesSingular: {
@@ -151,7 +113,7 @@ export function declensionPronoun(
           ins: ['(n)jimi'],
         },
       };
-    } else if (['sebe', 'se', 'sobe', 'si', 'soboju'].includes(word)) {
+    } else if (REFLEXIVE.includes(word)) {
       return {
         type: 'noun',
         columns: ['wordForm'],
@@ -164,11 +126,28 @@ export function declensionPronoun(
           ins: ['sobojų'],
         },
       };
+    } else if (ALONE.includes(word)) {
+      return {
+        type: 'adjective',
+        casesSingular: {
+          nom: ['sam', 'sama', 'samo'],
+          acc: ['samogo / sam', 'samų', 'samogo / samo'],
+          gen: ['samogo', 'samoj', 'samogo'],
+          loc: ['samom', 'samoj', 'samom'],
+          dat: ['samomu', 'samoj', 'samomu'],
+          ins: ['samym', 'samojų', 'samym'],
+        },
+        casesPlural: {
+          nom: ['sami / same', 'same'],
+          acc: ['samyh / same', 'same'],
+          gen: ['samyh'],
+          loc: ['samyh'],
+          dat: ['samym'],
+          ins: ['samymi'],
+        },
+      };
     }
-  } else if (
-    pronounType === 'possessive' &&
-    ['jih', 'jej', 'jego'].includes(word)
-  ) {
+  } else if (pronounType === 'possessive' && POSSESSIVE.includes(word)) {
     return {
       type: 'noun',
       columns: ['wordForm'],

--- a/src/pronoun/lookups.ts
+++ b/src/pronoun/lookups.ts
@@ -1,0 +1,52 @@
+export const FIRST_PERSON = [
+  'ja',
+  'mene',
+  'me',
+  'mne',
+  'mi',
+  'mnoju',
+  'my',
+  'nas',
+  'nam',
+  'nami',
+];
+
+export const SECOND_PERSON = [
+  'ty',
+  'tebe',
+  'te',
+  'tobe',
+  'ti',
+  'toboju',
+  'vy',
+  'vas',
+  'vam',
+  'vami',
+];
+
+export const THIRD_PERSON = [
+  'on',
+  'jego',
+  'go',
+  'je',
+  'jemu',
+  'mu',
+  'njim',
+  'ona',
+  'ono',
+  'ju',
+  'jej',
+  'jeju',
+  'njeju',
+  'oni',
+  'one',
+  'jih',
+  'jim',
+  'njimi',
+];
+
+export const REFLEXIVE = ['sebe', 'se', 'sobe', 'si', 'soboju'];
+
+export const ALONE = ['sam', 'sama', 'samo', 'sami', 'same'];
+
+export const POSSESSIVE = ['jih', 'jej', 'jego'];

--- a/src/pronoun/testCases.json
+++ b/src/pronoun/testCases.json
@@ -3294,7 +3294,59 @@
       "add": "(jego, jemu, njim)",
       "details": "pron.pers."
     },
-    "expected": null
+    "expected": {
+      "type": "adjective",
+      "casesSingular": {
+        "nom": [
+          "on",
+          "ono",
+          "ona"
+        ],
+        "acc": [
+          "(n)jego (go)",
+          "(n)jego (go)",
+          "(n)jų"
+        ],
+        "gen": [
+          "(n)jego",
+          "(n)jej"
+        ],
+        "loc": [
+          "(n)jem",
+          "(n)jej"
+        ],
+        "dat": [
+          "(n)jemu (mu)",
+          "(n)jej"
+        ],
+        "ins": [
+          "(n)jim",
+          "(n)jejų"
+        ]
+      },
+      "casesPlural": {
+        "nom": [
+          "oni / one",
+          "one"
+        ],
+        "acc": [
+          "(n)jih / (n)je",
+          "(n)je"
+        ],
+        "gen": [
+          "(n)jih"
+        ],
+        "loc": [
+          "(n)jih"
+        ],
+        "dat": [
+          "(n)jim"
+        ],
+        "ins": [
+          "(n)jimi"
+        ]
+      }
+    }
   },
   {
     "init": {
@@ -3542,7 +3594,63 @@
       "add": "",
       "details": "pron.pers."
     },
-    "expected": null
+    "expected": {
+      "type": "adjective",
+      "casesSingular": {
+        "nom": [
+          "sam",
+          "sama",
+          "samo"
+        ],
+        "acc": [
+          "samogo / sam",
+          "samų",
+          "samogo / samo"
+        ],
+        "gen": [
+          "samogo",
+          "samoj",
+          "samogo"
+        ],
+        "loc": [
+          "samom",
+          "samoj",
+          "samom"
+        ],
+        "dat": [
+          "samomu",
+          "samoj",
+          "samomu"
+        ],
+        "ins": [
+          "samym",
+          "samojų",
+          "samym"
+        ]
+      },
+      "casesPlural": {
+        "nom": [
+          "sami / same",
+          "same"
+        ],
+        "acc": [
+          "samyh / same",
+          "same"
+        ],
+        "gen": [
+          "samyh"
+        ],
+        "loc": [
+          "samyh"
+        ],
+        "dat": [
+          "samym"
+        ],
+        "ins": [
+          "samymi"
+        ]
+      }
+    }
   },
   {
     "init": {


### PR DESCRIPTION
Resolves #10.

1. Small refactor.
2. Added "ono" to the list of personal 3rd person pronouns.
3. Added "sam" as a special case.

## sam

![image](https://github.com/medzuslovjansky/js-utils/assets/1962469/6a035e9a-45b4-428e-9a86-2049b2c299fe)

## ono

![image](https://github.com/medzuslovjansky/js-utils/assets/1962469/5771ce78-692c-4cf2-9fdd-736acc63eb2a)

