### PR TITLE
fix: imperative mood in lj/nj verbs

### DIFF
--- a/src/verb/__tests__/__snapshots__/imperfect.test.ts.snap
+++ b/src/verb/__tests__/__snapshots__/imperfect.test.ts.snap
@@ -8627,7 +8627,7 @@ exports[`verb imperfect 925 1`] = `
     "bųdųt mlětì",
   ],
   "gerund": "mlěťje",
-  "imperative": "melj, meljmȯ, meljte",
+  "imperative": "melji, meljimȯ, meljite",
   "imperfect": [
     "mlěh",
     "mlěše",
@@ -106696,7 +106696,7 @@ exports[`verb imperfect 21575 1`] = `
     "bųdųt slatì",
   ],
   "gerund": "slańje",
-  "imperative": "šlj, šljmȯ, šljte",
+  "imperative": "šlji, šljimȯ, šljite",
   "imperfect": [
     "slah",
     "slaše",
@@ -129382,7 +129382,7 @@ exports[`verb imperfect 26528 1`] = `
     "bųdųt klåtì",
   ],
   "gerund": "klåťje",
-  "imperative": "kolj, koljmȯ, koljte",
+  "imperative": "kolji, koljimȯ, koljite",
   "imperfect": [
     "klåh",
     "klåše",
@@ -151569,7 +151569,7 @@ exports[`verb imperfect 33440 1`] = `
     "bųdųt stlatì",
   ],
   "gerund": "stlańje",
-  "imperative": "stelj, steljmȯ, steljte",
+  "imperative": "stelji, steljimȯ, steljite",
   "imperfect": [
     "stlah",
     "stlaše",

--- a/src/verb/__tests__/__snapshots__/perfect.test.ts.snap
+++ b/src/verb/__tests__/__snapshots__/perfect.test.ts.snap
@@ -10843,7 +10843,7 @@ exports[`verb perfect 1912 1`] = `
     "bųdųt poslatì",
   ],
   "gerund": "poslańje",
-  "imperative": "pošlj, pošljmȯ, pošljte",
+  "imperative": "pošlji, pošljimȯ, pošljite",
   "imperfect": [
     "poslah",
     "poslaše",
@@ -35134,7 +35134,7 @@ exports[`verb perfect 5620 1`] = `
     "bųdųt smlětì",
   ],
   "gerund": "smlěťje",
-  "imperative": "smelj, smeljmȯ, smeljte",
+  "imperative": "smelji, smeljimȯ, smeljite",
   "imperfect": [
     "smlěh",
     "smlěše",
@@ -40959,7 +40959,7 @@ exports[`verb perfect 8123 1`] = `
     "bųdųt izslatì",
   ],
   "gerund": "izslańje",
-  "imperative": "izšlj, izšljmȯ, izšljte",
+  "imperative": "izšlji, izšljimȯ, izšljite",
   "imperfect": [
     "izslah",
     "izslaše",
@@ -90362,7 +90362,7 @@ exports[`verb perfect 28032 1`] = `
     "bųdųt naklåtì",
   ],
   "gerund": "naklåťje",
-  "imperative": "nakolj, nakoljmȯ, nakoljte",
+  "imperative": "nakolji, nakoljimȯ, nakoljite",
   "imperfect": [
     "naklåh",
     "naklåše",
@@ -97931,7 +97931,7 @@ exports[`verb perfect 29116 1`] = `
     "bųdųt odslatì",
   ],
   "gerund": "odslańje",
-  "imperative": "odšlj, odšljmȯ, odšljte",
+  "imperative": "odšlji, odšljimȯ, odšljite",
   "imperfect": [
     "odslah",
     "odslaše",
@@ -107905,7 +107905,7 @@ exports[`verb perfect 30233 1`] = `
     "bųdųt råzklåtì",
   ],
   "gerund": "råzklåťje",
