### PR TITLE
fix: fixed conjugation of verb pasti

### DIFF
--- a/src/verb/__tests__/__snapshots__/imperfect.test.ts.snap
+++ b/src/verb/__tests__/__snapshots__/imperfect.test.ts.snap
@@ -46521,7 +46521,7 @@ exports[`verb imperfect 5017 1`] = `
     "bųdųt pastì",
   ],
   "gerund": "paseńje",
-  "imperative": "pi, pimȯ, pite",
+  "imperative": "pasi, pasimȯ, pasite",
   "imperfect": [
     "paseh",
     "paseše",
@@ -46555,17 +46555,17 @@ exports[`verb imperfect 5017 1`] = `
     "běhų pasli",
     "",
   ],
-  "prap": "pųćí (pųćá, pųćé)",
+  "prap": "pasųćí (pasųćá, pasųćé)",
   "present": [
-    "pų, pem",
-    "peš",
-    "pe",
-    "pemȯ",
-    "pete",
-    "pųt",
+    "pasų, pasem",
+    "paseš",
+    "pase",
+    "pasemȯ",
+    "pasete",
+    "pasųt",
     "",
   ],
-  "prpp": "pemý (pemá, pemœ)",
+  "prpp": "pasomý (pasomá, pasomœ)",
 }
 `;
 
@@ -148808,7 +148808,7 @@ exports[`verb imperfect 32945 1`] = `
     "bųdųt pastì sę",
   ],
   "gerund": "paseńje",
-  "imperative": "pi sę, pimȯ sę, pite sę",
+  "imperative": "pasi sę, pasimȯ sę, pasite sę",
   "imperfect": [
     "paseh sę",
     "paseše sę",
@@ -148842,17 +148842,17 @@ exports[`verb imperfect 32945 1`] = `
     "běhų pasli sę",
     "",
   ],
-  "prap": "pųćí (pųćá, pųćé) sę",
+  "prap": "pasųćí (pasųćá, pasųćé) sę",
   "present": [
-    "pų sę, pem sę",
-    "peš sę",
-    "pe sę",
-    "pemȯ sę",
-    "pete sę",
-    "pųt sę",
+    "pasų sę, pasem sę",
+    "paseš sę",
+    "pase sę",
+    "pasemȯ sę",
+    "pasete sę",
+    "pasųt sę",
     "",
   ],
-  "prpp": "pemý (pemá, pemœ)",
+  "prpp": "pasomý (pasomá, pasomœ)",
 }
 `;
 

--- a/src/verb/__tests__/__snapshots__/perfect.test.ts.snap
+++ b/src/verb/__tests__/__snapshots__/perfect.test.ts.snap
@@ -90847,7 +90847,7 @@ exports[`verb perfect 28091 1`] = `
     "bųdųt napastì",
   ],
   "gerund": "napaseńje",
-  "imperative": "napi, napimȯ, napite",
+  "imperative": "napasi, napasimȯ, napasite",
   "imperfect": [
     "napaseh",
     "napaseše",
@@ -90881,17 +90881,17 @@ exports[`verb perfect 28091 1`] = `
     "běhų napasli",
     "",
   ],
-  "prap": "napųćí (napųćá, napųćé)",
+  "prap": "napasųćí (napasųćá, napasųćé)",
   "present": [
-    "napų, napem",
-    "napeš",
-    "nape",
-    "napemȯ",
-    "napete",
-    "napųt",
+    "napasų, napasem",
+    "napaseš",
+    "napase",
+    "napasemȯ",
+    "napasete",
+    "napasųt",
     "",
   ],
-  "prpp": "napemý (napemá, napemœ)",
+  "prpp": "napasomý (napasomá, napasomœ)",
 }
 `;
 
@@ -116584,7 +116584,7 @@ exports[`verb perfect 32948 1`] = `
     "bųdųt napastì sę",
   ],
   "gerund": "napaseńje",
-  "imperative": "napi sę, napimȯ sę, napite sę",
+  "imperative": "napasi sę, napasimȯ sę, napasite sę",
   "imperfect": [
     "napaseh sę",
     "napaseše sę",
@@ -116618,17 +116618,17 @@ exports[`verb perfect 32948 1`] = `
     "běhų napasli sę",
     "",
   ],
-  "prap": "napųćí (napųćá, napųćé) sę",
+  "prap": "napasųćí (napasųćá, napasųćé) sę",
   "present": [
-    "napų sę, napem sę",
-    "napeš sę",
-    "nape sę",
-    "napemȯ sę",
-    "napete sę",
-    "napųt sę",
+    "napasų sę, napasem sę",
+    "napaseš sę",
+    "napase sę",
+    "napasemȯ sę",
+    "napasete sę",
+    "napasųt sę",
     "",
   ],
-  "prpp": "napemý (napemá, napemœ)",
+  "prpp": "napasomý (napasomá, napasomœ)",
 }
 `;
 

--- a/src/verb/conjugationVerb.ts
+++ b/src/verb/conjugationVerb.ts
@@ -383,7 +383,10 @@ function present_tense_stem(pref: string, pts: string, is: string) {
   if (pts.length == 0) {
     result = derive_present_tense_stem(is);
   } else {
-    if ((pts.slice(-2) === 'se' || pts.slice(-2) === 'sę') && pts.length > 2) {
+    if (
+      (pts.slice(-3) === ' se' || pts.slice(-3) === ' sę') &&
+      pts.length > 3
+    ) {
       pts = pts.slice(0, -3);
     } else if (pts.indexOf('se ') == 0 || pts.indexOf('sę ') == 0) {
       pts = pts.slice(3);


### PR DESCRIPTION
The stems of verbs that end in “se” in the present tense were cut off during conjugation. For example 'pase' -> 'pa'.