### PR TITLE
feat: adopt ISV code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Reference is automatically generated at: <https://medzuslovjansky.github.io/js-u
 
 ### Constants
 
-* `InterslavicBCP47` - primary BCP 47 codes for Interslavic like `art-x-interslv` and its variants per used alphabets.
+* `InterslavicBCP47` - primary BCP 47 codes for Interslavic like `isv` and its variants per used alphabets.
 * `FlavorisationBCP47` - all possible BCP 47 codes for Interslavic with flavorisations applied like Northern, Southern, Slovianto, etc.
 * `Glagolitic` - collection of named constants for Glagolitic letters, e.g. `Glagolitic.AZU`, `Glagolitic.BUKY`, etc.
 

--- a/src/__utils__/html/common.ts
+++ b/src/__utils__/html/common.ts
@@ -25,5 +25,5 @@ export function get<T>(obj: T): (...path: any[]) => string | null {
 }
 
 function normalize(string: string | null): string | null {
-  return string && transliterate(string, 'art-Latn-x-interslv-etym');
+  return string && transliterate(string, 'isv-Latn-x-etymolog');
 }

--- a/src/constants/bcp47.ts
+++ b/src/constants/bcp47.ts
@@ -1,9 +1,9 @@
 export const InterslavicBCP47 = {
-  Generic: 'art-x-interslv',
-  Latin: 'art-Latn-x-interslv',
-  Cyrillic: 'art-Cyrl-x-interslv',
-  Glagolitic: 'art-Glag-x-interslv',
-  IPA: 'art-x-interslv-fonipa',
+  Generic: 'isv',
+  Latin: 'isv-Latn',
+  Cyrillic: 'isv-Cyrl',
+  Glagolitic: 'isv-Glag',
+  IPA: 'isv-x-fonipa',
 } as const;
 
 export type InterslavicBCP47Code =
@@ -11,22 +11,22 @@ export type InterslavicBCP47Code =
 
 export const FlavorisationBCP47 = {
   ...InterslavicBCP47,
-  ASCII: 'art-Latn-x-interslv-ascii',
-  LatinEtymological: 'art-Latn-x-interslv-etym',
-  LatinNorthern: 'art-Latn-x-interslv-northern',
-  LatinSlovianto: 'art-Latn-x-interslv-sloviant',
-  LatinSouthern: 'art-Latn-x-interslv-southern',
-  Polish: 'art-Latn-PL-x-interslv',
-  GlagoliticEtymological: 'art-Glag-x-interslv-etym',
-  GlagoliticNorthern: 'art-Glag-x-interslv-northern',
-  GlagoliticSlovianto: 'art-Glag-x-interslv-sloviant',
-  GlagoliticSouthern: 'art-Glag-x-interslv-southern',
-  CyrillicEtymological: 'art-Cyrl-x-interslv-etym',
-  CyrillicIotated: 'art-Cyrl-x-interslv-iotated',
-  CyrillicIotatedExtended: 'art-Cyrl-x-interslv-iotated-ext',
-  CyrillicNorthern: 'art-Cyrl-x-interslv-northern',
-  CyrillicSlovianto: 'art-Cyrl-x-interslv-sloviant',
-  CyrillicSouthern: 'art-Cyrl-x-interslv-southern',
+  ASCII: 'isv-Latn-x-ascii',
+  LatinEtymological: 'isv-Latn-x-etymolog',
+  LatinNorthern: 'isv-Latn-x-northern',
+  LatinSlovianto: 'isv-Latn-x-sloviant',
+  LatinSouthern: 'isv-Latn-x-southern',
+  Polish: 'isv-Latn-PL',
+  GlagoliticEtymological: 'isv-Glag-x-etymolog',
+  GlagoliticNorthern: 'isv-Glag-x-northern',
+  GlagoliticSlovianto: 'isv-Glag-x-sloviant',
+  GlagoliticSouthern: 'isv-Glag-x-southern',
+  CyrillicEtymological: 'isv-Cyrl-x-etymolog',
+  CyrillicIotated: 'isv-Cyrl-x-iotated',
+  CyrillicIotatedExtended: 'isv-Cyrl-x-iotated-ext',
+  CyrillicNorthern: 'isv-Cyrl-x-northern',
+  CyrillicSlovianto: 'isv-Cyrl-x-sloviant',
+  CyrillicSouthern: 'isv-Cyrl-x-southern',
 } as const;
 
 export type FlavorisationBCP47Code =

--- a/src/numeral/declensionNumeral.ts
+++ b/src/numeral/declensionNumeral.ts
@@ -326,6 +326,6 @@ export function declensionNumeral(
 }
 
 function getLatin(word: string): string {
-  const latin = transliterate(word, 'art-Latn-x-interslv');
+  const latin = transliterate(word, 'isv-Latn');
   return stripDiacritics(latin);
 }

--- a/src/pronoun/declensionPronoun.ts
+++ b/src/pronoun/declensionPronoun.ts
@@ -65,7 +65,7 @@ export function declensionPronoun(
     return null;
   }
 
