### PR TITLE
feat(transliterate): add strict mode

### DIFF
--- a/src/__utils__/fixtures.ts
+++ b/src/__utils__/fixtures.ts
@@ -34,3 +34,5 @@ export const pronouns_reflexive: FixtureGetter = () =>
   jest.requireActual('../__fixtures__/pronouns-reflexive.json');
 export const pronouns_relative: FixtureGetter = () =>
   jest.requireActual('../__fixtures__/pronouns-relative.json');
+export const other: FixtureGetter = () =>
+  jest.requireActual('../__fixtures__/other.json');

--- a/src/transliterate/__tests__/integrity.test.ts
+++ b/src/transliterate/__tests__/integrity.test.ts
@@ -1,0 +1,31 @@
+import * as fixtures from '../../__utils__/fixtures';
+import transliterate from '..';
+
+describe('transliteration integrity', () => {
+  test.each([
+    ...fixtures.adjectives(),
+    ...fixtures.nouns_feminine(),
+    ...fixtures.nouns_masculine_animate(),
+    ...fixtures.nouns_masculine(),
+    ...fixtures.nouns_misc(),
+    ...fixtures.nouns_neuter(),
+    ...fixtures.verbs_imperfect(),
+    ...fixtures.verbs_perfect(),
+    ...fixtures.verbs_misc(),
+    ...fixtures.pronouns_demonstrative(),
+    ...fixtures.pronouns_indefinite(),
+    ...fixtures.pronouns_interrogative(),
+    ...fixtures.pronouns_personal(),
+    ...fixtures.pronouns_possessive(),
+    ...fixtures.pronouns_reciprocal(),
+    ...fixtures.pronouns_reflexive(),
+    ...fixtures.pronouns_relative(),
+    ...fixtures.other(),
+  ])('%s', (_id, _morphology, lemma, additional) => {
+    const value = lemma + ' ' + additional;
+    const script = 'isv-Cyrl-x-etymolog';
+    const withPreprocessing = transliterate(value, script, false);
+    const withoutPreprocessing = transliterate(value, script, true);
+    expect(withPreprocessing).toBe(withoutPreprocessing);
+  });
+});

--- a/src/transliterate/index.ts
+++ b/src/transliterate/index.ts
@@ -9,6 +9,7 @@ import { FlavorisationBCP47Code } from '../constants';
 export default function transliterate(
   text: string,
   lang: FlavorisationBCP47Code,
+  preprocessed = false,
 ): string {
   switch (lang) {
     case 'isv-Latn':
@@ -16,120 +17,140 @@ export default function transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Standard,
+        preprocessed,
       );
     case 'isv-Cyrl':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Standard,
+        preprocessed,
       );
     case 'isv-Glag':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Standard,
+        preprocessed,
       );
     case 'isv-x-fonipa':
       return _transliterate(
         text,
         TransliterationType.IPA,
         FlavorizationType.Etymological,
+        preprocessed,
       );
     case 'isv-Latn-x-etymolog':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Etymological,
+        preprocessed,
       );
     case 'isv-Cyrl-x-etymolog':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Etymological,
+        preprocessed,
       );
     case 'isv-Glag-x-etymolog':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Etymological,
+        preprocessed,
       );
     case 'isv-Cyrl-x-iotated':
       return _transliterate(
         text,
         TransliterationType.TraditionalIotatedCyrillic,
         FlavorizationType.Standard,
+        preprocessed,
       );
     case 'isv-Cyrl-x-iotated-ext':
       return _transliterate(
         text,
         TransliterationType.TraditionalIotatedCyrillic,
         FlavorizationType.CyrillicExtended,
+        preprocessed,
       );
     case 'isv-Cyrl-x-northern':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Northern,
+        preprocessed,
       );
     case 'isv-Cyrl-x-sloviant':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Slovianto,
+        preprocessed,
       );
     case 'isv-Cyrl-x-southern':
       return _transliterate(
         text,
         TransliterationType.StandardCyrillic,
         FlavorizationType.Southern,
+        preprocessed,
       );
     case 'isv-Latn-PL':
       return _transliterate(
         text,
         TransliterationType.Polish,
         FlavorizationType.Etymological,
+        preprocessed,
       );
     case 'isv-Latn-x-ascii':
       return _transliterate(
         text,
         TransliterationType.ASCII,
         FlavorizationType.Standard,
+        preprocessed,
       );
     case 'isv-Latn-x-northern':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Northern,
+        preprocessed,
       );
     case 'isv-Latn-x-sloviant':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Slovianto,
+        preprocessed,
       );
     case 'isv-Latn-x-southern':
       return _transliterate(
         text,
         TransliterationType.Latin,
         FlavorizationType.Southern,
+        preprocessed,
       );
     case 'isv-Glag-x-northern':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Northern,
+        preprocessed,
       );
     case 'isv-Glag-x-southern':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Southern,
+        preprocessed,
       );
     case 'isv-Glag-x-sloviant':
       return _transliterate(
         text,
         TransliterationType.Glagolitic,
         FlavorizationType.Slovianto,
+        preprocessed,
       );
     case 'isv':
       return text;


### PR DESCRIPTION
A new mode has been added to the `transliterate` function that enforces only minimal preprocessing.

You can now add an optional third parameter, `preprocessed = true`, to indicate that the text being processed does not require any additional workarounds, such as converting "sz" to "š", "cz" to "č", and so on. This update should help resolve any visual issues in the online dictionary.