### PR TITLE
Update declensionNoun.ts

### DIFF
--- a/src/noun/__tests__/__snapshots__/feminine.test.ts.snap
+++ b/src/noun/__tests__/__snapshots__/feminine.test.ts.snap
@@ -5055,31 +5055,31 @@ exports[`noun feminine 855 1`] = `
 {
   "acc": [
     "krađų",
-    "krađy",
+    "krađe",
   ],
   "dat": [
-    "krađě",
+    "krađi",
     "krađam",
   ],
   "gen": [
-    "krađy",
+    "krađe",
     "krađ",
   ],
   "ins": [
-    "krađojų",
+    "krađejų",
     "krađami",
   ],
   "loc": [
-    "krađě",
+    "krađi",
     "krađah",
   ],
   "nom": [
     "krađa",
-    "krađy",
+    "krađe",
   ],
   "voc": [
     "krađo",
-    "krađy",
+    "krađe",
   ],
 }
 `;
@@ -6938,31 +6938,31 @@ exports[`noun feminine 1235 1`] = `
 {
   "acc": [
     "rđų",
-    "rđy",
+    "rđe",
   ],
   "dat": [
-    "rđě",
+    "rđi",
     "rđam",
   ],
   "gen": [
-    "rđy",
+    "rđe",
     "rđ",
   ],
   "ins": [
-    "rđojų",
+    "rđejų",
     "rđami",
   ],
   "loc": [
-    "rđě",
+    "rđi",
     "rđah",
   ],
   "nom": [
     "rđa",
-    "rđy",
+    "rđe",
   ],
   "voc": [
     "rđo",
-    "rđy",
+    "rđe",
   ],
 }
 `;
@@ -8295,31 +8295,31 @@ exports[`noun feminine 1426 1`] = `
 {
   "acc": [
     "nųđų",
-    "nųđy",
+    "nųđe",
   ],
   "dat": [
-    "nųđě",
+    "nųđi",
     "nųđam",
   ],
   "gen": [
-    "nųđy",
+    "nųđe",
     "nųđ",
   ],
   "ins": [
-    "nųđojų",
+    "nųđejų",
     "nųđami",
   ],
   "loc": [
-    "nųđě",
+    "nųđi",
     "nųđah",
   ],
   "nom": [
     "nųđa",
-    "nųđy",
+    "nųđe",
   ],
   "voc": [
     "nųđo",
-    "nųđy",
+    "nųđe",
   ],
 }
 `;
@@ -12851,31 +12851,31 @@ exports[`noun feminine 2280 1`] = `
 {
   "acc": [
     "međų",
-    "međy",
+    "međe",
   ],
   "dat": [
-    "međě",
+    "međi",
     "međam",
   ],
   "gen": [
-    "međy",
+    "međe",
     "međ",
   ],
   "ins": [
-    "međojų",
+    "međejų",
     "međami",
   ],
   "loc": [
-    "međě",
+    "međi",
     "međah",
   ],
   "nom": [
     "međa",
-    "međy",
+    "međe",
   ],
   "voc": [
     "međo",
-    "međy",
+    "međe",
   ],
 }
 `;
@@ -20913,31 +20913,31 @@ exports[`noun feminine 3930 1`] = `
 {
   "acc": [
     "žęđų",
-    "žęđy",
+    "žęđe",
   ],
   "dat": [
-    "žęđě",
+    "žęđi",
     "žęđam",
   ],
   "gen": [
-    "žęđy",
+    "žęđe",
     "žęđ",
   ],
   "ins": [
-    "žęđojų",
+    "žęđejų",
     "žęđami",
   ],
   "loc": [
-    "žęđě",
+    "žęđi",
     "žęđah",
   ],
   "nom": [
     "žęđa",
-    "žęđy",
+    "žęđe",
   ],
   "voc": [
     "žęđo",
-    "žęđy",
+    "žęđe",
   ],
 }
 `;
@@ -42539,31 +42539,31 @@ exports[`noun feminine 16802 1`] = `
 {
   "acc": [
     "tvŕđų",
-    "tvŕđy",
+    "tvŕđe",
   ],
   "dat": [
-    "tvŕđě",
+    "tvŕđi",
     "tvŕđam",
   ],
   "gen": [
-    "tvŕđy",
+    "tvŕđe",
     "tvŕđ",
   ],
   "ins": [
-    "tvŕđojų",
+    "tvŕđejų",
     "tvŕđami",
   ],
   "loc": [
-    "tvŕđě",
+    "tvŕđi",
     "tvŕđah",
   ],
   "nom": [
     "tvŕđa",
-    "tvŕđy",
+    "tvŕđe",
   ],
   "voc": [
     "tvŕđo",
-    "tvŕđy",
+    "tvŕđe",
   ],
 }
 `;
@@ -42770,31 +42770,31 @@ exports[`noun feminine 16837 1`] = `
 {
   "acc": [
     "oděđų",
-    "oděđy",
+    "oděđe",
   ],
   "dat": [
-    "oděđě",
+    "oděđi",
     "oděđam",
   ],
   "gen": [
-    "oděđy",
+    "oděđe",
     "oděđ",
   ],
   "ins": [
-    "oděđojų",
+    "oděđejų",
     "oděđami",
   ],
   "loc": [
-    "oděđě",
+    "oděđi",
     "oděđah",
   ],
   "nom": [
     "oděđa",
-    "oděđy",
+    "oděđe",
   ],
   "voc": [
     "oděđo",
-    "oděđy",
+    "oděđe",
   ],
 }
 `;