-  const word = stripDiacritics(transliterate(rawWord, 'art-Latn-x-interslv'));
+  const word = stripDiacritics(transliterate(rawWord, 'isv-Latn'));
   if (pronounType === 'personal' || pronounType === 'reflexive') {
     if (FIRST_PERSON.includes(word)) {
       return {

--- a/src/transliterate/__snapshots__/index.test.ts.snap
+++ b/src/transliterate/__snapshots__/index.test.ts.snap
@@ -1,293 +1,293 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`transliterate to "art-Cyrl-x-interslv" a cyrillic text 1`] = `
-"На возвышености овца, ктора не имєла волну, увидєла коњев. Првы тегал тежкы воз, вторы носил велико брєме, третји брзо возил мужа.
-Овца рєкла коњам: «Боли мнє срдце, когда виджу, како чловєк владаје коњами.»
-Коњи рєкли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да бы имєл дља себе тепло палто. А овца јест без волны.»
-Услышавши то, овца избєгла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги повєдєли краљу о веселју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv" a latin text 1`] = `
-"На возвышености овца, ктора не имєла волну, увидєла коњев. Првы тегал тежкы воз, вторы носил велико брєме, третји брзо возил мужа.
-Овца рєкла коњам: «Боли мнє срдце, когда виджу, како чловєк владаје коњами.»
-Коњи рєкли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да бы имєл дља себе тепло палто. А овца јест без волны.»
-Услышавши то, овца избєгла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги повєдєли краљу о веселју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-etym" a cyrillic text 1`] = `
-"На возвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Првы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третји брзо возил мѫжа.
-Овца рѣкла коњам: «Боли мнѣ срдце, къгда виджу, како чловѣк владаје коњами.»
-Коњи рѣкли: «Слушај, овцо, нам боли срдце, къгда видимо ово: мѫж, господарь, бере твојѫ вълнѫ, да бы имѣл дља себе тепло пальто. А овца јесть без вълны.»
-Услышавши то, овца избѣгла в рӑвнину. | Одјезд. Тьма, и корење ревења почѧли рӑстеньје, а слуги повѣдѣли крӑљу о весельју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-etym" a latin text 1`] = `
-"На възвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Првы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третји брзо возил мѫжа.
-Овца рѣкла коњам: «Боли мнѣ срдце, къгда виђѫ, како чловѣк владаје коњами.»
-Коњи рѣкли: «Слушај, овцо, нам боли срдце, къгда видимо ово: мѫж, господарь, бере твојѫ вълнѫ, да бы имѣл дља себе тепло пальто. А овца јест без вълны.»
-Услышавши то, овца избѣгла в рӑвнинѫ. | Одјезд. Тьма, и корење ревења почѧли рӑстеньје, а слуги повѣдѣли крӑљу о весельју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-iotated" a cyrillic text 1`] = `
-"На возвышености овца, ктора не имела волну, увидела коньев. Првы тегал тежкы воз, вторы носил велико бреме, третьи брзо возил мужа.
-Овца рекла коням: «Боли мне срдце, когда виджу, како чловек владае конями.»
-Коньи рекли: «Слушай, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твою волну, да бы имел для себе тепло палто. А овца ест без волны.»
-Услышавши то, овца избегла в равнину. | Од’езд. Тма, и коренье ревеня почели растенье, а слуги поведели кралю о веселю."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-iotated" a latin text 1`] = `
-"На возвышености овца, ктора не имела волну, увидела коньев. Првы тегал тежкы воз, вторы носил велико бреме, третьи брзо возил мужа.
-Овца рекла коням: «Боли мне срдце, когда виджу, како чловек владае конями.»
-Коньи рекли: «Слушай, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твою волну, да бы имел для себе тепло палто. А овца ест без волны.»
-Услышавши то, овца избегла в равнину. | Од’езд. Тма, и коренье ревеня почели растенье, а слуги поведели кралю о веселю."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-iotated-ext" a cyrillic text 1`] = `
-"На возвышености овца, ктора не имѣла вълнѫ, увидѣла конѥв. Пьрвы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третӥ бързо возил мѫжа.
-Овца рѣкла коням: «Боли мнѣ сьрдце, къгда виджу, како чловѣк владаѥ конями.»
-Конӥ рѣкли: «Слушай, овцо, нам боли сьрдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл для себе тепло пальто. А овца ѥсть без вълны.»
-Услышавши то, овца избѣгла в рӑвнину. | Од’ѥзд. Тьма, и коренѥ ревеня почѧли рӑстеньѥ, а слуги повѣдѣли крӑлю о веселью."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-iotated-ext" a latin text 1`] = `
-"На възвышености овца, ктора не имѣла вълнѫ, увидѣла конѥв. Пьрвы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третӥ бързо возил мѫжа.
-Овца рѣкла коням: «Боли мнѣ сьрдце, къгда виђѫ, како чловѣк владаѥ конями.»
-Конӥ рѣкли: «Слушай, овцо, нам боли сьрдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл для себе тепло пальто. А овца ѥст без вълны.»
-Услышавши то, овца избѣгла в рӑвнинѫ. | Од’ѥзд. Тьма, и коренѥ ревеня почѧли рӑстеньѥ, а слуги повѣдѣли крӑлю о веселью."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-northern" a cyrillic text 1`] = `
-"На возвышености овца, ктора не имєла волну, увидєла коњев. Первы тјагал тјажки воз, вторы носил велико брємја, третји борзо возил мужа.
-Овца рєкла коњам: «Боли мнє сердце, когда виджу, како чловєк владаје коњами.»
-Коњи рєкли: «Слушај, овцо, нам боли сердце, когда видимо ово: муж, господарь, бере твоју волну, да бы имєл дља себе тепло пальто. А овца јесть без волны.»
-Услышавши то, овца избєгла в ровнину. | Одјезд. Тьма, и корење ревења почали ростеньје, а слуги повєдєли крољу о весельју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-northern" a latin text 1`] = `
-"На возвышености овца, ктора не имєла волну, увидєла коњев. Первы тјагал тјажки воз, вторы носил велико брємја, третји борзо возил мужа.
-Овца рєкла коњам: «Боли мнє сердце, когда виджу, како чловєк владаје коњами.»
-Коњи рєкли: «Слушај, овцо, нам боли сердце, когда видимо ово: муж, господарь, бере твоју волну, да бы имєл дља себе тепло пальто. А овца јест без волны.»
-Услышавши то, овца избєгла в ровнину. | Одјезд. Тьма, и корење ревења почали ростеньје, а слуги повєдєли крољу о весельју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-sloviant" a cyrillic text 1`] = `
-"На возвишености овца, ктора не имела волну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
-Овца рекла коњам: «Боли мне срдце, когда виджу, како чловек владаје коњами.»
-Коњи рекли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да би имел дља себе тепло палто. А овца јест без волни.»
-Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги поведели краљу о веселју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-sloviant" a latin text 1`] = `
-"На возвишености овца, ктора не имела волну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
-Овца рекла коњам: «Боли мне срдце, когда виджу, како чловек владаје коњами.»
-Коњи рекли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да би имел дља себе тепло палто. А овца јест без волни.»
-Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги поведели краљу о веселју."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-southern" a cyrillic text 1`] = `
-"На возвишености овца, ктора не имела вълну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
-Овца рекла коњам: «Боли мне срдце, къгда виджу, како чловек владаје коњами.»
-Коњи рекли: «Слушај, овцо, нам боли срдце, къгда видимо ово: муж, господар, бере твоју вълну, да би имел дља себе тепло палто. А овца јест без вълни.»
-Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растење, а слуги поведели краљу о весељу."
-`;
-
-exports[`transliterate to "art-Cyrl-x-interslv-southern" a latin text 1`] = `
-"На възвишености овца, ктора не имела вълну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
-Овца рекла коњам: «Боли мне срдце, къгда виђу, како чловек владаје коњами.»
-Коњи рекли: «Слушај, овцо, нам боли срдце, къгда видимо ово: муж, господар, бере твоју вълну, да би имел дља себе тепло палто. А овца јест без вълни.»
-Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растење, а слуги поведели краљу о весељу."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv" a cyrillic text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⱐⰹ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
-Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv" a latin text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⱐⰹ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
-Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-etym" a cyrillic text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱏⰾⱀⱘ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⱐⰲⱐⰹ ⱅⱔⰳⰰⰾ ⱅⱔⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱔ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱘⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱘⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱙ ⰲⱏⰾⱀⱘ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅⱐ ⰱⰵⰸ ⰲⱏⰾⱀⱐⰹ.»
-Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱉⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⱔⰾⰻ ⱃⱉⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱉⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-etym" a latin text 1`] = `
-"Ⱀⰰ ⰲⱏⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱏⰾⱀⱘ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⱐⰲⱐⰹ ⱅⱔⰳⰰⰾ ⱅⱔⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱔ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱘⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰼⱘ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱘⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱙ ⰲⱏⰾⱀⱘ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱏⰾⱀⱐⰹ.»
-Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱉⰲⱀⰻⱀⱘ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⱔⰾⰻ ⱃⱉⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱉⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-northern" a cyrillic text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⰵⱃⰲⱐⰹ ⱅⱝⰳⰰⰾ ⱅⱝⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱝ, ⱅⱃⰵⱅⰹⰻ ⰱⱁⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅⱐ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
-Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱁⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰰⰾⰻ ⱃⱁⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱁⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-northern" a latin text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⰵⱃⰲⱐⰹ ⱅⱝⰳⰰⰾ ⱅⱝⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱝ, ⱅⱃⰵⱅⰹⰻ ⰱⱁⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
-Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱁⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰰⰾⰻ ⱃⱁⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱁⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-sloviant" a cyrillic text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
-Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-sloviant" a latin text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
-Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-southern" a cyrillic text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
-Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
-`;
-
-exports[`transliterate to "art-Glag-x-interslv-southern" a latin text 1`] = `
-"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
-Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰼⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
-Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
-Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
-`;
-
-exports[`transliterate to "art-Latn-PL-x-interslv" a cyrillic text 1`] = `
-"Na wozwyszenosti owca, ktora ne imieła wołną, uwidieła koniew. Perwy tęgał tężki woz, wtory nosił weliko briemę, treti borzo woził mąża.
-Owca riekła koniam: «Boli mnie serdce, kogda widżu, kako człowiek władaje koniami.»
-Koni riekli: «Słuszaj, owco, nam boli serdce, kogda widimo owo: mąż, gospodaŕ, bere twoją wołną, da by imieł dla sebe tepło palto. A owca jesť bez wołny.»
-Usłyszawszi to, owca izbiegła w rawninu. | Odjezd. Ťma, i korenie rewenia poczęli rasteńie, a sługi powiedieli kralu o weseliu."
-`;
-
-exports[`transliterate to "art-Latn-PL-x-interslv" a latin text 1`] = `
-"Na wozwyszenosti owca, ktora ne imieła wołną, uwidieła koniew. Perwy tęgał tężki woz, wtory nosił weliko briemę, treti borzo woził mąża.
-Owca riekła koniam: «Boli mnie serdce, kogda widzią, kako człowiek władaje koniami.»
-Koni riekli: «Słuszaj, owco, nam boli serdce, kogda widimo owo: mąż, gospodaŕ, bere twoją wołną, da by imieł dla sebe tepło palto. A owca jest bez wołny.»
-Usłyszawszi to, owca izbiegła w rawniną. | Odjezd. Ťma, i korenie rewenia poczęli rasteńie, a sługi powiedieli kralu o weseliu."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv" a cyrillic text 1`] = `
-"Na vozvyšenosti ovca, ktora ne iměla volnu, uviděla konjev. Prvy tegal težky voz, vtory nosil veliko brěme, tretji brzo vozil muža.
-Ovca rěkla konjam: «Boli mně srdce, kogda vidžu, kako člověk vladaje konjami.»
-Konji rěkli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da by iměl dlja sebe teplo palto. A ovca jest bez volny.»
-Uslyšavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv" a latin text 1`] = `
-"Na vozvyšenosti ovca, ktora ne iměla volnu, uviděla konjev. Prvy tegal težky voz, vtory nosil veliko brěme, tretji brzo vozil muža.
-Ovca rěkla konjam: «Boli mně srdce, kogda vidžu, kako člověk vladaje konjami.»
-Konji rěkli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da by iměl dlja sebe teplo palto. A ovca jest bez volny.»
-Uslyšavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-ascii" a cyrillic text 1`] = `
-"Na vozvyszenosti ovca, ktora ne imjela volnu, uvidjela konjev. Prvy tegal tezsky voz, vtory nosil veliko brjeme, tretji brzo vozil muzsa.
-Ovca rjekla konjam: «Boli mnje srdce, kogda vidzsu, kako czlovjek vladaje konjami.»
-Konji rjekli: «Sluszaj, ovco, nam boli srdce, kogda vidimo ovo: muzs, gospodar, bere tvoju volnu, da by imjel dlja sebe teplo palto. A ovca jest bez volny.»
-Uslyszavszi to, ovca izbjegla v ravninu. | Odjezd. Tma, i korenje revenja poczeli rastenje, a slugi povjedjeli kralju o veselju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-ascii" a latin text 1`] = `
-"Na vozvyszenosti ovca, ktora ne imjela volnu, uvidjela konjev. Prvy tegal tezsky voz, vtory nosil veliko brjeme, tretji brzo vozil muzsa.
-Ovca rjekla konjam: «Boli mnje srdce, kogda vidzsu, kako czlovjek vladaje konjami.»
-Konji rjekli: «Sluszaj, ovco, nam boli srdce, kogda vidimo ovo: muzs, gospodar, bere tvoju volnu, da by imjel dlja sebe teplo palto. A ovca jest bez volny.»
-Uslyszavszi to, ovca izbjegla v ravninu. | Odjezd. Tma, i korenje revenja poczeli rastenje, a slugi povjedjeli kralju o veselju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-etym" a cyrillic text 1`] = `
-"Na vozvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
-Ovca rěkla konjam: «Boli mně sŕdce, kȯgda vidžu, kako člověk vladaje konjami.»
-Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest́ bez vȯlny.»
-Uslyšavši to, ovca izběgla v råvninu. | Odjezd. T́ma, i korenje revenja počęli råsteńje, a slugi pověděli krålju o veseĺju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-etym" a latin text 1`] = `
-"Na vȯzvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
-Ovca rěkla konjam: «Boli mně sŕdce, kȯgda viđų, kako člověk vladaje konjami.»
-Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest bez vȯlny.»
-Uslyšavši to, ovca izběgla v råvninų. | Odjezd. T́ma, i korenje revenja počęli råsteńje, a slugi pověděli krålju o veseĺju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-northern" a cyrillic text 1`] = `
-"Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
-Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
-Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paľto. A ovca jesť bez volny.»
-Uslyšavši to, ovca izbiegla v rovninu. | Odjezd. Ťma, i korenie revenia počali rostenie, a slugi poviedieli kroliu o veseliu."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-northern" a latin text 1`] = `
-"Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
-Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
-Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paľto. A ovca jest bez volny.»
-Uslyšavši to, ovca izbiegla v rovninu. | Odjezd. Ťma, i korenie revenia počali rostenie, a slugi poviedieli kroliu o veseliu."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-sloviant" a cyrillic text 1`] = `
-"Na vozvišenosti ovca, ktora ne imela volnu, uvidela konjev. Prvi tegal težki voz, vtori nosil veliko breme, tretji brzo vozil muža.
-Ovca rekla konjam: «Boli mne srdce, kogda vidžu, kako človek vladaje konjami.»
-Konji rekli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da bi imel dlja sebe teplo palto. A ovca jest bez volni.»
-Uslišavši to, ovca izbegla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi povedeli kralju o veselju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-sloviant" a latin text 1`] = `
-"Na vozvišenosti ovca, ktora ne imela volnu, uvidela konjev. Prvi tegal težki voz, vtori nosil veliko breme, tretji brzo vozil muža.
-Ovca rekla konjam: «Boli mne srdce, kogda vidžu, kako človek vladaje konjami.»
-Konji rekli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da bi imel dlja sebe teplo palto. A ovca jest bez volni.»
-Uslišavši to, ovca izbegla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi povedeli kralju o veselju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-southern" a cyrillic text 1`] = `
-"Na vozvišenosti ovca, ktora ne iměla vălnu, uviděla konjev. Prvi tegal težki voz, vtori nosil veliko brěme, tretji brzo vozil muža.
-Ovca rěkla konjam: «Boli mně srdce, kăgda vidžu, kako člověk vladaje konjami.»
-Konji rěkli: «Slušaj, ovco, nam boli srdce, kăgda vidimo ovo: muž, gospodar, bere tvoju vălnu, da bi iměl dlja sebe teplo palto. A ovca jest bez vălni.»
-Uslišavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
-`;
-
-exports[`transliterate to "art-Latn-x-interslv-southern" a latin text 1`] = `
-"Na văzvišenosti ovca, ktora ne iměla vălnu, uviděla konjev. Prvi tegal težki voz, vtori nosil veliko brěme, tretji brzo vozil muža.
-Ovca rěkla konjam: «Boli mně srdce, kăgda viđu, kako člověk vladaje konjami.»
-Konji rěkli: «Slušaj, ovco, nam boli srdce, kăgda vidimo ovo: muž, gospodar, bere tvoju vălnu, da bi iměl dlja sebe teplo palto. A ovca jest bez vălni.»
-Uslišavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
-`;
-
-exports[`transliterate to "art-x-interslv" a cyrillic text 1`] = `
+exports[`transliterate to "isv" a cyrillic text 1`] = `
 "На возвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Прьвы тѧгал тѧжкы воз, вторы носил велико брємѧ, третји брзо возил мѫжа.
 Овца рѣкла коням: «Боли мнє срьдце, къгда виџу, како чловѣк владаје коньами.»
 Конји рѣкли: «Слушай, овцо, нам боли срьдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл дља себе тепло пальто. А овца ѥсть без вълны.»
 Услышавши то, овца избѣгла в рӑвнинѹ. | Одјезд. Тьма, и корење ревења почѧли рӑстеньје, а слуги повєдѣли крӑљу о весельју."
 `;
 
-exports[`transliterate to "art-x-interslv" a latin text 1`] = `
+exports[`transliterate to "isv" a latin text 1`] = `
 "Na vȯzvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
 Ovca rěkla konjam: «Boli mně sŕdce, kȯgda viđų, kako člověk vladaje konjami.»
 Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest bez vȯlny.»
 Uslyšavši to, ovca izběgla v råvninų. | Odjezd. T́ma, i korenje revenja počęli råsteńje, a slugi pověděli krålju o veseĺju."
 `;
 
