### PR TITLE
add derivation-generation logic to import.js

### DIFF
--- a/scripts/import.js
+++ b/scripts/import.js
@@ -235,6 +235,9 @@ async function splitToFixtures() {
                 // blågy -> unši, blåžejši
                 // dobry -> lěpši, lučši
                 for (const new_adj of new_adj_set.split(", ")) {
+                    if (new_adj.includes("bolje ")) {
+                        continue;
+                    }
                     // or `adj.comp.:${new_adj}:`?
                     const key = `adj.:${new_adj}:`;
                     if (visited.has(key)) {
@@ -253,6 +256,10 @@ async function splitToFixtures() {
         if (/^v\./.test(morphology)) {
             let add_id = 0;
             // verb2noun
+            if (lemma.startsWith("ne ")) {
+                // things like "ne poslušańje"
+                continue;
+            }
             wordData = conjugationVerb.conjugationVerb(lemma, extra);
             if (!wordData) {
                 console.log(row);

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -5,11 +5,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { Writable } = require('node:stream');
 
-// import { conjugationVerb } from 'verb/conjugationVerb';
 const conjugationVerb = require('../dist/verb/conjugationVerb.js');
 const declensionAdjective = require('../dist/adjective/declensionAdjective');
-const declensionNoun = require('../dist/noun/declensionNoun');
-
 
 const csvParse = require('csv-parse').parse;
 const fetch = require('node-fetch');
@@ -68,7 +65,6 @@ const FIXTURE_PRONOUNS_RELATIVE = path.join(
   'pronouns-relative.json',
 );
 const FIXTURE_OTHER = path.join(FIXTURES_DIR, 'other.json');
-const FIXTURE_DERIVED_BASE = path.join(FIXTURES_DIR, 'base.json');
 
 async function downloadFile(url, outputPath) {
   const response = await fetch(url);
@@ -128,7 +124,6 @@ async function splitToFixtures() {
     rel: new JSONLFileStream({ filePath: FIXTURE_PRONOUNS_RELATIVE }),
   };
   const other = new JSONLFileStream({ filePath: FIXTURE_OTHER });
-  const derivation_stream = new JSONLFileStream({ filePath: FIXTURE_DERIVED_BASE });
 
   const checkDerivationPossible = (pos) => {
     if (/\badj\./.test(pos)) {


### PR DESCRIPTION
```
Processed 18458 records...
Added 25254 derived word forms.
2743 derived words already exist.
```

The result is strings like these added to some files:
```
nouns-neuter.json:
["32631>0","#n.vnoun.","žžeńje",""],
["29639>0","#n.vnoun.","oslěpnųťje",""],
["14817>0","#n.vnoun.","osloženjeńje",""],
["7>0","#n.vnoun.","osųđańje",""],

adjectives.json:
["4475>1","#adj.ptcp.","sȯvětujųćí",""],
["4475>2","#adj.ptcp.","sȯvětujemý",""],
["4475>3","#adj.ptcp.","sȯvětovavši",""],
["4475>4","#adj.ptcp.","sȯvětovaný",""],
["2224>1","#adj.ptcp.","spęćí",""],
["2224>2","#adj.ptcp.","spimý",""],
["2224>3","#adj.ptcp.","spavši",""],
["2224>4","#adj.ptcp.","spaný",""],
["1907>0","#adj.comp.","speciaľnějši",""],
["1907>1","#adj.comp.","najspeciaľnějši",""],
```

Some  care was taken to exclude multiword expressions like
```
["35354>0","#n.vnoun.","ne ljubjeńje",""],
["1398>0","#adj.comp.","bolje sovětski",""],
["1398>1","#adj.comp.","najbolje sovětski",""],
```

Some statistics. Out of 2743 "already existing" words, only 48 are derived from adjectives (like "starějši" and "najstarějši"), the rest are derived from verbs. 839 are verbal nouns (like "rěšeńje"), the rest are roughly evenly split between various participles (prap and prpp - 478 and 479 hits, pfap and pfpp - 453 and 446 hits).