@@ -47888,31 +47888,31 @@ exports[`noun feminine 18761 1`] = `
 {
   "acc": [
     "sađų",
-    "sađy",
+    "sađe",
   ],
   "dat": [
-    "sađě",
+    "sađi",
     "sađam",
   ],
   "gen": [
-    "sađy",
+    "sađe",
     "sađ",
   ],
   "ins": [
-    "sađojų",
+    "sađejų",
     "sađami",
   ],
   "loc": [
-    "sađě",
+    "sađi",
     "sađah",
   ],
   "nom": [
     "sađa",
-    "sađy",
+    "sađe",
   ],
   "voc": [
     "sađo",
-    "sađy",
+    "sađe",
   ],
 }
 `;
@@ -67881,31 +67881,31 @@ exports[`noun feminine 25749 1`] = `
 {
   "acc": [
     "gospođų",
-    "gospođy",
+    "gospođe",
   ],
   "dat": [
-    "gospođě",
+    "gospođi",
     "gospođam",
   ],
   "gen": [
-    "gospođy",
+    "gospođe",
     "gospođ",
   ],
   "ins": [
-    "gospođojų",
+    "gospođejų",
     "gospođami",
   ],
   "loc": [
-    "gospođě",
+    "gospođi",
     "gospođah",
   ],
   "nom": [
     "gospođa",
-    "gospođy",
+    "gospođe",
   ],
   "voc": [
     "gospođo",
-    "gospođy",
+    "gospođe",
   ],
 }
 `;
@@ -77665,31 +77665,31 @@ exports[`noun feminine 31282 1`] = `
 {
   "acc": [
     "vođų",
-    "vođy",
+    "vođe",
   ],
   "dat": [
-    "vođě",
+    "vođi",
     "vođam",
   ],
   "gen": [
-    "vođy",
+    "vođe",
     "vođ",
   ],
   "ins": [
-    "vođojų",
+    "vođejų",
     "vođami",
   ],
   "loc": [
-    "vođě",
+    "vođi",
     "vođah",
   ],
   "nom": [
     "vođa",
-    "vođy",
+    "vođe",
   ],
   "voc": [
     "vođo",
-    "vođy",
+    "vođe",
   ],
 }
 `;
@@ -79653,31 +79653,31 @@ exports[`noun feminine 32106 1`] = `
 {
   "acc": [
     "pręđų",
-    "pręđy",
+    "pręđe",
   ],
   "dat": [
-    "pręđě",
+    "pręđi",
     "pręđam",
   ],
   "gen": [
-    "pręđy",
+    "pręđe",
     "pręđ",
   ],
   "ins": [
-    "pręđojų",
+    "pręđejų",
     "pręđami",
   ],
   "loc": [
-    "pręđě",
+    "pręđi",
     "pręđah",
   ],
   "nom": [
     "pręđa",
-    "pręđy",
+    "pręđe",
   ],
   "voc": [
     "pręđo",
-    "pręđy",
+    "pręđe",
   ],
 }
 `;

--- a/src/noun/__tests__/__snapshots__/masculine-animate.test.ts.snap
+++ b/src/noun/__tests__/__snapshots__/masculine-animate.test.ts.snap
@@ -5913,7 +5913,7 @@ exports[`noun masculine (animate) 2541 1`] = `
 {
   "acc": [
     "vođa",
-    "vođov",
+    "vođev",
   ],
   "dat": [
     "vođu",
@@ -5921,10 +5921,10 @@ exports[`noun masculine (animate) 2541 1`] = `
   ],
   "gen": [
     "vođa",
-    "vođov",
+    "vođev",
   ],
   "ins": [
-    "vođom",
+    "vođem",
     "vođami",
   ],
   "loc": [
@@ -5936,7 +5936,7 @@ exports[`noun masculine (animate) 2541 1`] = `
     "vođi",
   ],
   "voc": [
-    "vođe",
+    "vođu",
     "vođi",
   ],
 }

--- a/src/noun/declensionNoun.ts
+++ b/src/noun/declensionNoun.ts
@@ -115,7 +115,7 @@ export function declensionNoun(
   noun = noun.replace(/[ńň]$/, 'nj');
   noun = noun.replace(/[ľĺ]$/, 'lj');
   noun =
-    noun.slice(0, -2) + noun.slice(-2).replace(/([cšžčćńľŕťďśźj])/g, '$1ь');
+    noun.slice(0, -2) + noun.slice(-2).replace(/([cšžčćńľŕťďśźđj])/g, '$1ь');
 
   const nounWithoutFluent = noun.replace(/\([oe]\)/, '');
 
@@ -466,7 +466,7 @@ function genitive_pl(root: string, gender: string) {
     result = 'sȯt';
   } else if (gender.charAt(0) == 'n') {
     result =
-      root.replace('ь', '%').replace(/([pbvfmlnrszńľŕťďśźščž])j%/, '$1ij') +
+      root.replace('ь', '%').replace(/([pbvfmlnrszńľŕťďśźščžđ])j%/, '$1ij') +
       '%';
     if (gender == 'n3') {
       result = result + ' / ' + palatalizationEnding(root) + 'es';


### PR DESCRIPTION
Đđ jest mekka suglaska, i deklinator na sajtu Jana van Steenbergena takože rabotaje s njeju kako s mekkoju. Zato, za izběganje problemov so sklanjanjem slov na -đ i -đa (vođ, oděđa), proponuju dodati ju v kod.

![image](https://github.com/user-attachments/assets/ddd82ff1-a229-4774-88a8-950cecbc0d92)
![image](https://github.com/user-attachments/assets/385b26b8-a2f7-41fe-9d52-80c8586f2535)
