### PR TITLE
feat: adjective comparsion

### DIFF
--- a/src/adjective/__snapshots__/declensionAdjective.test.ts.snap
+++ b/src/adjective/__snapshots__/declensionAdjective.test.ts.snap
@@ -16012,16 +16012,13 @@ exports[`adjective boljši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "boljšejši",
-      "boljšeje",
-    ],
-    "positive": [
       "boljši",
       "boljše",
     ],
+    "positive": [],
     "superlative": [
-      "najboljšejši",
-      "najboljšeje",
+      "najboljši",
+      "najboljše",
     ],
   },
   "plural": {
@@ -20704,16 +20701,13 @@ exports[`adjective daljši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "daljšejši",
-      "daljšeje",
-    ],
-    "positive": [
       "daljši",
       "daljše",
     ],
+    "positive": [],
     "superlative": [
-      "najdaljšejši",
-      "najdaljšeje",
+      "najdaljši",
+      "najdaljše",
     ],
   },
   "plural": {
@@ -23602,16 +23596,13 @@ exports[`adjective divnějši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "divnějšejši",
-      "divnějšeje",
-    ],
-    "positive": [
       "divnějši",
       "divnějše",
     ],
+    "positive": [],
     "superlative": [
-      "najdivnějšejši",
-      "najdivnějšeje",
+      "najdivnějši",
+      "najdivnějše",
     ],
   },
   "plural": {
@@ -44716,16 +44707,13 @@ exports[`adjective hlådnějši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "hlådnějšejši",
-      "hlådnějšeje",
-    ],
-    "positive": [
       "hlådnějši",
       "hlådnějše",
     ],
+    "positive": [],
     "superlative": [
-      "najhlådnějšejši",
-      "najhlådnějšeje",
+      "najhlådnějši",
+      "najhlådnějše",
     ],
   },
   "plural": {
@@ -64864,16 +64852,13 @@ exports[`adjective krasnějši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "krasnějšejši",
-      "krasnějšeje",
-    ],
-    "positive": [
       "krasnějši",
       "krasnějše",
     ],
+    "positive": [],
     "superlative": [
-      "najkrasnějšejši",
-      "najkrasnějšeje",
+      "najkrasnějši",
+      "najkrasnějše",
     ],
   },
   "plural": {
@@ -87288,17 +87273,11 @@ exports[`adjective naivny  1`] = `
 exports[`adjective najblizši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najblizšejši",
-      "najblizšeje",
-    ],
-    "positive": [
-      "najblizši",
-      "najblizše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajblizšejši",
-      "najnajblizšeje",
+      "najblizši",
+      "najblizši",
     ],
   },
   "plural": {
@@ -87357,17 +87336,11 @@ exports[`adjective najblizši  1`] = `
 exports[`adjective najbogatši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najbogatšejši",
-      "najbogatšeje",
-    ],
-    "positive": [
-      "najbogatši",
-      "najbogatše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajbogatšejši",
-      "najnajbogatšeje",
+      "najbogatši",
+      "najbogatši",
     ],
   },
   "plural": {
@@ -87426,17 +87399,11 @@ exports[`adjective najbogatši  1`] = `
 exports[`adjective najboljši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najboljšejši",
-      "najboljšeje",
-    ],
-    "positive": [
-      "najboljši",
-      "najboljše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajboljšejši",
-      "najnajboljšeje",
+      "najboljši",
+      "najboljši",
     ],
   },
   "plural": {
@@ -87495,17 +87462,11 @@ exports[`adjective najboljši  1`] = `
 exports[`adjective najdaljši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najdaljšejši",
-      "najdaljšeje",
-    ],
-    "positive": [
-      "najdaljši",
-      "najdaljše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajdaljšejši",
-      "najnajdaljšeje",
+      "najdaljši",
+      "najdaljši",
     ],
   },
   "plural": {
@@ -87564,17 +87525,11 @@ exports[`adjective najdaljši  1`] = `
 exports[`adjective najdivnějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najdivnějšejši",
-      "najdivnějšeje",
-    ],
-    "positive": [
-      "najdivnějši",
-      "najdivnějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajdivnějšejši",
-      "najnajdivnějšeje",
+      "najdivnějši",
+      "najdivnějši",
     ],
   },
   "plural": {
@@ -87702,17 +87657,11 @@ exports[`adjective najemny  1`] = `
 exports[`adjective najglųbši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najglųbšejši",
-      "najglųbšeje",
-    ],
-    "positive": [
-      "najglųbši",
-      "najglųbše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajglųbšejši",
-      "najnajglųbšeje",
+      "najglųbši",
+      "najglųbši",
     ],
   },
   "plural": {
@@ -87771,17 +87720,11 @@ exports[`adjective najglųbši  1`] = `
 exports[`adjective najgorši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najgoršejši",
-      "najgoršeje",
-    ],
-    "positive": [
-      "najgorši",
-      "najgorše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajgoršejši",
-      "najnajgoršeje",
+      "najgorši",
+      "najgorši",
     ],
   },
   "plural": {
@@ -87840,17 +87783,11 @@ exports[`adjective najgorši  1`] = `
 exports[`adjective najhlådnějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najhlådnějšejši",
-      "najhlådnějšeje",
-    ],
-    "positive": [
-      "najhlådnějši",
-      "najhlådnějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajhlådnějšejši",
-      "najnajhlådnějšeje",
+      "najhlådnějši",
+      "najhlådnějši",
     ],
   },
   "plural": {
@@ -87909,17 +87846,11 @@ exports[`adjective najhlådnějši  1`] = `
 exports[`adjective najkrasivši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najkrasivšejši",
-      "najkrasivšeje",
-    ],
-    "positive": [
-      "najkrasivši",
-      "najkrasivše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajkrasivšejši",
-      "najnajkrasivšeje",
+      "najkrasivši",
+      "najkrasivši",
     ],
   },
   "plural": {
@@ -87978,17 +87909,11 @@ exports[`adjective najkrasivši  1`] = `
 exports[`adjective najkrasnějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najkrasnějšejši",
-      "najkrasnějšeje",
-    ],
-    "positive": [
-      "najkrasnějši",
-      "najkrasnějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajkrasnějšejši",
-      "najnajkrasnějšeje",
+      "najkrasnějši",
+      "najkrasnějši",
     ],
   },
   "plural": {
@@ -88047,17 +87972,11 @@ exports[`adjective najkrasnějši  1`] = `
 exports[`adjective najkrvavši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najkrvavšejši",
-      "najkrvavšeje",
-    ],
-    "positive": [
-      "najkrvavši",
-      "najkrvavše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajkrvavšejši",
-      "najnajkrvavšeje",
+      "najkrvavši",
+      "najkrvavši",
     ],
   },
   "plural": {
@@ -88116,17 +88035,11 @@ exports[`adjective najkrvavši  1`] = `
 exports[`adjective najlegši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najlegšejši",
-      "najlegšeje",
-    ],
-    "positive": [
-      "najlegši",
-      "najlegše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajlegšejši",
-      "najnajlegšeje",
+      "najlegši",
+      "najlegši",
     ],
   },
   "plural": {
@@ -88185,17 +88098,11 @@ exports[`adjective najlegši  1`] = `
 exports[`adjective najlučši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najlučšejši",
-      "najlučšeje",
-    ],
-    "positive": [
-      "najlučši",
-      "najlučše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajlučšejši",
-      "najnajlučšeje",
+      "najlučši",
+      "najlučši",
     ],
   },
   "plural": {
@@ -88254,17 +88161,11 @@ exports[`adjective najlučši  1`] = `
 exports[`adjective najlěpši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najlěpšejši",
-      "najlěpšeje",
-    ],
-    "positive": [
-      "najlěpši",
-      "najlěpše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajlěpšejši",
-      "najnajlěpšeje",
+      "najlěpši",
+      "najlěpši",
     ],
   },
   "plural": {
@@ -88323,17 +88224,11 @@ exports[`adjective najlěpši  1`] = `
 exports[`adjective najmenši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najmenšejši",
-      "najmenšeje",
-    ],
-    "positive": [
-      "najmenši",
-      "najmenše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajmenšejši",
-      "najnajmenšeje",
+      "najmenši",
+      "najmenši",
     ],
   },
   "plural": {
@@ -88392,17 +88287,11 @@ exports[`adjective najmenši  1`] = `
 exports[`adjective najmękši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najmękšejši",
-      "najmękšeje",
-    ],
-    "positive": [
-      "najmękši",
-      "najmękše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajmękšejši",
-      "najnajmękšeje",
+      "najmękši",
+      "najmękši",
     ],
   },
   "plural": {
@@ -88461,17 +88350,11 @@ exports[`adjective najmękši  1`] = `
 exports[`adjective najnizši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najnizšejši",
-      "najnizšeje",
-    ],
-    "positive": [
-      "najnizši",
-      "najnizše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajnizšejši",
-      "najnajnizšeje",
+      "najnizši",
+      "najnizši",
     ],
   },
   "plural": {
@@ -88530,17 +88413,11 @@ exports[`adjective najnizši  1`] = `
 exports[`adjective najnovějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najnovějšejši",
-      "najnovějšeje",
-    ],
-    "positive": [
-      "najnovějši",
-      "najnovějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajnovějšejši",
-      "najnajnovějšeje",
+      "najnovějši",
+      "najnovějši",
     ],
   },
   "plural": {
@@ -88599,17 +88476,11 @@ exports[`adjective najnovějši  1`] = `
 exports[`adjective najpozdnějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najpozdnějšejši",
-      "najpozdnějšeje",
-    ],
-    "positive": [
-      "najpozdnějši",
-      "najpozdnějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajpozdnějšejši",
-      "najnajpozdnějšeje",
+      "najpozdnějši",
+      "najpozdnějši",
     ],
   },
   "plural": {
@@ -88668,17 +88539,11 @@ exports[`adjective najpozdnějši  1`] = `
 exports[`adjective najprostějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najprostějšejši",
-      "najprostějšeje",
-    ],
-    "positive": [
-      "najprostějši",
-      "najprostějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajprostějšejši",
-      "najnajprostějšeje",
+      "najprostějši",
+      "najprostějši",
     ],
   },
   "plural": {
@@ -88737,17 +88602,11 @@ exports[`adjective najprostějši  1`] = `
 exports[`adjective najranši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najranšejši",
-      "najranšeje",
-    ],
-    "positive": [
-      "najranši",
-      "najranše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajranšejši",
-      "najnajranšeje",
+      "najranši",
+      "najranši",
     ],
   },
   "plural": {
@@ -88806,17 +88665,11 @@ exports[`adjective najranši  1`] = `
 exports[`adjective najstarějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najstarějšejši",
-      "najstarějšeje",
-    ],
-    "positive": [
-      "najstarějši",
-      "najstarějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajstarějšejši",
-      "najnajstarějšeje",
+      "najstarějši",
+      "najstarějši",
     ],
   },
   "plural": {
@@ -88875,17 +88728,11 @@ exports[`adjective najstarějši  1`] = `
 exports[`adjective najstarši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najstaršejši",
-      "najstaršeje",
-    ],
-    "positive": [
-      "najstarši",
-      "najstarše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajstaršejši",
-      "najnajstaršeje",
+      "najstarši",
+      "najstarši",
     ],
   },
   "plural": {
@@ -88944,17 +88791,11 @@ exports[`adjective najstarši  1`] = `
 exports[`adjective najveliky  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najveličějši",
-      "najveličeje",
-    ],
-    "positive": [
-      "najveliky",
-      "najveliko",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajveličějši",
-      "najnajveličeje",
+      "najveliky",
+      "najveliky",
     ],
   },
   "plural": {
@@ -89013,17 +88854,11 @@ exports[`adjective najveliky  1`] = `
 exports[`adjective najvęćši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najvęćšejši",
-      "najvęćšeje",
-    ],
-    "positive": [
-      "najvęćši",
-      "najvęćše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajvęćšejši",
-      "najnajvęćšeje",
+      "najvęćši",
+      "najvęćši",
     ],
   },
   "plural": {
@@ -89082,17 +88917,11 @@ exports[`adjective najvęćši  1`] = `
 exports[`adjective najzimnějši  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najzimnějšejši",
-      "najzimnějšeje",
-    ],
-    "positive": [
-      "najzimnějši",
-      "najzimnějše",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajzimnějšejši",
-      "najnajzimnějšeje",
+      "najzimnějši",
+      "najzimnějši",
     ],
   },
   "plural": {
@@ -89151,17 +88980,11 @@ exports[`adjective najzimnějši  1`] = `
 exports[`adjective najzly  1`] = `
 {
   "comparison": {
-    "comparative": [
-      "najzlějši",
-      "najzlěje",
-    ],
-    "positive": [
-      "najzly",
-      "najzlo",
-    ],
+    "comparative": [],
+    "positive": [],
     "superlative": [
-      "najnajzlějši",
-      "najnajzlěje",
+      "najzly",
+      "najzly",
     ],
   },
   "plural": {
@@ -131173,16 +130996,13 @@ exports[`adjective pozdnějši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "pozdnějšejši",
-      "pozdnějšeje",
-    ],
-    "positive": [
       "pozdnějši",
       "pozdnějše",
     ],
+    "positive": [],
     "superlative": [
-      "najpozdnějšejši",
-      "najpozdnějšeje",
+      "najpozdnějši",
+      "najpozdnějše",
     ],
   },
   "plural": {
@@ -137521,16 +137341,13 @@ exports[`adjective prostějši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "prostějšejši",
-      "prostějšeje",
-    ],
-    "positive": [
       "prostějši",
       "prostějše",
     ],
+    "positive": [],
     "superlative": [
-      "najprostějšejši",
-      "najprostějšeje",
+      "najprostějši",
+      "najprostějše",
     ],
   },
   "plural": {
@@ -162361,16 +162178,13 @@ exports[`adjective starějši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "starějšejši",
-      "starějšeje",
-    ],
-    "positive": [
       "starějši",
       "starějše",
     ],
+    "positive": [],
     "superlative": [
-      "najstarějšejši",
-      "najstarějšeje",
+      "najstarějši",
+      "najstarějše",
     ],
   },
   "plural": {
@@ -180577,16 +180391,13 @@ exports[`adjective veličejši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "veličejšejši",
-      "veličejšeje",
-    ],
-    "positive": [
       "veličejši",
       "veličejše",
     ],
+    "positive": [],
     "superlative": [
-      "najveličejšejši",
-      "najveličejšeje",
+      "najveličejši",
+      "najveličejše",
     ],
   },
   "plural": {
@@ -194653,16 +194464,13 @@ exports[`adjective zimnějši  1`] = `
 {
   "comparison": {
     "comparative": [
-      "zimnějšejši",
-      "zimnějšeje",
-    ],
-    "positive": [
       "zimnějši",
       "zimnějše",
     ],
+    "positive": [],
     "superlative": [
-      "najzimnějšejši",
-      "najzimnějšeje",
+      "najzimnějši",
+      "najzimnějše",
     ],
   },
   "plural": {

--- a/src/adjective/declensionAdjective.test.ts
+++ b/src/adjective/declensionAdjective.test.ts
@@ -1,7 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
-import { declensionAdjective } from './declensionAdjective';
+import {
+  declensionAdjective,
+  declensionAdjectiveFlat,
+} from './declensionAdjective';
 
 const rawTestCases = yaml.load(
   fs.readFileSync(path.join(__dirname, 'testCases.yml'), 'utf8'),
@@ -14,7 +17,20 @@ const adjective = rawTestCases.map(
 describe('adjective', () => {
   test.each(adjective)('%s %s', (lemma, _extra, morphology) => {
     if (!morphology.startsWith('adj')) throw 'not an adjective';
-    const actual = declensionAdjective(lemma, '');
+    const actual = declensionAdjective(lemma, '', morphology);
     expect(actual).toMatchSnapshot();
   });
+});
+
+test('declensionAdjectiveFlat integrity', () => {
+  const positive = declensionAdjectiveFlat('dobry', '', 'adj.');
+  const comparative = declensionAdjectiveFlat('lěpši', '', 'adj.comp.');
+  const superlative = declensionAdjectiveFlat('najlěpši', '', 'adj.sup.');
+  const joint = [...positive, ...comparative, ...superlative];
+
+  // No empty strings expected
+  expect(joint.filter(Boolean).length).toBe(joint.length);
+  expect(positive.length).toBe(18);
+  expect(comparative.length).toBe(14);
+  expect(superlative.length).toBe(12);
 });

--- a/src/adjective/testCases.yml
+++ b/src/adjective/testCases.yml
@@ -492,7 +492,7 @@
 - lemma: boljny
   morphology: adj.
 - lemma: boljši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: bordovy
   morphology: adj.
 - lemma: bosnijsky
@@ -674,7 +674,7 @@
 - lemma: daljny
   morphology: adj.
 - lemma: daljši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: dalmatinsky
   morphology: adj.
 - lemma: dansky
@@ -764,7 +764,7 @@
 - lemma: diskusijny
   morphology: adj.
 - lemma: divnějši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: divny
   morphology: adj.
 - lemma: divy
@@ -1365,7 +1365,7 @@
 - lemma: historičny
   morphology: adj.
 - lemma: hlådnějši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: hlådny
   morphology: adj.
 - lemma: hmeljny
@@ -1953,7 +1953,7 @@
 - lemma: krasivy
   morphology: adj.
 - lemma: krasnějši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: krasnorěčivy
   morphology: adj.
 - lemma: krasny
@@ -2597,61 +2597,61 @@
 - lemma: naivny
   morphology: adj.
 - lemma: najblizši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najbogatši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najboljši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najdaljši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najdivnějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najemny
   morphology: adj.
 - lemma: najglųbši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najgorši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najhlådnějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najkrasivši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najkrasnějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najkrvavši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najlegši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najlěpši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najlučši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najmękši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najmenši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najnizši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najnovějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najpozdnějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najprostějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najranši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najstarějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najstarši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najvęćši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najveliky
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najzimnějši
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: najzly
-  morphology: adj.
+  morphology: adj.sup.
 - lemma: naklonjeny
   morphology: adj.
 - lemma: naležity
@@ -3898,7 +3898,7 @@
 - lemma: povyši
   morphology: adj.
 - lemma: pozdnějši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: pozdny
   morphology: adj.
 - lemma: pozemny
@@ -4158,7 +4158,7 @@
 - lemma: prostačsky
   morphology: adj.
 - lemma: prostějši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: prostrånny
   morphology: adj.
 - lemma: prostrånny
@@ -4809,7 +4809,7 @@
 - lemma: staranny
   morphology: adj.
 - lemma: starějši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: starši
   morphology: adj.
 - lemma: starinny
@@ -5345,7 +5345,7 @@
 - lemma: velebny
   morphology: adj.
 - lemma: veličejši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: veličstveny
   morphology: adj.
 - lemma: velikodušny
@@ -5739,7 +5739,7 @@
 - lemma: zemsky
   morphology: adj.
 - lemma: zimnějši
-  morphology: adj.
+  morphology: adj.comp.
 - lemma: zimny
   morphology: adj.
 - lemma: zimovy


### PR DESCRIPTION
1. Adds optional argument to `declensionAdjective` and `declensionAdjectiveFlat`, which allows to limit output for superlative (`adj.sup.`) and comparative (`adj.comp.`) adjectives and avoids tautological forms like `najnajlěpšejši.`
2. Updates test cases with the `adj.comp.` and `adj.sup.` instances.