-  "imperative": "råzkolj, råzkoljmȯ, råzkoljte",
+  "imperative": "råzkolji, råzkoljimȯ, råzkoljite",
   "imperfect": [
     "råzklåh",
     "råzklåše",
@@ -109361,7 +109361,7 @@ exports[`verb perfect 30321 1`] = `
     "bųdųt råzmlětì",
   ],
   "gerund": "råzmlěťje",
-  "imperative": "råzmelj, råzmeljmȯ, råzmeljte",
+  "imperative": "råzmelji, råzmeljimȯ, råzmeljite",
   "imperfect": [
     "råzmlěh",
     "råzmlěše",
@@ -109847,7 +109847,7 @@ exports[`verb perfect 30361 1`] = `
     "bųdųt råzslatì",
   ],
   "gerund": "råzslańje",
-  "imperative": "råzšlj, råzšljmȯ, råzšljte",
+  "imperative": "råzšlji, råzšljimȯ, råzšljite",
   "imperfect": [
     "råzslah",
     "råzslaše",
@@ -113876,7 +113876,7 @@ exports[`verb perfect 32007 1`] = `
     "bųdųt zaklåtì",
   ],
   "gerund": "zaklåťje",
-  "imperative": "zakolj, zakoljmȯ, zakoljte",
+  "imperative": "zakolji, zakoljimȯ, zakoljite",
   "imperfect": [
     "zaklåh",
     "zaklåše",
@@ -113946,7 +113946,7 @@ exports[`verb perfect 32011 1`] = `
     "bųdųt uklåtì",
   ],
   "gerund": "uklåťje",
-  "imperative": "ukolj, ukoljmȯ, ukoljte",
+  "imperative": "ukolji, ukoljimȯ, ukoljite",
   "imperfect": [
     "uklåh",
     "uklåše",
@@ -118389,7 +118389,7 @@ exports[`verb perfect 33446 1`] = `
     "bųdųt postlatì",
   ],
   "gerund": "postlańje",
-  "imperative": "postelj, posteljmȯ, posteljte",
+  "imperative": "postelji, posteljimȯ, posteljite",
   "imperfect": [
     "postlah",
     "postlaše",
@@ -118528,7 +118528,7 @@ exports[`verb perfect 33452 1`] = `
     "bųdųt råzstlatì",
   ],
   "gerund": "råzstlańje",
-  "imperative": "råzstelj, råzsteljmȯ, råzsteljte",
+  "imperative": "råzstelji, råzsteljimȯ, råzsteljite",
   "imperfect": [
     "råzstlah",
     "råzstlaše",
@@ -125060,7 +125060,7 @@ exports[`verb perfect 35147 1`] = `
     "bųdųt prislatì",
   ],
   "gerund": "prislańje",
-  "imperative": "prišlj, prišljmȯ, prišljte",
+  "imperative": "prišlji, prišljimȯ, prišljite",
   "imperfect": [
     "prislah",
     "prislaše",

--- a/src/verb/conjugationVerb.ts
+++ b/src/verb/conjugationVerb.ts
@@ -675,6 +675,8 @@ function buildConditional(lpa: string, refl: string): string[] {
 function build_imperative(pref: string, ps: string, refl: string): string {
   let p2s = '';
   const i = ps.length - 1;
+  const last = ps[i];
+  const penultimate = ps[i - 1];
 
   if (ps == 'jes') {
     p2s = 'bųď';
@@ -683,15 +685,14 @@ function build_imperative(pref: string, ps: string, refl: string): string {
     p2s = pref + ps + 'j';
   } else if (ps in irregular_stems) {
     p2s = pref + ps + 'ď';
-  } else if (ps.charAt(i) == 'ĵ' || ps.charAt(i) == 'j') {
-    p2s = pref + ps;
   } else if (
-    ps.charAt(i) == 'a' ||
-    ps.charAt(i) == 'e' ||
-    ps.charAt(i) == 'ě'
+    (last == 'ĵ' || last == 'j') &&
+    !(penultimate === 'l' || penultimate === 'n')
   ) {
+    p2s = pref + ps;
+  } else if (last == 'a' || last == 'e' || last == 'ě') {
     p2s = pref + ps + 'j';
-  } else if (ps.charAt(i) == 'i') {
+  } else if (last == 'i') {
     p2s = pref + ps;
   } else {
     p2s = pref + ps + 'i';


### PR DESCRIPTION
Fixes issue with imperative mood for verbs like: `poslati`, `izslati`, `razslati`.

Resolves #49 