-exports[`transliterate to "art-x-interslv-fonipa" a cyrillic text 1`] = `
+exports[`transliterate to "isv-Cyrl" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имєла волну, увидєла коњев. Првы тегал тежкы воз, вторы носил велико брєме, третји брзо возил мужа.
+Овца рєкла коњам: «Боли мнє срдце, когда виджу, како чловєк владаје коњами.»
+Коњи рєкли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да бы имєл дља себе тепло палто. А овца јест без волны.»
+Услышавши то, овца избєгла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги повєдєли краљу о веселју."
+`;
+
+exports[`transliterate to "isv-Cyrl" a latin text 1`] = `
+"На возвышености овца, ктора не имєла волну, увидєла коњев. Првы тегал тежкы воз, вторы носил велико брєме, третји брзо возил мужа.
+Овца рєкла коњам: «Боли мнє срдце, когда виджу, како чловєк владаје коњами.»
+Коњи рєкли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да бы имєл дља себе тепло палто. А овца јест без волны.»
+Услышавши то, овца избєгла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги повєдєли краљу о веселју."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-etymolog" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Првы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третји брзо возил мѫжа.
+Овца рѣкла коњам: «Боли мнѣ срдце, къгда виджу, како чловѣк владаје коњами.»
+Коњи рѣкли: «Слушај, овцо, нам боли срдце, къгда видимо ово: мѫж, господарь, бере твојѫ вълнѫ, да бы имѣл дља себе тепло пальто. А овца јесть без вълны.»
+Услышавши то, овца избѣгла в рӑвнину. | Одјезд. Тьма, и корење ревења почѧли рӑстеньје, а слуги повѣдѣли крӑљу о весельју."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-etymolog" a latin text 1`] = `
+"На възвышености овца, ктора не имѣла вълнѫ, увидѣла коњев. Првы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третји брзо возил мѫжа.
+Овца рѣкла коњам: «Боли мнѣ срдце, къгда виђѫ, како чловѣк владаје коњами.»
+Коњи рѣкли: «Слушај, овцо, нам боли срдце, къгда видимо ово: мѫж, господарь, бере твојѫ вълнѫ, да бы имѣл дља себе тепло пальто. А овца јест без вълны.»
+Услышавши то, овца избѣгла в рӑвнинѫ. | Одјезд. Тьма, и корење ревења почѧли рӑстеньје, а слуги повѣдѣли крӑљу о весельју."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-iotated" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имела волну, увидела коньев. Првы тегал тежкы воз, вторы носил велико бреме, третьи брзо возил мужа.
+Овца рекла коням: «Боли мне срдце, когда виджу, како чловек владае конями.»
+Коньи рекли: «Слушай, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твою волну, да бы имел для себе тепло палто. А овца ест без волны.»
+Услышавши то, овца избегла в равнину. | Од’езд. Тма, и коренье ревеня почели растенье, а слуги поведели кралю о веселю."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-iotated" a latin text 1`] = `
+"На возвышености овца, ктора не имела волну, увидела коньев. Првы тегал тежкы воз, вторы носил велико бреме, третьи брзо возил мужа.
+Овца рекла коням: «Боли мне срдце, когда виджу, како чловек владае конями.»
+Коньи рекли: «Слушай, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твою волну, да бы имел для себе тепло палто. А овца ест без волны.»
+Услышавши то, овца избегла в равнину. | Од’езд. Тма, и коренье ревеня почели растенье, а слуги поведели кралю о веселю."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-iotated-ext" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имѣла вълнѫ, увидѣла конѥв. Пьрвы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третӥ бързо возил мѫжа.
+Овца рѣкла коням: «Боли мнѣ сьрдце, къгда виджу, како чловѣк владаѥ конями.»
+Конӥ рѣкли: «Слушай, овцо, нам боли сьрдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл для себе тепло пальто. А овца ѥсть без вълны.»
+Услышавши то, овца избѣгла в рӑвнину. | Од’ѥзд. Тьма, и коренѥ ревеня почѧли рӑстеньѥ, а слуги повѣдѣли крӑлю о веселью."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-iotated-ext" a latin text 1`] = `
+"На възвышености овца, ктора не имѣла вълнѫ, увидѣла конѥв. Пьрвы тѧгал тѧжкы воз, вторы носил велико брѣмѧ, третӥ бързо возил мѫжа.
+Овца рѣкла коням: «Боли мнѣ сьрдце, къгда виђѫ, како чловѣк владаѥ конями.»
+Конӥ рѣкли: «Слушай, овцо, нам боли сьрдце, къгда видимо ово: мѫж, господарь, бере твоѭ вълнѫ, да бы имѣл для себе тепло пальто. А овца ѥст без вълны.»
+Услышавши то, овца избѣгла в рӑвнинѫ. | Од’ѥзд. Тьма, и коренѥ ревеня почѧли рӑстеньѥ, а слуги повѣдѣли крӑлю о веселью."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-northern" a cyrillic text 1`] = `
+"На возвышености овца, ктора не имєла волну, увидєла коњев. Первы тјагал тјажки воз, вторы носил велико брємја, третји борзо возил мужа.
+Овца рєкла коњам: «Боли мнє сердце, когда виджу, како чловєк владаје коњами.»
+Коњи рєкли: «Слушај, овцо, нам боли сердце, когда видимо ово: муж, господарь, бере твоју волну, да бы имєл дља себе тепло пальто. А овца јесть без волны.»
+Услышавши то, овца избєгла в ровнину. | Одјезд. Тьма, и корење ревења почали ростеньје, а слуги повєдєли крољу о весельју."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-northern" a latin text 1`] = `
+"На возвышености овца, ктора не имєла волну, увидєла коњев. Первы тјагал тјажки воз, вторы носил велико брємја, третји борзо возил мужа.
+Овца рєкла коњам: «Боли мнє сердце, когда виджу, како чловєк владаје коњами.»
+Коњи рєкли: «Слушај, овцо, нам боли сердце, когда видимо ово: муж, господарь, бере твоју волну, да бы имєл дља себе тепло пальто. А овца јест без волны.»
+Услышавши то, овца избєгла в ровнину. | Одјезд. Тьма, и корење ревења почали ростеньје, а слуги повєдєли крољу о весельју."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-sloviant" a cyrillic text 1`] = `
+"На возвишености овца, ктора не имела волну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
+Овца рекла коњам: «Боли мне срдце, когда виджу, како чловек владаје коњами.»
+Коњи рекли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да би имел дља себе тепло палто. А овца јест без волни.»
+Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги поведели краљу о веселју."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-sloviant" a latin text 1`] = `
+"На возвишености овца, ктора не имела волну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
+Овца рекла коњам: «Боли мне срдце, когда виджу, како чловек владаје коњами.»
+Коњи рекли: «Слушај, овцо, нам боли срдце, когда видимо ово: муж, господар, бере твоју волну, да би имел дља себе тепло палто. А овца јест без волни.»
+Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растенје, а слуги поведели краљу о веселју."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-southern" a cyrillic text 1`] = `
+"На возвишености овца, ктора не имела вълну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
+Овца рекла коњам: «Боли мне срдце, къгда виджу, како чловек владаје коњами.»
+Коњи рекли: «Слушај, овцо, нам боли срдце, къгда видимо ово: муж, господар, бере твоју вълну, да би имел дља себе тепло палто. А овца јест без вълни.»
+Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растење, а слуги поведели краљу о весељу."
+`;
+
+exports[`transliterate to "isv-Cyrl-x-southern" a latin text 1`] = `
+"На възвишености овца, ктора не имела вълну, увидела коњев. Први тегал тежки воз, втори носил велико бреме, третји брзо возил мужа.
+Овца рекла коњам: «Боли мне срдце, къгда виђу, како чловек владаје коњами.»
+Коњи рекли: «Слушај, овцо, нам боли срдце, къгда видимо ово: муж, господар, бере твоју вълну, да би имел дља себе тепло палто. А овца јест без вълни.»
+Услишавши то, овца избегла в равнину. | Одјезд. Тма, и корење ревења почели растење, а слуги поведели краљу о весељу."
+`;
+
+exports[`transliterate to "isv-Glag" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⱐⰹ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
+`;
+
+exports[`transliterate to "isv-Glag" a latin text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⱐⰹ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-etymolog" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱏⰾⱀⱘ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⱐⰲⱐⰹ ⱅⱔⰳⰰⰾ ⱅⱔⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱔ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱘⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱘⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱙ ⰲⱏⰾⱀⱘ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅⱐ ⰱⰵⰸ ⰲⱏⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱉⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⱔⰾⰻ ⱃⱉⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱉⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-etymolog" a latin text 1`] = `
+"Ⱀⰰ ⰲⱏⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱏⰾⱀⱘ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⱐⰲⱐⰹ ⱅⱔⰳⰰⰾ ⱅⱔⰶⰽⱐⰹ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱔ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱘⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰼⱘ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⱐⰴⱌⰵ, ⰽⱏⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱘⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱙ ⰲⱏⰾⱀⱘ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱏⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱉⰲⱀⰻⱀⱘ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⱔⰾⰻ ⱃⱉⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱉⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-northern" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⰵⱃⰲⱐⰹ ⱅⱝⰳⰰⰾ ⱅⱝⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱝ, ⱅⱃⰵⱅⰹⰻ ⰱⱁⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅⱐ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱁⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰰⰾⰻ ⱃⱁⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱁⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-northern" a latin text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⱐⰹⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⱑⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⱑⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⰵⱃⰲⱐⰹ ⱅⱝⰳⰰⰾ ⱅⱝⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⱐⰹ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⱑⱞⱝ, ⱅⱃⰵⱅⰹⰻ ⰱⱁⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⱑⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⱑ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⱑⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⱑⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⰵⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃⱐ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⱐⰹ ⰻⱞⱑⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱐⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⱐⰹ.»
+Ⱆⱄⰾⱐⰹⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⱑⰳⰾⰰ ⰲ ⱃⱁⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱐⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰰⰾⰻ ⱃⱁⱄⱅⰵⱀⱐⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⱑⰴⱑⰾⰻ ⰽⱃⱁⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱐⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-sloviant" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
+Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-sloviant" a latin text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
+Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-southern" a cyrillic text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰶⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
+Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
+`;
+
+exports[`transliterate to "isv-Glag-x-southern" a latin text 1`] = `
+"Ⱀⰰ ⰲⱁⰸⰲⰻⱎⰵⱀⱁⱄⱅⰻ ⱁⰲⱌⰰ, ⰽⱅⱁⱃⰰ ⱀⰵ ⰻⱞⰵⰾⰰ ⰲⱁⰾⱀⱆ, ⱆⰲⰻⰴⰵⰾⰰ ⰽⱁⱀⰹⰵⰲ. Ⱂⱃⰲⰻ ⱅⰵⰳⰰⰾ ⱅⰵⰶⰽⰻ ⰲⱁⰸ, ⰲⱅⱁⱃⰻ ⱀⱁⱄⰻⰾ ⰲⰵⰾⰻⰽⱁ ⰱⱃⰵⱞⰵ, ⱅⱃⰵⱅⰹⰻ ⰱⱃⰸⱁ ⰲⱁⰸⰻⰾ ⱞⱆⰶⰰ.
+Ⱁⰲⱌⰰ ⱃⰵⰽⰾⰰ ⰽⱁⱀⱝⱞ: «Ⰱⱁⰾⰻ ⱞⱀⰵ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰼⱆ, ⰽⰰⰽⱁ ⱍⰾⱁⰲⰵⰽ ⰲⰾⰰⰴⰰⰹⰵ ⰽⱁⱀⱝⱞⰻ.»
+Ⰽⱁⱀⰹⰻ ⱃⰵⰽⰾⰻ: «Ⱄⰾⱆⱎⰰⰹ, ⱁⰲⱌⱁ, ⱀⰰⱞ ⰱⱁⰾⰻ ⱄⱃⰴⱌⰵ, ⰽⱁⰳⰴⰰ ⰲⰻⰴⰻⱞⱁ ⱁⰲⱁ: ⱞⱆⰶ, ⰳⱁⱄⱂⱁⰴⰰⱃ, ⰱⰵⱃⰵ ⱅⰲⱁⱓ ⰲⱁⰾⱀⱆ, ⰴⰰ ⰱⰻ ⰻⱞⰵⰾ ⰴⰾⱝ ⱄⰵⰱⰵ ⱅⰵⱂⰾⱁ ⱂⰰⰾⱅⱁ. Ⰰ ⱁⰲⱌⰰ ⰹⰵⱄⱅ ⰱⰵⰸ ⰲⱁⰾⱀⰻ.»
+Ⱆⱄⰾⰻⱎⰰⰲⱎⰻ ⱅⱁ, ⱁⰲⱌⰰ ⰻⰸⰱⰵⰳⰾⰰ ⰲ ⱃⰰⰲⱀⰻⱀⱆ. | Ⱁⰴⱏⰹⰵⰸⰴ. Ⱅⱞⰰ, ⰻ ⰽⱁⱃⰵⱀⰹⰵ ⱃⰵⰲⰵⱀⱝ ⱂⱁⱍⰵⰾⰻ ⱃⰰⱄⱅⰵⱀⰹⰵ, ⰰ ⱄⰾⱆⰳⰻ ⱂⱁⰲⰵⰴⰵⰾⰻ ⰽⱃⰰⰾⱓ ⱁ ⰲⰵⱄⰵⰾⱓ."
+`;
+
+exports[`transliterate to "isv-Latn" a cyrillic text 1`] = `
+"Na vozvyšenosti ovca, ktora ne iměla volnu, uviděla konjev. Prvy tegal težky voz, vtory nosil veliko brěme, tretji brzo vozil muža.
+Ovca rěkla konjam: «Boli mně srdce, kogda vidžu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da by iměl dlja sebe teplo palto. A ovca jest bez volny.»
+Uslyšavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-Latn" a latin text 1`] = `
+"Na vozvyšenosti ovca, ktora ne iměla volnu, uviděla konjev. Prvy tegal težky voz, vtory nosil veliko brěme, tretji brzo vozil muža.
+Ovca rěkla konjam: «Boli mně srdce, kogda vidžu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da by iměl dlja sebe teplo palto. A ovca jest bez volny.»
+Uslyšavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-Latn-PL" a cyrillic text 1`] = `
+"Na wozwyszenosti owca, ktora ne imieła wołną, uwidieła koniew. Perwy tęgał tężki woz, wtory nosił weliko briemę, treti borzo woził mąża.
+Owca riekła koniam: «Boli mnie serdce, kogda widżu, kako człowiek władaje koniami.»
+Koni riekli: «Słuszaj, owco, nam boli serdce, kogda widimo owo: mąż, gospodaŕ, bere twoją wołną, da by imieł dla sebe tepło palto. A owca jesť bez wołny.»
+Usłyszawszi to, owca izbiegła w rawninu. | Odjezd. Ťma, i korenie rewenia poczęli rasteńie, a sługi powiedieli kralu o weseliu."
+`;
+
+exports[`transliterate to "isv-Latn-PL" a latin text 1`] = `
+"Na wozwyszenosti owca, ktora ne imieła wołną, uwidieła koniew. Perwy tęgał tężki woz, wtory nosił weliko briemę, treti borzo woził mąża.
+Owca riekła koniam: «Boli mnie serdce, kogda widzią, kako człowiek władaje koniami.»
+Koni riekli: «Słuszaj, owco, nam boli serdce, kogda widimo owo: mąż, gospodaŕ, bere twoją wołną, da by imieł dla sebe tepło palto. A owca jest bez wołny.»
+Usłyszawszi to, owca izbiegła w rawniną. | Odjezd. Ťma, i korenie rewenia poczęli rasteńie, a sługi powiedieli kralu o weseliu."
+`;
+
+exports[`transliterate to "isv-Latn-x-ascii" a cyrillic text 1`] = `
+"Na vozvyszenosti ovca, ktora ne imjela volnu, uvidjela konjev. Prvy tegal tezsky voz, vtory nosil veliko brjeme, tretji brzo vozil muzsa.
+Ovca rjekla konjam: «Boli mnje srdce, kogda vidzsu, kako czlovjek vladaje konjami.»
+Konji rjekli: «Sluszaj, ovco, nam boli srdce, kogda vidimo ovo: muzs, gospodar, bere tvoju volnu, da by imjel dlja sebe teplo palto. A ovca jest bez volny.»
+Uslyszavszi to, ovca izbjegla v ravninu. | Odjezd. Tma, i korenje revenja poczeli rastenje, a slugi povjedjeli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-Latn-x-ascii" a latin text 1`] = `
+"Na vozvyszenosti ovca, ktora ne imjela volnu, uvidjela konjev. Prvy tegal tezsky voz, vtory nosil veliko brjeme, tretji brzo vozil muzsa.
+Ovca rjekla konjam: «Boli mnje srdce, kogda vidzsu, kako czlovjek vladaje konjami.»
+Konji rjekli: «Sluszaj, ovco, nam boli srdce, kogda vidimo ovo: muzs, gospodar, bere tvoju volnu, da by imjel dlja sebe teplo palto. A ovca jest bez volny.»
+Uslyszavszi to, ovca izbjegla v ravninu. | Odjezd. Tma, i korenje revenja poczeli rastenje, a slugi povjedjeli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-Latn-x-etymolog" a cyrillic text 1`] = `
+"Na vozvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
+Ovca rěkla konjam: «Boli mně sŕdce, kȯgda vidžu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest́ bez vȯlny.»
+Uslyšavši to, ovca izběgla v råvninu. | Odjezd. T́ma, i korenje revenja počęli råsteńje, a slugi pověděli krålju o veseĺju."
+`;
+
+exports[`transliterate to "isv-Latn-x-etymolog" a latin text 1`] = `
+"Na vȯzvyšenosti ovca, ktora ne iměla vȯlnų, uviděla konjev. Pŕvy tęgal tęžky voz, vtory nosil veliko brěmę, tretji brzo vozil mųža.
+Ovca rěkla konjam: «Boli mně sŕdce, kȯgda viđų, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli sŕdce, kȯgda vidimo ovo: mųž, gospodaŕ, bere tvojų vȯlnų, da by iměl dlja sebe teplo paĺto. A ovca jest bez vȯlny.»
+Uslyšavši to, ovca izběgla v råvninų. | Odjezd. T́ma, i korenje revenja počęli råsteńje, a slugi pověděli krålju o veseĺju."
+`;
+
+exports[`transliterate to "isv-Latn-x-northern" a cyrillic text 1`] = `
+"Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
+Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
+Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paľto. A ovca jesť bez volny.»
+Uslyšavši to, ovca izbiegla v rovninu. | Odjezd. Ťma, i korenie revenia počali rostenie, a slugi poviedieli kroliu o veseliu."
+`;
+
+exports[`transliterate to "isv-Latn-x-northern" a latin text 1`] = `
+"Na vozvyšenosti ovca, ktora ne imiela volnu, uvidiela koniev. Pervy tiagal tiažki voz, vtory nosil veliko briemia, tretii borzo vozil muža.
+Ovca riekla koniam: «Boli mnie serdce, kogda vidžu, kako človiek vladaje koniami.»
+Konii riekli: «Slušaj, ovco, nam boli serdce, kogda vidimo ovo: muž, gospodaŕ, bere tvoju volnu, da by imiel dlia sebe teplo paľto. A ovca jest bez volny.»
+Uslyšavši to, ovca izbiegla v rovninu. | Odjezd. Ťma, i korenie revenia počali rostenie, a slugi poviedieli kroliu o veseliu."
+`;
+
+exports[`transliterate to "isv-Latn-x-sloviant" a cyrillic text 1`] = `
+"Na vozvišenosti ovca, ktora ne imela volnu, uvidela konjev. Prvi tegal težki voz, vtori nosil veliko breme, tretji brzo vozil muža.
+Ovca rekla konjam: «Boli mne srdce, kogda vidžu, kako človek vladaje konjami.»
+Konji rekli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da bi imel dlja sebe teplo palto. A ovca jest bez volni.»
+Uslišavši to, ovca izbegla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi povedeli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-Latn-x-sloviant" a latin text 1`] = `
+"Na vozvišenosti ovca, ktora ne imela volnu, uvidela konjev. Prvi tegal težki voz, vtori nosil veliko breme, tretji brzo vozil muža.
+Ovca rekla konjam: «Boli mne srdce, kogda vidžu, kako človek vladaje konjami.»
+Konji rekli: «Slušaj, ovco, nam boli srdce, kogda vidimo ovo: muž, gospodar, bere tvoju volnu, da bi imel dlja sebe teplo palto. A ovca jest bez volni.»
+Uslišavši to, ovca izbegla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi povedeli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-Latn-x-southern" a cyrillic text 1`] = `
+"Na vozvišenosti ovca, ktora ne iměla vălnu, uviděla konjev. Prvi tegal težki voz, vtori nosil veliko brěme, tretji brzo vozil muža.
+Ovca rěkla konjam: «Boli mně srdce, kăgda vidžu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli srdce, kăgda vidimo ovo: muž, gospodar, bere tvoju vălnu, da bi iměl dlja sebe teplo palto. A ovca jest bez vălni.»
+Uslišavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-Latn-x-southern" a latin text 1`] = `
+"Na văzvišenosti ovca, ktora ne iměla vălnu, uviděla konjev. Prvi tegal težki voz, vtori nosil veliko brěme, tretji brzo vozil muža.
+Ovca rěkla konjam: «Boli mně srdce, kăgda viđu, kako člověk vladaje konjami.»
+Konji rěkli: «Slušaj, ovco, nam boli srdce, kăgda vidimo ovo: muž, gospodar, bere tvoju vălnu, da bi iměl dlja sebe teplo palto. A ovca jest bez vălni.»
+Uslišavši to, ovca izběgla v ravninu. | Odjezd. Tma, i korenje revenja počeli rastenje, a slugi pověděli kralju o veselju."
+`;
+
+exports[`transliterate to "isv-x-fonipa" a cyrillic text 1`] = `
 "na vɔzvɪʃɛnɔsti ɔvt͡sa, ktɔra nɛ imjɛɫa vəɫnʊ, uvidʲɛɫa kɔɲɛv. pjǝrvɪ tʲægaɫ tʲæʒkɪ vɔz, vtɔrɪ nɔsiɫ vɛlikɔ brʲɛmjæ, trɛtji bərzɔ vɔziɫ mʊʒa.
 ɔvt͡sa rʲɛkɫa kɔɲam: «bɔli mɲɛ sʲǝrdt͡sɛ, kəgda vid͡ʒu, kakɔ t͡ʃɫɔvjɛk vɫadajɛ kɔɲami.»
 kɔɲi rʲɛkli: «sɫuʃaj, ɔvt͡sɔ, nam bɔli sʲǝrdt͡sɛ, kəgda vidimɔ ɔvɔ: mʊʒ, gɔspɔdarʲ, bɛrɛ tvɔjʊ vəɫnʊ, da bɪ imjɛɫ dʎa sɛbɛ tɛpɫɔ paʎtɔ. a ɔvt͡sa jɛsʲtʲ bɛz vəɫnɪ.»
 usɫɪʃavʃi tɔ, ɔvt͡sa izbjɛgɫa v rɒvninu. | ɔdjɛzd. tʲma, i kɔrɛɲɛ rɛvɛɲa pɔt͡ʃæli rɒstɛɲi̯ɛ, a sɫugi pɔvjɛdʲɛli krɒʎu ɔ vɛsɛʎi̯u."
 `;
 
-exports[`transliterate to "art-x-interslv-fonipa" a latin text 1`] = `
+exports[`transliterate to "isv-x-fonipa" a latin text 1`] = `
 "na vəzvɪʃɛnɔsti ɔvt͡sa, ktɔra nɛ imjɛɫa vəɫnʊ, uvidʲɛɫa kɔɲɛv. pjǝrvɪ tʲægaɫ tʲæʒkɪ vɔz, vtɔrɪ nɔsiɫ vɛlikɔ brʲɛmjæ, trɛtji bərzɔ vɔziɫ mʊʒa.
 ɔvt͡sa rʲɛkɫa kɔɲam: «bɔli mɲɛ sʲǝrdt͡sɛ, kəgda vid͡ʑʊ, kakɔ t͡ʃɫɔvjɛk vɫadajɛ kɔɲami.»
 kɔɲi rʲɛkli: «sɫuʃaj, ɔvt͡sɔ, nam bɔli sʲǝrdt͡sɛ, kəgda vidimɔ ɔvɔ: mʊʒ, gɔspɔdarʲ, bɛrɛ tvɔjʊ vəɫnʊ, da bɪ imjɛɫ dʎa sɛbɛ tɛpɫɔ paʎtɔ. a ɔvt͡sa jɛst bɛz vəɫnɪ.»

--- a/src/transliterate/index.test.ts
+++ b/src/transliterate/index.test.ts
@@ -14,27 +14,27 @@ const cyrillic = `\
 
 describe('transliterate to', () => {
   describe.each([
-    ['art-Cyrl-x-interslv'],
-    ['art-Cyrl-x-interslv-etym'],
-    ['art-Cyrl-x-interslv-iotated'],
-    ['art-Cyrl-x-interslv-iotated-ext'],
-    ['art-Cyrl-x-interslv-northern'],
-    ['art-Cyrl-x-interslv-sloviant'],
-    ['art-Cyrl-x-interslv-southern'],
-    ['art-Glag-x-interslv'],
-    ['art-Glag-x-interslv-etym'],
-    ['art-Glag-x-interslv-sloviant'],
-    ['art-Glag-x-interslv-southern'],
-    ['art-Glag-x-interslv-northern'],
-    ['art-Latn-PL-x-interslv'],
-    ['art-Latn-x-interslv'],
-    ['art-Latn-x-interslv-ascii'],
-    ['art-Latn-x-interslv-etym'],
-    ['art-Latn-x-interslv-northern'],
-    ['art-Latn-x-interslv-sloviant'],
-    ['art-Latn-x-interslv-southern'],
-    ['art-x-interslv-fonipa'],
-    ['art-x-interslv'],
+    ['isv-Cyrl'],
+    ['isv-Cyrl-x-etymolog'],
+    ['isv-Cyrl-x-iotated'],
+    ['isv-Cyrl-x-iotated-ext'],
+    ['isv-Cyrl-x-northern'],
+    ['isv-Cyrl-x-sloviant'],
+    ['isv-Cyrl-x-southern'],
+    ['isv-Glag'],
+    ['isv-Glag-x-etymolog'],
+    ['isv-Glag-x-sloviant'],
+    ['isv-Glag-x-southern'],
+    ['isv-Glag-x-northern'],
+    ['isv-Latn'],
+    ['isv-Latn-PL'],
+    ['isv-Latn-x-ascii'],
+    ['isv-Latn-x-etymolog'],
+    ['isv-Latn-x-northern'],
+    ['isv-Latn-x-sloviant'],
+    ['isv-Latn-x-southern'],
+    ['isv-x-fonipa'],
+    ['isv'],
   ] as const)('%j', (bcp47) => {
     test('a latin text', () => {
       expect(transliterate(latin, bcp47)).toMatchSnapshot();
@@ -45,11 +45,7 @@ describe('transliterate to', () => {
     });
   });
 
-  test.each([
-    ['art-Latn-x-interslv'],
-    ['art-Cyrl-x-interslv'],
-    ['art-Glag-x-interslv'],
-  ] as const)(
+  test.each([['isv-Latn'], ['isv-Cyrl'], ['isv-Glag']] as const)(
     'should work equally from Latin and Cyrillic scripts to %j',
     (bcp47) => {
       const latn = transliterate(latin, bcp47);
@@ -62,15 +58,11 @@ describe('transliterate to', () => {
   test.failing(
     'double transliteration should work equally from Latin and Cyrillic scripts',
     () => {
-      const latn2cyrl = transliterate(latin, 'art-Cyrl-x-interslv');
-      const cyrl2latn = transliterate(cyrillic, 'art-Latn-x-interslv');
+      const latn2cyrl = transliterate(latin, 'isv-Cyrl');
+      const cyrl2latn = transliterate(cyrillic, 'isv-Latn');
 
-      expect(transliterate(latn2cyrl, 'art-Latn-x-interslv')).toEqual(
-        cyrl2latn,
-      );
-      expect(transliterate(cyrl2latn, 'art-Cyrl-x-interslv')).toEqual(
-        latn2cyrl,
-      );
+      expect(transliterate(latn2cyrl, 'isv-Latn')).toEqual(cyrl2latn);
+      expect(transliterate(cyrl2latn, 'isv-Cyrl')).toEqual(latn2cyrl);
     },
   );
 

--- a/src/transliterate/index.ts
+++ b/src/transliterate/index.ts
@@ -11,127 +11,127 @@ export default function transliterate(
   lang: FlavorisationBCP47Code,
 ): string {
   switch (lang) {
-    case 'art-Latn-x-interslv':
+    case 'isv-Latn':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Standard,
       );
-    case 'art-Cyrl-x-interslv':
+    case 'isv-Cyrl':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Standard,
       );
-    case 'art-Glag-x-interslv':
+    case 'isv-Glag':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Standard,
       );
-    case 'art-x-interslv-fonipa':
+    case 'isv-x-fonipa':
       return _transliterate(
         text,
         TransliterationType.IPA,
         FlavorizationType.Etymological,
       );
-    case 'art-Latn-x-interslv-etym':
+    case 'isv-Latn-x-etymolog':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Etymological,
       );
-    case 'art-Cyrl-x-interslv-etym':
+    case 'isv-Cyrl-x-etymolog':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Etymological,
       );
-    case 'art-Glag-x-interslv-etym':
+    case 'isv-Glag-x-etymolog':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Etymological,
       );
-    case 'art-Cyrl-x-interslv-iotated':
+    case 'isv-Cyrl-x-iotated':
       return _transliterate(
         text,
         TransliterationType.TraditionalIotatedCyrillic,
         FlavorizationType.Standard,
       );
-    case 'art-Cyrl-x-interslv-iotated-ext':
+    case 'isv-Cyrl-x-iotated-ext':
       return _transliterate(
         text,
         TransliterationType.TraditionalIotatedCyrillic,
         FlavorizationType.CyrillicExtended,
       );
-    case 'art-Cyrl-x-interslv-northern':
+    case 'isv-Cyrl-x-northern':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Northern,
       );
-    case 'art-Cyrl-x-interslv-sloviant':
+    case 'isv-Cyrl-x-sloviant':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Slovianto,
       );
-    case 'art-Cyrl-x-interslv-southern':
+    case 'isv-Cyrl-x-southern':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Southern,
       );
-    case 'art-Latn-PL-x-interslv':
+    case 'isv-Latn-PL':
       return _transliterate(
         text,
         TransliterationType.Polish,
         FlavorizationType.Etymological,
       );
-    case 'art-Latn-x-interslv-ascii':
+    case 'isv-Latn-x-ascii':
       return _transliterate(
         text,
         TransliterationType.ASCII,
         FlavorizationType.Standard,
       );
-    case 'art-Latn-x-interslv-northern':
+    case 'isv-Latn-x-northern':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Northern,
       );
-    case 'art-Latn-x-interslv-sloviant':
+    case 'isv-Latn-x-sloviant':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Slovianto,
       );
-    case 'art-Latn-x-interslv-southern':
+    case 'isv-Latn-x-southern':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Southern,
       );
-    case 'art-Glag-x-interslv-northern':
+    case 'isv-Glag-x-northern':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Northern,
       );
-    case 'art-Glag-x-interslv-southern':
+    case 'isv-Glag-x-southern':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Southern,
       );
-    case 'art-Glag-x-interslv-sloviant':
+    case 'isv-Glag-x-sloviant':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Slovianto,
       );
-    case 'art-x-interslv':
+    case 'isv':
       return text;
     default:
       throw new TypeError(`Unsupported IETF BCP47 tag: ${lang}`);


### PR DESCRIPTION
## BREAKING!

Instead of using `art` codes, we'll be using now `isv` codes:

* isv – Interslavic
* isv-Latn – Interslavic (Latin)
* isv-Cyrl – Interslavic (Cyrillic)
* isv-Latn-x-etymolog – Interslavic (Latin, Etymological)
* ... and so on.

This pull request will result in a major version bump.