### PR TITLE
feat: short adjective forms

### DIFF
--- a/src/__fixtures__/adjectives.json
+++ b/src/__fixtures__/adjectives.json
@@ -501,7 +501,7 @@
 ["2077","adj.","ekskluzivny",""],
 ["20374","adj.","eksperimentaľny",""],
 ["4799","adj.","eksplozivny",""],
-["35974","adj.","eksponencialny",""],
+["35974","adj.","eksponenciaľny",""],
 ["1685","adj.","ekstremističny",""],
 ["35683","adj.","ekumeničny",""],
 ["22437","adj.","ekvadorsky",""],

--- a/src/adjective/__tests__/__snapshots__/adjective.test.ts.snap
+++ b/src/adjective/__tests__/__snapshots__/adjective.test.ts.snap
@@ -38,6 +38,7 @@ exports[`adjective 5 1`] = `
       "tęžke",
     ],
   },
+  "short": "tęžėk",
   "singular": {
     "acc": [
       "tęžkogo / tęžky",
@@ -107,6 +108,7 @@ exports[`adjective 6 1`] = `
       "velike",
     ],
   },
+  "short": "velik",
   "singular": {
     "acc": [
       "velikogo / veliky",
@@ -176,6 +178,7 @@ exports[`adjective 29 1`] = `
       "časove",
     ],
   },
+  "short": "časov",
   "singular": {
     "acc": [
       "časovogo / časovy",
@@ -245,6 +248,7 @@ exports[`adjective 43 1`] = `
       "aktivne",
     ],
   },
+  "short": "aktivėn",
   "singular": {
     "acc": [
       "aktivnogo / aktivny",
@@ -314,6 +318,7 @@ exports[`adjective 52 1`] = `
       "amerikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "amerikanskogo / amerikansky",
@@ -383,6 +388,7 @@ exports[`adjective 66 1`] = `
       "vųzke",
     ],
   },
+  "short": "vųzȯk",
   "singular": {
     "acc": [
       "vųzkogo / vųzky",
@@ -452,6 +458,7 @@ exports[`adjective 68 1`] = `
       "gornolužičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gornolužičskogo / gornolužičsky",
@@ -521,6 +528,7 @@ exports[`adjective 78 1`] = `
       "vųgrske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vųgrskogo / vųgrsky",
@@ -590,6 +598,7 @@ exports[`adjective 79 1`] = `
       "deševe",
     ],
   },
+  "short": "dešev",
   "singular": {
     "acc": [
       "deševogo / deševy",
@@ -659,6 +668,7 @@ exports[`adjective 88 1`] = `
       "religiozne",
     ],
   },
+  "short": "religiozėn",
   "singular": {
     "acc": [
       "religioznogo / religiozny",
@@ -728,6 +738,7 @@ exports[`adjective 93 1`] = `
       "vśakodenne",
     ],
   },
+  "short": "vśakodenėn",
   "singular": {
     "acc": [
       "vśakodennogo / vśakodenny",
@@ -797,6 +808,7 @@ exports[`adjective 93-1 1`] = `
       "vśakodnevne",
     ],
   },
+  "short": "vśakodnevėn",
   "singular": {
     "acc": [
       "vśakodnevnogo / vśakodnevny",
@@ -866,6 +878,7 @@ exports[`adjective 100 1`] = `
       "pomoćne",
     ],
   },
+  "short": "pomoćėn",
   "singular": {
     "acc": [
       "pomoćnogo / pomoćny",
@@ -935,6 +948,7 @@ exports[`adjective 101 1`] = `
       "črvene",
     ],
   },
+  "short": "črven",
   "singular": {
     "acc": [
       "črvenogo / črveny",
@@ -1004,6 +1018,7 @@ exports[`adjective 103 1`] = `
       "pobrěžne",
     ],
   },
+  "short": "pobrěžėn",
   "singular": {
     "acc": [
       "pobrěžnogo / pobrěžny",
@@ -1073,6 +1088,7 @@ exports[`adjective 106 1`] = `
       "afrikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "afrikanskogo / afrikansky",
@@ -1142,6 +1158,7 @@ exports[`adjective 142 1`] = `
       "albanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "albanskogo / albansky",
@@ -1211,6 +1228,7 @@ exports[`adjective 145 1`] = `
       "sŕbske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sŕbskogo / sŕbsky",
@@ -1280,6 +1298,7 @@ exports[`adjective 174 1`] = `
       "radikaľne",
     ],
   },
+  "short": "radikaľėn",
   "singular": {
     "acc": [
       "radikaľnogo / radikaľny",
@@ -1349,6 +1368,7 @@ exports[`adjective 175 1`] = `
       "provokatorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "provokatorskogo / provokatorsky",
@@ -1418,6 +1438,7 @@ exports[`adjective 176 1`] = `
       "kašubske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kašubskogo / kašubsky",
@@ -1487,6 +1508,7 @@ exports[`adjective 177 1`] = `
       "bezšumne",
     ],
   },
+  "short": "bezšumėn",
   "singular": {
     "acc": [
       "bezšumnogo / bezšumny",
@@ -1556,6 +1578,7 @@ exports[`adjective 178 1`] = `
       "bezprecedentne",
     ],
   },
+  "short": "bezprecedentėn",
   "singular": {
     "acc": [
       "bezprecedentnogo / bezprecedentny",
@@ -1625,6 +1648,7 @@ exports[`adjective 180 1`] = `
       "vȯzråstle",
     ],
   },
+  "short": "vȯzråstl",
   "singular": {
     "acc": [
       "vȯzråstlogo / vȯzråstly",
@@ -1694,6 +1718,7 @@ exports[`adjective 185 1`] = `
       "doľnolužičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "doľnolužičskogo / doľnolužičsky",
@@ -1763,6 +1788,7 @@ exports[`adjective 196 1`] = `
       "široke",
     ],
   },
+  "short": "širok",
   "singular": {
     "acc": [
       "širokogo / široky",
@@ -1832,6 +1858,7 @@ exports[`adjective 202 1`] = `
       "boljne",
     ],
   },
+  "short": "boljėn",
   "singular": {
     "acc": [
       "boljnogo / boljny",
@@ -1901,6 +1928,7 @@ exports[`adjective 205 1`] = `
       "liberaľne",
     ],
   },
+  "short": "liberaľėn",
   "singular": {
     "acc": [
       "liberaľnogo / liberaľny",
@@ -1970,6 +1998,7 @@ exports[`adjective 212 1`] = `
       "bogate",
     ],
   },
+  "short": "bogat",
   "singular": {
     "acc": [
       "bogatogo / bogaty",
@@ -2039,6 +2068,7 @@ exports[`adjective 250 1`] = `
       "strašne",
     ],
   },
+  "short": "strašėn",
   "singular": {
     "acc": [
       "strašnogo / strašny",
@@ -2108,6 +2138,7 @@ exports[`adjective 255 1`] = `
       "jevrejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "jevrejskogo / jevrejsky",
@@ -2177,6 +2208,7 @@ exports[`adjective 262 1`] = `
       "teroristične",
     ],
   },
+  "short": "terorističėn",
   "singular": {
     "acc": [
       "terorističnogo / terorističny",
@@ -2246,6 +2278,7 @@ exports[`adjective 270 1`] = `
       "same",
     ],
   },
+  "short": "sam",
   "singular": {
     "acc": [
       "samogo / samy",
@@ -2315,6 +2348,7 @@ exports[`adjective 280 1`] = `
       "možlive",
     ],
   },
+  "short": "možliv",
   "singular": {
     "acc": [
       "možlivogo / možlivy",
@@ -2384,6 +2418,7 @@ exports[`adjective 284 1`] = `
       "duhovne",
     ],
   },
+  "short": "duhovėn",
   "singular": {
     "acc": [
       "duhovnogo / duhovny",
@@ -2453,6 +2488,7 @@ exports[`adjective 291 1`] = `
       "oficiaľne",
     ],
   },
+  "short": "oficiaľėn",
   "singular": {
     "acc": [
       "oficiaľnogo / oficiaľny",
@@ -2522,6 +2558,7 @@ exports[`adjective 308 1`] = `
       "lěve",
     ],
   },
+  "short": "lěv",
   "singular": {
     "acc": [
       "lěvogo / lěvy",
@@ -2591,6 +2628,7 @@ exports[`adjective 320 1`] = `
       "odpovědaľne",
     ],
   },
+  "short": "odpovědaľėn",
   "singular": {
     "acc": [
       "odpovědaľnogo / odpovědaľny",
@@ -2660,6 +2698,7 @@ exports[`adjective 329 1`] = `
       "lyse",
     ],
   },
+  "short": "lys",
   "singular": {
     "acc": [
       "lysogo / lysy",
@@ -2729,6 +2768,7 @@ exports[`adjective 332 1`] = `
       "liturgične",
     ],
   },
+  "short": "liturgičėn",
   "singular": {
     "acc": [
       "liturgičnogo / liturgičny",
@@ -2798,6 +2838,7 @@ exports[`adjective 343 1`] = `
       "litȯvske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "litȯvskogo / litȯvsky",
@@ -2867,6 +2908,7 @@ exports[`adjective 344 1`] = `
       "teple",
     ],
   },
+  "short": "tepl",
   "singular": {
     "acc": [
       "teplogo / teply",
@@ -2936,6 +2978,7 @@ exports[`adjective 348 1`] = `
       "črnogorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "črnogorskogo / črnogorsky",
@@ -3005,6 +3048,7 @@ exports[`adjective 363 1`] = `
       "logične",
     ],
   },
+  "short": "logičėn",
   "singular": {
     "acc": [
       "logičnogo / logičny",
@@ -3074,6 +3118,7 @@ exports[`adjective 373 1`] = `
       "politične",
     ],
   },
+  "short": "političėn",
   "singular": {
     "acc": [
       "političnogo / političny",
@@ -3143,6 +3188,7 @@ exports[`adjective 382 1`] = `
       "diplomatične",
     ],
   },
+  "short": "diplomatičėn",
   "singular": {
     "acc": [
       "diplomatičnogo / diplomatičny",
@@ -3212,6 +3258,7 @@ exports[`adjective 391 1`] = `
       "menše",
     ],
   },
+  "short": "menš",
   "singular": {
     "acc": [
       "menšego / menši",
@@ -3281,6 +3328,7 @@ exports[`adjective 402 1`] = `
       "nizke",
     ],
   },
+  "short": "nizȯk",
   "singular": {
     "acc": [
       "nizkogo / nizky",
@@ -3350,6 +3398,7 @@ exports[`adjective 404 1`] = `
       "mirne",
     ],
   },
+  "short": "mirėn",
   "singular": {
     "acc": [
       "mirnogo / mirny",
@@ -3419,6 +3468,7 @@ exports[`adjective 409 1`] = `
       "vysoke",
     ],
   },
+  "short": "vysok",
   "singular": {
     "acc": [
       "vysokogo / vysoky",
@@ -3488,6 +3538,7 @@ exports[`adjective 412 1`] = `
       "vęćše",
     ],
   },
+  "short": "vęćš",
   "singular": {
     "acc": [
       "vęćšego / vęćši",
@@ -3557,6 +3608,7 @@ exports[`adjective 416 1`] = `
       "těsne",
     ],
   },
+  "short": "těsėn",
   "singular": {
     "acc": [
       "těsnogo / těsny",
@@ -3626,6 +3678,7 @@ exports[`adjective 428 1`] = `
       "proslavjene",
     ],
   },
+  "short": "proslavjen",
   "singular": {
     "acc": [
       "proslavjenogo / proslavjeny",
@@ -3695,6 +3748,7 @@ exports[`adjective 432 1`] = `
       "dråge",
     ],
   },
+  "short": "dråg",
   "singular": {
     "acc": [
       "drågogo / drågy",
@@ -3764,6 +3818,7 @@ exports[`adjective 438 1`] = `
       "upite",
     ],
   },
+  "short": "upit",
   "singular": {
     "acc": [
       "upitogo / upity",
@@ -3833,6 +3888,7 @@ exports[`adjective 440 1`] = `
       "drastične",
     ],
   },
+  "short": "drastičėn",
   "singular": {
     "acc": [
       "drastičnogo / drastičny",
@@ -3902,6 +3958,7 @@ exports[`adjective 447 1`] = `
       "slådke",
     ],
   },
+  "short": "slådȯk",
   "singular": {
     "acc": [
       "slådkogo / slådky",
@@ -3971,6 +4028,7 @@ exports[`adjective 463 1`] = `
       "spokojne",
     ],
   },
+  "short": "spokojėn",
   "singular": {
     "acc": [
       "spokojnogo / spokojny",
@@ -4040,6 +4098,7 @@ exports[`adjective 476 1`] = `
       "dvojne",
     ],
   },
+  "short": "dvojėn",
   "singular": {
     "acc": [
       "dvojnogo / dvojny",
@@ -4109,6 +4168,7 @@ exports[`adjective 477 1`] = `
       "znane",
     ],
   },
+  "short": "znan",
   "singular": {
     "acc": [
       "znanogo / znany",
@@ -4178,6 +4238,7 @@ exports[`adjective 480 1`] = `
       "efektivne",
     ],
   },
+  "short": "efektivėn",
   "singular": {
     "acc": [
       "efektivnogo / efektivny",
@@ -4247,6 +4308,7 @@ exports[`adjective 487 1`] = `
       "posrědnje",
     ],
   },
+  "short": "posrědėn",
   "singular": {
     "acc": [
       "posrědnjego / posrědnji",
@@ -4316,6 +4378,7 @@ exports[`adjective 487-1 1`] = `
       "posrědne",
     ],
   },
+  "short": "posrědėn",
   "singular": {
     "acc": [
       "posrědnogo / posrědny",
@@ -4385,6 +4448,7 @@ exports[`adjective 497 1`] = `
       "kakostne",
     ],
   },
+  "short": "kakostėn",
   "singular": {
     "acc": [
       "kakostnogo / kakostny",
@@ -4454,6 +4518,7 @@ exports[`adjective 499 1`] = `
       "mlåde",
     ],
   },
+  "short": "mlåd",
   "singular": {
     "acc": [
       "mlådogo / mlådy",
@@ -4523,6 +4588,7 @@ exports[`adjective 511 1`] = `
       "sinje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sinjego / sinji",
@@ -4592,6 +4658,7 @@ exports[`adjective 515 1`] = `
       "mękke",
     ],
   },
+  "short": "mękȯk",
   "singular": {
     "acc": [
       "mękkogo / mękky",
@@ -4661,6 +4728,7 @@ exports[`adjective 520 1`] = `
       "črne",
     ],
   },
+  "short": "črėn",
   "singular": {
     "acc": [
       "črnogo / črny",
@@ -4730,6 +4798,7 @@ exports[`adjective 526 1`] = `
       "zadovoljene",
     ],
   },
+  "short": "zadovoljen",
   "singular": {
     "acc": [
       "zadovoljenogo / zadovoljeny",
@@ -4799,6 +4868,7 @@ exports[`adjective 529 1`] = `
       "teritoriaľne",
     ],
   },
+  "short": "teritoriaľėn",
   "singular": {
     "acc": [
       "teritoriaľnogo / teritoriaľny",
@@ -4868,6 +4938,7 @@ exports[`adjective 539 1`] = `
       "oranževe",
     ],
   },
+  "short": "oranžev",
   "singular": {
     "acc": [
       "oranževogo / oranževy",
@@ -4937,6 +5008,7 @@ exports[`adjective 542 1`] = `
       "azijatske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "azijatskogo / azijatsky",
@@ -5006,6 +5078,7 @@ exports[`adjective 552 1`] = `
       "kitajske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kitajskogo / kitajsky",
@@ -5075,6 +5148,7 @@ exports[`adjective 561 1`] = `
       "emocionaľne",
     ],
   },
+  "short": "emocionaľėn",
   "singular": {
     "acc": [
       "emocionaľnogo / emocionaľny",
@@ -5144,6 +5218,7 @@ exports[`adjective 563 1`] = `
       "vȯorųžene",
     ],
   },
+  "short": "vȯorųžen",
   "singular": {
     "acc": [
       "vȯorųženogo / vȯorųženy",
@@ -5213,6 +5288,7 @@ exports[`adjective 577 1`] = `
       "stabiľne",
     ],
   },
+  "short": "stabiľėn",
   "singular": {
     "acc": [
       "stabiľnogo / stabiľny",
@@ -5282,6 +5358,7 @@ exports[`adjective 582 1`] = `
       "čiste",
     ],
   },
+  "short": "čist",
   "singular": {
     "acc": [
       "čistogo / čisty",
@@ -5351,6 +5428,7 @@ exports[`adjective 585 1`] = `
       "pomoŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pomoŕskogo / pomoŕsky",
@@ -5420,6 +5498,7 @@ exports[`adjective 591 1`] = `
       "sŕbskohrvatske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sŕbskohrvatskogo / sŕbskohrvatsky",
@@ -5489,6 +5568,7 @@ exports[`adjective 594 1`] = `
       "umorjene",
     ],
   },
+  "short": "umorjen",
   "singular": {
     "acc": [
       "umorjenogo / umorjeny",
@@ -5558,6 +5638,7 @@ exports[`adjective 606 1`] = `
       "bosnijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bosnijskogo / bosnijsky",
@@ -5627,6 +5708,7 @@ exports[`adjective 610 1`] = `
       "ćuđe",
     ],
   },
+  "short": "ćuđ",
   "singular": {
     "acc": [
       "ćuđego / ćuđi",
@@ -5696,6 +5778,7 @@ exports[`adjective 612 1`] = `
       "daleke",
     ],
   },
+  "short": "dalek",
   "singular": {
     "acc": [
       "dalekogo / daleky",
@@ -5765,6 +5848,7 @@ exports[`adjective 615 1`] = `
       "pestre",
     ],
   },
+  "short": "pestr",
   "singular": {
     "acc": [
       "pestrogo / pestry",
@@ -5834,6 +5918,7 @@ exports[`adjective 617 1`] = `
       "smųtne",
     ],
   },
+  "short": "smųtėn",
   "singular": {
     "acc": [
       "smųtnogo / smųtny",
@@ -5903,6 +5988,7 @@ exports[`adjective 618 1`] = `
       "sěvernoslovinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sěvernoslovinskogo / sěvernoslovinsky",
@@ -5972,6 +6058,7 @@ exports[`adjective 620 1`] = `
       "blåge",
     ],
   },
+  "short": "blåg",
   "singular": {
     "acc": [
       "blågogo / blågy",
@@ -6041,6 +6128,7 @@ exports[`adjective 623 1`] = `
       "demonstrativne",
     ],
   },
+  "short": "demonstrativėn",
   "singular": {
     "acc": [
       "demonstrativnogo / demonstrativny",
@@ -6110,6 +6198,7 @@ exports[`adjective 643 1`] = `
       "italijanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "italijanskogo / italijansky",
@@ -6179,6 +6268,7 @@ exports[`adjective 661 1`] = `
       "spravědlive",
     ],
   },
+  "short": "spravědliv",
   "singular": {
     "acc": [
       "spravědlivogo / spravědlivy",
@@ -6248,6 +6338,7 @@ exports[`adjective 662 1`] = `
       "popularne",
     ],
   },
+  "short": "popularėn",
   "singular": {
     "acc": [
       "popularnogo / popularny",
@@ -6317,6 +6408,7 @@ exports[`adjective 687 1`] = `
       "fanatične",
     ],
   },
+  "short": "fanatičėn",
   "singular": {
     "acc": [
       "fanatičnogo / fanatičny",
@@ -6386,6 +6478,7 @@ exports[`adjective 691 1`] = `
       "grozne",
     ],
   },
+  "short": "grozėn",
   "singular": {
     "acc": [
       "groznogo / grozny",
@@ -6420,18 +6513,9 @@ exports[`adjective 691 1`] = `
 exports[`adjective 705 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "vyše veličějši",
-      "vyše veličeje",
-    ],
-    "positive": [
-      "vyše veliky",
-      "vyše veliko",
-    ],
-    "superlative": [
-      "najvyše veličějši",
-      "najvyše veličeje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -6455,6 +6539,7 @@ exports[`adjective 705 1`] = `
       "vyše velike",
     ],
   },
+  "short": "vyše velik",
   "singular": {
     "acc": [
       "vyše velikogo / vyše veliky",
@@ -6524,6 +6609,7 @@ exports[`adjective 730 1`] = `
       "staranne",
     ],
   },
+  "short": "staranėn",
   "singular": {
     "acc": [
       "starannogo / staranny",
@@ -6593,6 +6679,7 @@ exports[`adjective 731 1`] = `
       "radioaktivne",
     ],
   },
+  "short": "radioaktivėn",
   "singular": {
     "acc": [
       "radioaktivnogo / radioaktivny",
@@ -6662,6 +6749,7 @@ exports[`adjective 734 1`] = `
       "jasne",
     ],
   },
+  "short": "jasėn",
   "singular": {
     "acc": [
       "jasnogo / jasny",
@@ -6731,6 +6819,7 @@ exports[`adjective 748 1`] = `
       "krive",
     ],
   },
+  "short": "kriv",
   "singular": {
     "acc": [
       "krivogo / krivy",
@@ -6800,6 +6889,7 @@ exports[`adjective 752 1`] = `
       "zelene",
     ],
   },
+  "short": "zelen",
   "singular": {
     "acc": [
       "zelenogo / zeleny",
@@ -6869,6 +6959,7 @@ exports[`adjective 757 1`] = `
       "krajne",
     ],
   },
+  "short": "krajėn",
   "singular": {
     "acc": [
       "krajnogo / krajny",
@@ -6938,6 +7029,7 @@ exports[`adjective 759 1`] = `
       "råzdražlive",
     ],
   },
+  "short": "råzdražliv",
   "singular": {
     "acc": [
       "råzdražlivogo / råzdražlivy",
@@ -7007,6 +7099,7 @@ exports[`adjective 770 1`] = `
       "lične",
     ],
   },
+  "short": "ličėn",
   "singular": {
     "acc": [
       "ličnogo / ličny",
@@ -7070,6 +7163,7 @@ exports[`adjective 779 1`] = `
       "najgorše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najgoršego / najgorši",
@@ -7139,6 +7233,7 @@ exports[`adjective 803 1`] = `
       "radostne",
     ],
   },
+  "short": "radostėn",
   "singular": {
     "acc": [
       "radostnogo / radostny",
@@ -7208,6 +7303,7 @@ exports[`adjective 810 1`] = `
       "konkretne",
     ],
   },
+  "short": "konkretėn",
   "singular": {
     "acc": [
       "konkretnogo / konkretny",
@@ -7277,6 +7373,7 @@ exports[`adjective 831 1`] = `
       "ukrajinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ukrajinskogo / ukrajinsky",
@@ -7346,6 +7443,7 @@ exports[`adjective 837 1`] = `
       "gladke",
     ],
   },
+  "short": "gladȯk",
   "singular": {
     "acc": [
       "gladkogo / gladky",
@@ -7415,6 +7513,7 @@ exports[`adjective 838 1`] = `
       "rimske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "rimskogo / rimsky",
@@ -7484,6 +7583,7 @@ exports[`adjective 842 1`] = `
       "zapadne",
     ],
   },
+  "short": "zapadėn",
   "singular": {
     "acc": [
       "zapadnogo / zapadny",
@@ -7553,6 +7653,7 @@ exports[`adjective 862 1`] = `
       "informovane",
     ],
   },
+  "short": "informovan",
   "singular": {
     "acc": [
       "informovanogo / informovany",
@@ -7622,6 +7723,7 @@ exports[`adjective 864 1`] = `
       "ine",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "inogo / iny",
@@ -7691,6 +7793,7 @@ exports[`adjective 868 1`] = `
       "kosovske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kosovskogo / kosovsky",
@@ -7760,6 +7863,7 @@ exports[`adjective 877 1`] = `
       "zlåte",
     ],
   },
+  "short": "zlåt",
   "singular": {
     "acc": [
       "zlåtogo / zlåty",
@@ -7829,6 +7933,7 @@ exports[`adjective 884 1`] = `
       "legke",
     ],
   },
+  "short": "legȯk",
   "singular": {
     "acc": [
       "legkogo / legky",
@@ -7898,6 +8003,7 @@ exports[`adjective 894 1`] = `
       "lehitske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lehitskogo / lehitsky",
@@ -7967,6 +8073,7 @@ exports[`adjective 897 1`] = `
       "indoevropejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "indoevropejskogo / indoevropejsky",
@@ -8036,6 +8143,7 @@ exports[`adjective 900 1`] = `
       "moderne",
     ],
   },
+  "short": "moderėn",
   "singular": {
     "acc": [
       "modernogo / moderny",
@@ -8105,6 +8213,7 @@ exports[`adjective 907 1`] = `
       "odděljene",
     ],
   },
+  "short": "odděljen",
   "singular": {
     "acc": [
       "odděljenogo / odděljeny",
@@ -8174,6 +8283,7 @@ exports[`adjective 937 1`] = `
       "každe",
     ],
   },
+  "short": "každ",
   "singular": {
     "acc": [
       "každogo / každy",
@@ -8243,6 +8353,7 @@ exports[`adjective 947 1`] = `
       "ostre",
     ],
   },
+  "short": "ostr",
   "singular": {
     "acc": [
       "ostrogo / ostry",
@@ -8312,6 +8423,7 @@ exports[`adjective 949 1`] = `
       "něme",
     ],
   },
+  "short": "něm",
   "singular": {
     "acc": [
       "němogo / němy",
@@ -8381,6 +8493,7 @@ exports[`adjective 963 1`] = `
       "nedavne",
     ],
   },
+  "short": "nedavėn",
   "singular": {
     "acc": [
       "nedavnogo / nedavny",
@@ -8450,6 +8563,7 @@ exports[`adjective 970 1`] = `
       "žive",
     ],
   },
+  "short": "živ",
   "singular": {
     "acc": [
       "živogo / živy",
@@ -8519,6 +8633,7 @@ exports[`adjective 971 1`] = `
       "nazvane",
     ],
   },
+  "short": "nazvan",
   "singular": {
     "acc": [
       "nazvanogo / nazvany",
@@ -8588,6 +8703,7 @@ exports[`adjective 972 1`] = `
       "nebeske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "nebeskogo / nebesky",
@@ -8657,6 +8773,7 @@ exports[`adjective 981 1`] = `
       "prošedše",
     ],
   },
+  "short": "prošedš",
   "singular": {
     "acc": [
       "prošedšego / prošedši",
@@ -8726,6 +8843,7 @@ exports[`adjective 983 1`] = `
       "někake",
     ],
   },
+  "short": "někak",
   "singular": {
     "acc": [
       "někakogo / někaky",
@@ -8795,6 +8913,7 @@ exports[`adjective 984 1`] = `
       "němečske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "němečskogo / němečsky",
@@ -8864,6 +8983,7 @@ exports[`adjective 999 1`] = `
       "jedine",
     ],
   },
+  "short": "jedin",
   "singular": {
     "acc": [
       "jedinogo / jediny",
@@ -8933,6 +9053,7 @@ exports[`adjective 1000 1`] = `
       "obće",
     ],
   },
+  "short": "obć",
   "singular": {
     "acc": [
       "obćego / obći",
@@ -9002,6 +9123,7 @@ exports[`adjective 1009 1`] = `
       "vinne",
     ],
   },
+  "short": "vinėn",
   "singular": {
     "acc": [
       "vinnogo / vinny",
@@ -9071,6 +9193,7 @@ exports[`adjective 1020 1`] = `
       "francuzske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "francuzskogo / francuzsky",
@@ -9140,6 +9263,7 @@ exports[`adjective 1021 1`] = `
       "niderlandske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "niderlandskogo / niderlandsky",
@@ -9209,6 +9333,7 @@ exports[`adjective 1027 1`] = `
       "cěle",
     ],
   },
+  "short": "cěl",
   "singular": {
     "acc": [
       "cělogo / cěly",
@@ -9278,6 +9403,7 @@ exports[`adjective 1040 1`] = `
       "gruzinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gruzinskogo / gruzinsky",
@@ -9347,6 +9473,7 @@ exports[`adjective 1048 1`] = `
       "ogromne",
     ],
   },
+  "short": "ogromėn",
   "singular": {
     "acc": [
       "ogromnogo / ogromny",
@@ -9416,6 +9543,7 @@ exports[`adjective 1052 1`] = `
       "oslabjene",
     ],
   },
+  "short": "oslabjen",
   "singular": {
     "acc": [
       "oslabjenogo / oslabjeny",
@@ -9485,6 +9613,7 @@ exports[`adjective 1056 1`] = `
       "otvorjene",
     ],
   },
+  "short": "otvorjen",
   "singular": {
     "acc": [
       "otvorjenogo / otvorjeny",
@@ -9554,6 +9683,7 @@ exports[`adjective 1065 1`] = `
       "komunistične",
     ],
   },
+  "short": "komunističėn",
   "singular": {
     "acc": [
       "komunističnogo / komunističny",
@@ -9623,6 +9753,7 @@ exports[`adjective 1079 1`] = `
       "pěše",
     ],
   },
+  "short": "pěš",
   "singular": {
     "acc": [
       "pěšego / pěši",
@@ -9692,6 +9823,7 @@ exports[`adjective 1083 1`] = `
       "puste",
     ],
   },
+  "short": "pust",
   "singular": {
     "acc": [
       "pustogo / pusty",
@@ -9761,6 +9893,7 @@ exports[`adjective 1128 1`] = `
       "gluhe",
     ],
   },
+  "short": "gluh",
   "singular": {
     "acc": [
       "gluhogo / gluhy",
@@ -9830,6 +9963,7 @@ exports[`adjective 1130 1`] = `
       "prisvojne",
     ],
   },
+  "short": "prisvojėn",
   "singular": {
     "acc": [
       "prisvojnogo / prisvojny",
@@ -9899,6 +10033,7 @@ exports[`adjective 1144 1`] = `
       "dobre",
     ],
   },
+  "short": "dobr",
   "singular": {
     "acc": [
       "dobrogo / dobry",
@@ -9968,6 +10103,7 @@ exports[`adjective 1157 1`] = `
       "nevinne",
     ],
   },
+  "short": "nevinėn",
   "singular": {
     "acc": [
       "nevinnogo / nevinny",
@@ -10037,6 +10173,7 @@ exports[`adjective 1164 1`] = `
       "prave",
     ],
   },
+  "short": "prav",
   "singular": {
     "acc": [
       "pravogo / pravy",
@@ -10106,6 +10243,7 @@ exports[`adjective 1186 1`] = `
       "strategične",
     ],
   },
+  "short": "strategičėn",
   "singular": {
     "acc": [
       "strategičnogo / strategičny",
@@ -10175,6 +10313,7 @@ exports[`adjective 1209 1`] = `
       "prěme",
     ],
   },
+  "short": "prěm",
   "singular": {
     "acc": [
       "prěmogo / prěmy",
@@ -10244,6 +10383,7 @@ exports[`adjective 1213 1`] = `
       "publične",
     ],
   },
+  "short": "publičėn",
   "singular": {
     "acc": [
       "publičnogo / publičny",
@@ -10313,6 +10453,7 @@ exports[`adjective 1215 1`] = `
       "prirodne",
     ],
   },
+  "short": "prirodėn",
   "singular": {
     "acc": [
       "prirodnogo / prirodny",
@@ -10382,6 +10523,7 @@ exports[`adjective 1242 1`] = `
       "råvne",
     ],
   },
+  "short": "råvėn",
   "singular": {
     "acc": [
       "råvnogo / råvny",
@@ -10451,6 +10593,7 @@ exports[`adjective 1249 1`] = `
       "lojaľne",
     ],
   },
+  "short": "lojaľėn",
   "singular": {
     "acc": [
       "lojaľnogo / lojaľny",
@@ -10520,6 +10663,7 @@ exports[`adjective 1253 1`] = `
       "rizične",
     ],
   },
+  "short": "rizičėn",
   "singular": {
     "acc": [
       "rizičnogo / rizičny",
@@ -10589,6 +10733,7 @@ exports[`adjective 1272 1`] = `
       "rusinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "rusinskogo / rusinsky",
@@ -10658,6 +10803,7 @@ exports[`adjective 1276 1`] = `
       "generaľne",
     ],
   },
+  "short": "generaľėn",
   "singular": {
     "acc": [
       "generaľnogo / generaľny",
@@ -10727,6 +10873,7 @@ exports[`adjective 1296 1`] = `
       "potrěbne",
     ],
   },
+  "short": "potrěbėn",
   "singular": {
     "acc": [
       "potrěbnogo / potrěbny",
@@ -10796,6 +10943,7 @@ exports[`adjective 1300 1`] = `
       "ingušske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ingušskogo / ingušsky",
@@ -10865,6 +11013,7 @@ exports[`adjective 1310 1`] = `
       "siľne",
     ],
   },
+  "short": "siľėn",
   "singular": {
     "acc": [
       "siľnogo / siľny",
@@ -10934,6 +11083,7 @@ exports[`adjective 1316 1`] = `
       "sistematične",
     ],
   },
+  "short": "sistematičėn",
   "singular": {
     "acc": [
       "sistematičnogo / sistematičny",
@@ -11003,6 +11153,7 @@ exports[`adjective 1320 1`] = `
       "federativne",
     ],
   },
+  "short": "federativėn",
   "singular": {
     "acc": [
       "federativnogo / federativny",
@@ -11072,6 +11223,7 @@ exports[`adjective 1338 1`] = `
       "slavne",
     ],
   },
+  "short": "slavėn",
   "singular": {
     "acc": [
       "slavnogo / slavny",
@@ -11141,6 +11293,7 @@ exports[`adjective 1341 1`] = `
       "slabe",
     ],
   },
+  "short": "slab",
   "singular": {
     "acc": [
       "slabogo / slaby",
@@ -11210,6 +11363,7 @@ exports[`adjective 1349 1`] = `
       "slovenečske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "slovenečskogo / slovenečsky",
@@ -11279,6 +11433,7 @@ exports[`adjective 1353 1`] = `
       "portugaľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "portugaľskogo / portugaľsky",
@@ -11348,6 +11503,7 @@ exports[`adjective 1355 1`] = `
       "slovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "slovjanskogo / slovjansky",
@@ -11417,6 +11573,7 @@ exports[`adjective 1362 1`] = `
       "samotne",
     ],
   },
+  "short": "samotėn",
   "singular": {
     "acc": [
       "samotnogo / samotny",
@@ -11486,6 +11643,7 @@ exports[`adjective 1378 1`] = `
       "slědujųće",
     ],
   },
+  "short": "slědujųć",
   "singular": {
     "acc": [
       "slědujųćego / slědujųći",
@@ -11555,6 +11713,7 @@ exports[`adjective 1390 1`] = `
       "slovačske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "slovačskogo / slovačsky",
@@ -11624,6 +11783,7 @@ exports[`adjective 1398 1`] = `
       "sovětske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sovětskogo / sovětsky",
@@ -11693,6 +11853,7 @@ exports[`adjective 1399 1`] = `
       "stare",
     ],
   },
+  "short": "star",
   "singular": {
     "acc": [
       "starogo / stary",
@@ -11762,6 +11923,7 @@ exports[`adjective 1409 1`] = `
       "cěnne",
     ],
   },
+  "short": "cěnėn",
   "singular": {
     "acc": [
       "cěnnogo / cěnny",
@@ -11831,6 +11993,7 @@ exports[`adjective 1415 1`] = `
       "pozitivne",
     ],
   },
+  "short": "pozitivėn",
   "singular": {
     "acc": [
       "pozitivnogo / pozitivny",
@@ -11900,6 +12063,7 @@ exports[`adjective 1418 1`] = `
       "kysle",
     ],
   },
+  "short": "kysl",
   "singular": {
     "acc": [
       "kyslogo / kysly",
@@ -11969,6 +12133,7 @@ exports[`adjective 1420 1`] = `
       "švedske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "švedskogo / švedsky",
@@ -12038,6 +12203,7 @@ exports[`adjective 1425 1`] = `
       "nezaležne",
     ],
   },
+  "short": "nezaležėn",
   "singular": {
     "acc": [
       "nezaležnogo / nezaležny",
@@ -12107,6 +12273,7 @@ exports[`adjective 1433 1`] = `
       "suverenne",
     ],
   },
+  "short": "suverenėn",
   "singular": {
     "acc": [
       "suverennogo / suverenny",
@@ -12176,6 +12343,7 @@ exports[`adjective 1435 1`] = `
       "koričneve",
     ],
   },
+  "short": "koričnev",
   "singular": {
     "acc": [
       "koričnevogo / koričnevy",
@@ -12245,6 +12413,7 @@ exports[`adjective 1458 1`] = `
       "tradicijne",
     ],
   },
+  "short": "tradicijėn",
   "singular": {
     "acc": [
       "tradicijnogo / tradicijny",
@@ -12314,6 +12483,7 @@ exports[`adjective 1459 1`] = `
       "mělke",
     ],
   },
+  "short": "mělȯk",
   "singular": {
     "acc": [
       "mělkogo / mělky",
@@ -12383,6 +12553,7 @@ exports[`adjective 1476 1`] = `
       "štučne",
     ],
   },
+  "short": "štučėn",
   "singular": {
     "acc": [
       "štučnogo / štučny",
@@ -12452,6 +12623,7 @@ exports[`adjective 1479 1`] = `
       "spoľne",
     ],
   },
+  "short": "spoľėn",
   "singular": {
     "acc": [
       "spoľnogo / spoľny",
@@ -12521,6 +12693,7 @@ exports[`adjective 1482 1`] = `
       "lěne",
     ],
   },
+  "short": "lěn",
   "singular": {
     "acc": [
       "lěnogo / lěny",
@@ -12590,6 +12763,7 @@ exports[`adjective 1499 1`] = `
       "žȯlte",
     ],
   },
+  "short": "žȯlt",
   "singular": {
     "acc": [
       "žȯltogo / žȯlty",
@@ -12659,6 +12833,7 @@ exports[`adjective 1511 1`] = `
       "homoseksuaľne",
     ],
   },
+  "short": "homoseksuaľėn",
   "singular": {
     "acc": [
       "homoseksuaľnogo / homoseksuaľny",
@@ -12728,6 +12903,7 @@ exports[`adjective 1514 1`] = `
       "polarne",
     ],
   },
+  "short": "polarėn",
   "singular": {
     "acc": [
       "polarnogo / polarny",
@@ -12797,6 +12973,7 @@ exports[`adjective 1516 1`] = `
       "despotične",
     ],
   },
+  "short": "despotičėn",
   "singular": {
     "acc": [
       "despotičnogo / despotičny",
@@ -12866,6 +13043,7 @@ exports[`adjective 1520 1`] = `
       "značne",
     ],
   },
+  "short": "značėn",
   "singular": {
     "acc": [
       "značnogo / značny",
@@ -12935,6 +13113,7 @@ exports[`adjective 1528 1`] = `
       "japonske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "japonskogo / japonsky",
@@ -13004,6 +13183,7 @@ exports[`adjective 1532 1`] = `
       "tvŕde",
     ],
   },
+  "short": "tvŕd",
   "singular": {
     "acc": [
       "tvŕdogo / tvŕdy",
@@ -13073,6 +13253,7 @@ exports[`adjective 1536 1`] = `
       "segodenne",
     ],
   },
+  "short": "segodenėn",
   "singular": {
     "acc": [
       "segodennogo / segodenny",
@@ -13142,6 +13323,7 @@ exports[`adjective 1544 1`] = `
       "srědnje",
     ],
   },
+  "short": "srědėn",
   "singular": {
     "acc": [
       "srědnjego / srědnji",
@@ -13211,6 +13393,7 @@ exports[`adjective 1544-1 1`] = `
       "srědne",
     ],
   },
+  "short": "srědėn",
   "singular": {
     "acc": [
       "srědnogo / srědny",
@@ -13280,6 +13463,7 @@ exports[`adjective 1545 1`] = `
       "ščęstlive",
     ],
   },
+  "short": "ščęstliv",
   "singular": {
     "acc": [
       "ščęstlivogo / ščęstlivy",
@@ -13349,6 +13533,7 @@ exports[`adjective 1548 1`] = `
       "tvorčje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "tvorčjego / tvorčji",
@@ -13418,6 +13603,7 @@ exports[`adjective 1551 1`] = `
       "čestne",
     ],
   },
+  "short": "čestėn",
   "singular": {
     "acc": [
       "čestnogo / čestny",
@@ -13487,6 +13673,7 @@ exports[`adjective 1560 1`] = `
       "sěre",
     ],
   },
+  "short": "sěr",
   "singular": {
     "acc": [
       "sěrogo / sěry",
@@ -13556,6 +13743,7 @@ exports[`adjective 1577 1`] = `
       "tenke",
     ],
   },
+  "short": "tenȯk",
   "singular": {
     "acc": [
       "tenkogo / tenky",
@@ -13625,6 +13813,7 @@ exports[`adjective 1599 1`] = `
       "uvěrjene",
     ],
   },
+  "short": "uvěrjen",
   "singular": {
     "acc": [
       "uvěrjenogo / uvěrjeny",
@@ -13694,6 +13883,7 @@ exports[`adjective 1611 1`] = `
       "uvědomjene",
     ],
   },
+  "short": "uvědomjen",
   "singular": {
     "acc": [
       "uvědomjenogo / uvědomjeny",
@@ -13763,6 +13953,7 @@ exports[`adjective 1613 1`] = `
       "iračske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "iračskogo / iračsky",
@@ -13832,6 +14023,7 @@ exports[`adjective 1618 1`] = `
       "uslovne",
     ],
   },
+  "short": "uslovėn",
   "singular": {
     "acc": [
       "uslovnogo / uslovny",
@@ -13901,6 +14093,7 @@ exports[`adjective 1632 1`] = `
       "važne",
     ],
   },
+  "short": "važėn",
   "singular": {
     "acc": [
       "važnogo / važny",
@@ -13970,6 +14163,7 @@ exports[`adjective 1639 1`] = `
       "hråpave",
     ],
   },
+  "short": "hråpav",
   "singular": {
     "acc": [
       "hråpavogo / hråpavy",
@@ -14039,6 +14233,7 @@ exports[`adjective 1657 1`] = `
       "věčne",
     ],
   },
+  "short": "věčėn",
   "singular": {
     "acc": [
       "věčnogo / věčny",
@@ -14108,6 +14303,7 @@ exports[`adjective 1660 1`] = `
       "urodlive",
     ],
   },
+  "short": "urodliv",
   "singular": {
     "acc": [
       "urodlivogo / urodlivy",
@@ -14177,6 +14373,7 @@ exports[`adjective 1666 1`] = `
       "vŕhne",
     ],
   },
+  "short": "vŕhėn",
   "singular": {
     "acc": [
       "vŕhnogo / vŕhny",
@@ -14246,6 +14443,7 @@ exports[`adjective 1667 1`] = `
       "indoiranske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "indoiranskogo / indoiransky",
@@ -14315,6 +14513,7 @@ exports[`adjective 1668 1`] = `
       "revnive",
     ],
   },
+  "short": "revniv",
   "singular": {
     "acc": [
       "revnivogo / revnivy",
@@ -14384,6 +14583,7 @@ exports[`adjective 1685 1`] = `
       "ekstremistične",
     ],
   },
+  "short": "ekstremističėn",
   "singular": {
     "acc": [
       "ekstremističnogo / ekstremističny",
@@ -14453,6 +14653,7 @@ exports[`adjective 1691 1`] = `
       "turečske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "turečskogo / turečsky",
@@ -14522,6 +14723,7 @@ exports[`adjective 1709 1`] = `
       "prěstrašene",
     ],
   },
+  "short": "prěstrašen",
   "singular": {
     "acc": [
       "prěstrašenogo / prěstrašeny",
@@ -14591,6 +14793,7 @@ exports[`adjective 1718 1`] = `
       "podobne",
     ],
   },
+  "short": "podobėn",
   "singular": {
     "acc": [
       "podobnogo / podobny",
@@ -14660,6 +14863,7 @@ exports[`adjective 1727 1`] = `
       "centraľne",
     ],
   },
+  "short": "centraľėn",
   "singular": {
     "acc": [
       "centraľnogo / centraľny",
@@ -14729,6 +14933,7 @@ exports[`adjective 1734 1`] = `
       "etnične",
     ],
   },
+  "short": "etničėn",
   "singular": {
     "acc": [
       "etničnogo / etničny",
@@ -14798,6 +15003,7 @@ exports[`adjective 1736 1`] = `
       "grube",
     ],
   },
+  "short": "grub",
   "singular": {
     "acc": [
       "grubogo / gruby",
@@ -14867,6 +15073,7 @@ exports[`adjective 1747 1`] = `
       "zakonne",
     ],
   },
+  "short": "zakonėn",
   "singular": {
     "acc": [
       "zakonnogo / zakonny",
@@ -14936,6 +15143,7 @@ exports[`adjective 1749 1`] = `
       "temne",
     ],
   },
+  "short": "temėn",
   "singular": {
     "acc": [
       "temnogo / temny",
@@ -15005,6 +15213,7 @@ exports[`adjective 1751 1`] = `
       "glupe",
     ],
   },
+  "short": "glup",
   "singular": {
     "acc": [
       "glupogo / glupy",
@@ -15074,6 +15283,7 @@ exports[`adjective 1757 1`] = `
       "glųboke",
     ],
   },
+  "short": "glųbok",
   "singular": {
     "acc": [
       "glųbokogo / glųboky",
@@ -15143,6 +15353,7 @@ exports[`adjective 1762 1`] = `
       "bystre",
     ],
   },
+  "short": "bystr",
   "singular": {
     "acc": [
       "bystrogo / bystry",
@@ -15212,6 +15423,7 @@ exports[`adjective 1767 1`] = `
       "nelegaľne",
     ],
   },
+  "short": "nelegaľėn",
   "singular": {
     "acc": [
       "nelegaľnogo / nelegaľny",
@@ -15281,6 +15493,7 @@ exports[`adjective 1775 1`] = `
       "suhe",
     ],
   },
+  "short": "suh",
   "singular": {
     "acc": [
       "suhogo / suhy",
@@ -15350,6 +15563,7 @@ exports[`adjective 1778 1`] = `
       "ekonomične",
     ],
   },
+  "short": "ekonomičėn",
   "singular": {
     "acc": [
       "ekonomičnogo / ekonomičny",
@@ -15419,6 +15633,7 @@ exports[`adjective 1781 1`] = `
       "jednostrånne",
     ],
   },
+  "short": "jednostrånėn",
   "singular": {
     "acc": [
       "jednostrånnogo / jednostrånny",
@@ -15488,6 +15703,7 @@ exports[`adjective 1784 1`] = `
       "seksuaľne",
     ],
   },
+  "short": "seksuaľėn",
   "singular": {
     "acc": [
       "seksuaľnogo / seksuaľny",
@@ -15557,6 +15773,7 @@ exports[`adjective 1792 1`] = `
       "bezposrědnje",
     ],
   },
+  "short": "bezposrědėn",
   "singular": {
     "acc": [
       "bezposrědnjego / bezposrědnji",
@@ -15626,6 +15843,7 @@ exports[`adjective 1792-1 1`] = `
       "bezposrědne",
     ],
   },
+  "short": "bezposrědėn",
   "singular": {
     "acc": [
       "bezposrědnogo / bezposrědny",
@@ -15695,6 +15913,7 @@ exports[`adjective 1793 1`] = `
       "mŕtve",
     ],
   },
+  "short": "mŕtv",
   "singular": {
     "acc": [
       "mŕtvogo / mŕtvy",
@@ -15764,6 +15983,7 @@ exports[`adjective 1798 1`] = `
       "izdŕžlive",
     ],
   },
+  "short": "izdŕžliv",
   "singular": {
     "acc": [
       "izdŕžlivogo / izdŕžlivy",
@@ -15833,6 +16053,7 @@ exports[`adjective 1804 1`] = `
       "vzajemne",
     ],
   },
+  "short": "vzajemėn",
   "singular": {
     "acc": [
       "vzajemnogo / vzajemny",
@@ -15902,6 +16123,7 @@ exports[`adjective 1812 1`] = `
       "gněde",
     ],
   },
+  "short": "gněd",
   "singular": {
     "acc": [
       "gnědogo / gnědy",
@@ -15971,6 +16193,7 @@ exports[`adjective 1832 1`] = `
       "kråljevske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kråljevskogo / kråljevsky",
@@ -16040,6 +16263,7 @@ exports[`adjective 1844 1`] = `
       "tihe",
     ],
   },
+  "short": "tih",
   "singular": {
     "acc": [
       "tihogo / tihy",
@@ -16109,6 +16333,7 @@ exports[`adjective 1847 1`] = `
       "bųdųće",
     ],
   },
+  "short": "bųdųć",
   "singular": {
     "acc": [
       "bųdųćego / bųdųći",
@@ -16178,6 +16403,7 @@ exports[`adjective 1879 1`] = `
       "civiľne",
     ],
   },
+  "short": "civiľėn",
   "singular": {
     "acc": [
       "civiľnogo / civiľny",
@@ -16247,6 +16473,7 @@ exports[`adjective 1881 1`] = `
       "oble",
     ],
   },
+  "short": "obėl",
   "singular": {
     "acc": [
       "oblogo / obly",
@@ -16316,6 +16543,7 @@ exports[`adjective 1898 1`] = `
       "mile",
     ],
   },
+  "short": "mil",
   "singular": {
     "acc": [
       "milogo / mily",
@@ -16385,6 +16613,7 @@ exports[`adjective 1903 1`] = `
       "dramatične",
     ],
   },
+  "short": "dramatičėn",
   "singular": {
     "acc": [
       "dramatičnogo / dramatičny",
@@ -16454,6 +16683,7 @@ exports[`adjective 1905 1`] = `
       "evropejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "evropejskogo / evropejsky",
@@ -16523,6 +16753,7 @@ exports[`adjective 1905-1 1`] = `
       "evropske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "evropskogo / evropsky",
@@ -16592,6 +16823,7 @@ exports[`adjective 1907 1`] = `
       "speciaľne",
     ],
   },
+  "short": "speciaľėn",
   "singular": {
     "acc": [
       "speciaľnogo / speciaľny",
@@ -16661,6 +16893,7 @@ exports[`adjective 1913 1`] = `
       "vlastne",
     ],
   },
+  "short": "vlastėn",
   "singular": {
     "acc": [
       "vlastnogo / vlastny",
@@ -16730,6 +16963,7 @@ exports[`adjective 1931 1`] = `
       "finansove",
     ],
   },
+  "short": "finansov",
   "singular": {
     "acc": [
       "finansovogo / finansovy",
@@ -16799,6 +17033,7 @@ exports[`adjective 1956 1`] = `
       "originaľne",
     ],
   },
+  "short": "originaľėn",
   "singular": {
     "acc": [
       "originaľnogo / originaľny",
@@ -16868,6 +17103,7 @@ exports[`adjective 1977 1`] = `
       "svobodne",
     ],
   },
+  "short": "svobodėn",
   "singular": {
     "acc": [
       "svobodnogo / svobodny",
@@ -16937,6 +17173,7 @@ exports[`adjective 1980 1`] = `
       "španske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "španskogo / špansky",
@@ -17006,6 +17243,7 @@ exports[`adjective 1985 1`] = `
       "gorše",
     ],
   },
+  "short": "gorš",
   "singular": {
     "acc": [
       "goršego / gorši",
@@ -17075,6 +17313,7 @@ exports[`adjective 2017 1`] = `
       "nepodatlive",
     ],
   },
+  "short": "nepodatliv",
   "singular": {
     "acc": [
       "nepodatlivogo / nepodatlivy",
@@ -17144,6 +17383,7 @@ exports[`adjective 2019 1`] = `
       "obyčne",
     ],
   },
+  "short": "obyčėn",
   "singular": {
     "acc": [
       "obyčnogo / obyčny",
@@ -17213,6 +17453,7 @@ exports[`adjective 2021 1`] = `
       "sporne",
     ],
   },
+  "short": "sporėn",
   "singular": {
     "acc": [
       "spornogo / sporny",
@@ -17282,6 +17523,7 @@ exports[`adjective 2024 1`] = `
       "iskrene",
     ],
   },
+  "short": "iskren",
   "singular": {
     "acc": [
       "iskrenogo / iskreny",
@@ -17351,6 +17593,7 @@ exports[`adjective 2033 1`] = `
       "eventuaľne",
     ],
   },
+  "short": "eventuaľėn",
   "singular": {
     "acc": [
       "eventuaľnogo / eventuaľny",
@@ -17420,6 +17663,7 @@ exports[`adjective 2034 1`] = `
       "råzne",
     ],
   },
+  "short": "råzėn",
   "singular": {
     "acc": [
       "råznogo / råzny",
@@ -17489,6 +17733,7 @@ exports[`adjective 2077 1`] = `
       "ekskluzivne",
     ],
   },
+  "short": "ekskluzivėn",
   "singular": {
     "acc": [
       "ekskluzivnogo / ekskluzivny",
@@ -17558,6 +17803,7 @@ exports[`adjective 2090 1`] = `
       "svęte",
     ],
   },
+  "short": "svęt",
   "singular": {
     "acc": [
       "svętogo / svęty",
@@ -17627,6 +17873,7 @@ exports[`adjective 2108 1`] = `
       "jędrne",
     ],
   },
+  "short": "jędrėn",
   "singular": {
     "acc": [
       "jędrnogo / jędrny",
@@ -17696,6 +17943,7 @@ exports[`adjective 2122 1`] = `
       "rodstvene",
     ],
   },
+  "short": "rodstven",
   "singular": {
     "acc": [
       "rodstvenogo / rodstveny",
@@ -17765,6 +18013,7 @@ exports[`adjective 2124 1`] = `
       "vojenne",
     ],
   },
+  "short": "vojenėn",
   "singular": {
     "acc": [
       "vojennogo / vojenny",
@@ -17834,6 +18083,7 @@ exports[`adjective 2125 1`] = `
       "znamenite",
     ],
   },
+  "short": "znamenit",
   "singular": {
     "acc": [
       "znamenitogo / znamenity",
@@ -17903,6 +18153,7 @@ exports[`adjective 2147 1`] = `
       "mokre",
     ],
   },
+  "short": "mokr",
   "singular": {
     "acc": [
       "mokrogo / mokry",
@@ -17972,6 +18223,7 @@ exports[`adjective 2166 1`] = `
       "arabske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "arabskogo / arabsky",
@@ -18041,6 +18293,7 @@ exports[`adjective 2167 1`] = `
       "zdråve",
     ],
   },
+  "short": "zdråv",
   "singular": {
     "acc": [
       "zdråvogo / zdråvy",
@@ -18110,6 +18363,7 @@ exports[`adjective 2173 1`] = `
       "negativne",
     ],
   },
+  "short": "negativėn",
   "singular": {
     "acc": [
       "negativnogo / negativny",
@@ -18179,6 +18433,7 @@ exports[`adjective 2182 1`] = `
       "romantične",
     ],
   },
+  "short": "romantičėn",
   "singular": {
     "acc": [
       "romantičnogo / romantičny",
@@ -18248,6 +18503,7 @@ exports[`adjective 2187 1`] = `
       "pendžabske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pendžabskogo / pendžabsky",
@@ -18317,6 +18573,7 @@ exports[`adjective 2207 1`] = `
       "rođene",
     ],
   },
+  "short": "rođen",
   "singular": {
     "acc": [
       "rođenogo / rođeny",
@@ -18386,6 +18643,7 @@ exports[`adjective 2211 1`] = `
       "råzlične",
     ],
   },
+  "short": "råzličėn",
   "singular": {
     "acc": [
       "råzličnogo / råzličny",
@@ -18455,6 +18713,7 @@ exports[`adjective 2216 1`] = `
       "reaľne",
     ],
   },
+  "short": "reaľėn",
   "singular": {
     "acc": [
       "reaľnogo / reaľny",
@@ -18524,6 +18783,7 @@ exports[`adjective 2223 1`] = `
       "socialistične",
     ],
   },
+  "short": "socialističėn",
   "singular": {
     "acc": [
       "socialističnogo / socialističny",
@@ -18593,6 +18853,7 @@ exports[`adjective 2267 1`] = `
       "pozdne",
     ],
   },
+  "short": "pozdėn",
   "singular": {
     "acc": [
       "pozdnogo / pozdny",
@@ -18662,6 +18923,7 @@ exports[`adjective 2272 1`] = `
       "rědke",
     ],
   },
+  "short": "rědȯk",
   "singular": {
     "acc": [
       "rědkogo / rědky",
@@ -18731,6 +18993,7 @@ exports[`adjective 2273 1`] = `
       "čęste",
     ],
   },
+  "short": "čęst",
   "singular": {
     "acc": [
       "čęstogo / čęsty",
@@ -18800,6 +19063,7 @@ exports[`adjective 2289 1`] = `
       "gotove",
     ],
   },
+  "short": "gotov",
   "singular": {
     "acc": [
       "gotovogo / gotovy",
@@ -18866,6 +19130,7 @@ exports[`adjective 2299 1`] = `
       "lěpše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lěpšego / lěpši",
@@ -18935,6 +19200,7 @@ exports[`adjective 2311 1`] = `
       "russke",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "russkogo / russky",
@@ -19004,6 +19270,7 @@ exports[`adjective 2313 1`] = `
       "tȯlste",
     ],
   },
+  "short": "tȯlst",
   "singular": {
     "acc": [
       "tȯlstogo / tȯlsty",
@@ -19073,6 +19340,7 @@ exports[`adjective 2319 1`] = `
       "spontanne",
     ],
   },
+  "short": "spontanėn",
   "singular": {
     "acc": [
       "spontannogo / spontanny",
@@ -19142,6 +19410,7 @@ exports[`adjective 2323 1`] = `
       "poslědnje",
     ],
   },
+  "short": "poslědėn",
   "singular": {
     "acc": [
       "poslědnjego / poslědnji",
@@ -19211,6 +19480,7 @@ exports[`adjective 2323-1 1`] = `
       "poslědne",
     ],
   },
+  "short": "poslědėn",
   "singular": {
     "acc": [
       "poslědnogo / poslědny",
@@ -19280,6 +19550,7 @@ exports[`adjective 2333 1`] = `
       "poslědovateljne",
     ],
   },
+  "short": "poslědovateljėn",
   "singular": {
     "acc": [
       "poslědovateljnogo / poslědovateljny",
@@ -19349,6 +19620,7 @@ exports[`adjective 2334 1`] = `
       "proste",
     ],
   },
+  "short": "prost",
   "singular": {
     "acc": [
       "prostogo / prosty",
@@ -19418,6 +19690,7 @@ exports[`adjective 2341 1`] = `
       "krųgle",
     ],
   },
+  "short": "krųgl",
   "singular": {
     "acc": [
       "krųglogo / krųgly",
@@ -19487,6 +19760,7 @@ exports[`adjective 2346 1`] = `
       "šumne",
     ],
   },
+  "short": "šumėn",
   "singular": {
     "acc": [
       "šumnogo / šumny",
@@ -19556,6 +19830,7 @@ exports[`adjective 2375 1`] = `
       "pěgave",
     ],
   },
+  "short": "pěgav",
   "singular": {
     "acc": [
       "pěgavogo / pěgavy",
@@ -19625,6 +19900,7 @@ exports[`adjective 2377 1`] = `
       "paradoksaľne",
     ],
   },
+  "short": "paradoksaľėn",
   "singular": {
     "acc": [
       "paradoksaľnogo / paradoksaľny",
@@ -19694,6 +19970,7 @@ exports[`adjective 2381 1`] = `
       "goŕke",
     ],
   },
+  "short": "goŕėk",
   "singular": {
     "acc": [
       "goŕkogo / goŕky",
@@ -19763,6 +20040,7 @@ exports[`adjective 2386 1`] = `
       "sposobne",
     ],
   },
+  "short": "sposobėn",
   "singular": {
     "acc": [
       "sposobnogo / sposobny",
@@ -19832,6 +20110,7 @@ exports[`adjective 2392 1`] = `
       "privykle",
     ],
   },
+  "short": "privykl",
   "singular": {
     "acc": [
       "privyklogo / privykly",
@@ -19901,6 +20180,7 @@ exports[`adjective 2400 1`] = `
       "pasivne",
     ],
   },
+  "short": "pasivėn",
   "singular": {
     "acc": [
       "pasivnogo / pasivny",
@@ -19970,6 +20250,7 @@ exports[`adjective 2402 1`] = `
       "plodne",
     ],
   },
+  "short": "plodėn",
   "singular": {
     "acc": [
       "plodnogo / plodny",
@@ -20039,6 +20320,7 @@ exports[`adjective 2417 1`] = `
       "češske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "češskogo / češsky",
@@ -20108,6 +20390,7 @@ exports[`adjective 2421 1`] = `
       "medle",
     ],
   },
+  "short": "medl",
   "singular": {
     "acc": [
       "medlogo / medly",
@@ -20177,6 +20460,7 @@ exports[`adjective 2423 1`] = `
       "prědšedše",
     ],
   },
+  "short": "prědšedš",
   "singular": {
     "acc": [
       "prědšedšego / prědšedši",
@@ -20246,6 +20530,7 @@ exports[`adjective 2443 1`] = `
       "bědne",
     ],
   },
+  "short": "bědėn",
   "singular": {
     "acc": [
       "bědnogo / bědny",
@@ -20315,6 +20600,7 @@ exports[`adjective 2453 1`] = `
       "blěde",
     ],
   },
+  "short": "blěd",
   "singular": {
     "acc": [
       "blědogo / blědy",
@@ -20384,6 +20670,7 @@ exports[`adjective 2463 1`] = `
       "bose",
     ],
   },
+  "short": "bos",
   "singular": {
     "acc": [
       "bosogo / bosy",
@@ -20453,6 +20740,7 @@ exports[`adjective 2470 1`] = `
       "britanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "britanskogo / britansky",
@@ -20522,6 +20810,7 @@ exports[`adjective 2475 1`] = `
       "bridke",
     ],
   },
+  "short": "bridȯk",
   "singular": {
     "acc": [
       "bridkogo / bridky",
@@ -20591,6 +20880,7 @@ exports[`adjective 2482 1`] = `
       "bulgarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bulgarskogo / bulgarsky",
@@ -20660,6 +20950,7 @@ exports[`adjective 2483 1`] = `
       "brutaľne",
     ],
   },
+  "short": "brutaľėn",
   "singular": {
     "acc": [
       "brutaľnogo / brutaľny",
@@ -20729,6 +21020,7 @@ exports[`adjective 2497 1`] = `
       "iranske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "iranskogo / iransky",
@@ -20798,6 +21090,7 @@ exports[`adjective 2500 1`] = `
       "interesne",
     ],
   },
+  "short": "interesėn",
   "singular": {
     "acc": [
       "interesnogo / interesny",
@@ -20867,6 +21160,7 @@ exports[`adjective 2510 1`] = `
       "dostatȯčne",
     ],
   },
+  "short": "dostatȯčėn",
   "singular": {
     "acc": [
       "dostatȯčnogo / dostatȯčny",
@@ -20936,6 +21230,7 @@ exports[`adjective 2512 1`] = `
       "drěvěne",
     ],
   },
+  "short": "drěvěn",
   "singular": {
     "acc": [
       "drěvěnogo / drěvěny",
@@ -21005,6 +21300,7 @@ exports[`adjective 2521 1`] = `
       "durne",
     ],
   },
+  "short": "durėn",
   "singular": {
     "acc": [
       "durnogo / durny",
@@ -21074,6 +21370,7 @@ exports[`adjective 2534 1`] = `
       "vnųtrne",
     ],
   },
+  "short": "vnųtrėn",
   "singular": {
     "acc": [
       "vnųtrnogo / vnųtrny",
@@ -21143,6 +21440,7 @@ exports[`adjective 2546 1`] = `
       "jevrejskoslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "jevrejskoslovjanskogo / jevrejskoslovjansky",
@@ -21212,6 +21510,7 @@ exports[`adjective 2548 1`] = `
       "južne",
     ],
   },
+  "short": "južėn",
   "singular": {
     "acc": [
       "južnogo / južny",
@@ -21281,6 +21580,7 @@ exports[`adjective 2561 1`] = `
       "kanadske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kanadskogo / kanadsky",
@@ -21350,6 +21650,7 @@ exports[`adjective 2579 1`] = `
       "hlådne",
     ],
   },
+  "short": "hlådėn",
   "singular": {
     "acc": [
       "hlådnogo / hlådny",
@@ -21419,6 +21720,7 @@ exports[`adjective 2584 1`] = `
       "godne",
     ],
   },
+  "short": "godėn",
   "singular": {
     "acc": [
       "godnogo / godny",
@@ -21488,6 +21790,7 @@ exports[`adjective 2588 1`] = `
       "ganske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ganskogo / gansky",
@@ -21557,6 +21860,7 @@ exports[`adjective 2592 1`] = `
       "humanitarne",
     ],
   },
+  "short": "humanitarėn",
   "singular": {
     "acc": [
       "humanitarnogo / humanitarny",
@@ -21626,6 +21930,7 @@ exports[`adjective 2595 1`] = `
       "ideaľne",
     ],
   },
+  "short": "ideaľėn",
   "singular": {
     "acc": [
       "ideaľnogo / ideaľny",
@@ -21695,6 +22000,7 @@ exports[`adjective 2597 1`] = `
       "identične",
     ],
   },
+  "short": "identičėn",
   "singular": {
     "acc": [
       "identičnogo / identičny",
@@ -21764,6 +22070,7 @@ exports[`adjective 2606 1`] = `
       "hristijanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "hristijanskogo / hristijansky",
@@ -21833,6 +22140,7 @@ exports[`adjective 2607 1`] = `
       "hråbre",
     ],
   },
+  "short": "hråbr",
   "singular": {
     "acc": [
       "hråbrogo / hråbry",
@@ -21902,6 +22210,7 @@ exports[`adjective 2622 1`] = `
       "demokratične",
     ],
   },
+  "short": "demokratičėn",
   "singular": {
     "acc": [
       "demokratičnogo / demokratičny",
@@ -21971,6 +22280,7 @@ exports[`adjective 2634 1`] = `
       "indoarijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "indoarijskogo / indoarijsky",
@@ -22040,6 +22350,7 @@ exports[`adjective 2635 1`] = `
       "kose",
     ],
   },
+  "short": "kos",
   "singular": {
     "acc": [
       "kosogo / kosy",
@@ -22109,6 +22420,7 @@ exports[`adjective 2639 1`] = `
       "kritične",
     ],
   },
+  "short": "kritičėn",
   "singular": {
     "acc": [
       "kritičnogo / kritičny",
@@ -22178,6 +22490,7 @@ exports[`adjective 2641 1`] = `
       "kråtke",
     ],
   },
+  "short": "kråtȯk",
   "singular": {
     "acc": [
       "kråtkogo / kråtky",
@@ -22247,6 +22560,7 @@ exports[`adjective 2647 1`] = `
       "kulturne",
     ],
   },
+  "short": "kulturėn",
   "singular": {
     "acc": [
       "kulturnogo / kulturny",
@@ -22316,6 +22630,7 @@ exports[`adjective 2649 1`] = `
       "latinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "latinskogo / latinsky",
@@ -22385,6 +22700,7 @@ exports[`adjective 2671 1`] = `
       "glåvne",
     ],
   },
+  "short": "glåvėn",
   "singular": {
     "acc": [
       "glåvnogo / glåvny",
@@ -22454,6 +22770,7 @@ exports[`adjective 2673 1`] = `
       "gȯrde",
     ],
   },
+  "short": "gȯrd",
   "singular": {
     "acc": [
       "gȯrdogo / gȯrdy",
@@ -22523,6 +22840,7 @@ exports[`adjective 2678 1`] = `
       "fonetične",
     ],
   },
+  "short": "fonetičėn",
   "singular": {
     "acc": [
       "fonetičnogo / fonetičny",
@@ -22592,6 +22910,7 @@ exports[`adjective 2679 1`] = `
       "běle",
     ],
   },
+  "short": "běl",
   "singular": {
     "acc": [
       "bělogo / běly",
@@ -22661,6 +22980,7 @@ exports[`adjective 2681 1`] = `
       "madjarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "madjarskogo / madjarsky",
@@ -22730,6 +23050,7 @@ exports[`adjective 2682 1`] = `
       "male",
     ],
   },
+  "short": "mal",
   "singular": {
     "acc": [
       "malogo / maly",
@@ -22799,6 +23120,7 @@ exports[`adjective 2691 1`] = `
       "lužičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lužičskogo / lužičsky",
@@ -22868,6 +23190,7 @@ exports[`adjective 2698 1`] = `
       "krasive",
     ],
   },
+  "short": "krasiv",
   "singular": {
     "acc": [
       "krasivogo / krasivy",
@@ -22937,6 +23260,7 @@ exports[`adjective 2702 1`] = `
       "jednake",
     ],
   },
+  "short": "jednak",
   "singular": {
     "acc": [
       "jednakogo / jednaky",
@@ -23006,6 +23330,7 @@ exports[`adjective 2710 1`] = `
       "libijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "libijskogo / libijsky",
@@ -23075,6 +23400,7 @@ exports[`adjective 2714 1`] = `
       "međunarodne",
     ],
   },
+  "short": "međunarodėn",
   "singular": {
     "acc": [
       "međunarodnogo / međunarodny",
@@ -23144,6 +23470,7 @@ exports[`adjective 2734 1`] = `
       "minųle",
     ],
   },
+  "short": "minųl",
   "singular": {
     "acc": [
       "minųlogo / minųly",
@@ -23213,6 +23540,7 @@ exports[`adjective 2739 1`] = `
       "nacistične",
     ],
   },
+  "short": "nacističėn",
   "singular": {
     "acc": [
       "nacističnogo / nacističny",
@@ -23282,6 +23610,7 @@ exports[`adjective 2742 1`] = `
       "modre",
     ],
   },
+  "short": "modr",
   "singular": {
     "acc": [
       "modrogo / modry",
@@ -23351,6 +23680,7 @@ exports[`adjective 2743 1`] = `
       "moćne",
     ],
   },
+  "short": "moćėn",
   "singular": {
     "acc": [
       "moćnogo / moćny",
@@ -23420,6 +23750,7 @@ exports[`adjective 2751 1`] = `
       "mųdre",
     ],
   },
+  "short": "mųdr",
   "singular": {
     "acc": [
       "mųdrogo / mųdry",
@@ -23489,6 +23820,7 @@ exports[`adjective 2764 1`] = `
       "nagle",
     ],
   },
+  "short": "nagl",
   "singular": {
     "acc": [
       "naglogo / nagly",
@@ -23552,6 +23884,7 @@ exports[`adjective 2770 1`] = `
       "najlěpše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najlěpšego / najlěpši",
@@ -23621,6 +23954,7 @@ exports[`adjective 2779 1`] = `
       "nastojęće",
     ],
   },
+  "short": "nastojęć",
   "singular": {
     "acc": [
       "nastojęćego / nastojęći",
@@ -23690,6 +24024,7 @@ exports[`adjective 2798 1`] = `
       "obrędne",
     ],
   },
+  "short": "obrędėn",
   "singular": {
     "acc": [
       "obrędnogo / obrędny",
@@ -23759,6 +24094,7 @@ exports[`adjective 2804 1`] = `
       "nove",
     ],
   },
+  "short": "nov",
   "singular": {
     "acc": [
       "novogo / novy",
@@ -23828,6 +24164,7 @@ exports[`adjective 2825 1`] = `
       "palestinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "palestinskogo / palestinsky",
@@ -23897,6 +24234,7 @@ exports[`adjective 2831 1`] = `
       "osnovne",
     ],
   },
+  "short": "osnovėn",
   "singular": {
     "acc": [
       "osnovnogo / osnovny",
@@ -23966,6 +24304,7 @@ exports[`adjective 2843 1`] = `
       "polabske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "polabskogo / polabsky",
@@ -24035,6 +24374,7 @@ exports[`adjective 2850 1`] = `
       "anglijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "anglijskogo / anglijsky",
@@ -24104,6 +24444,7 @@ exports[`adjective 2859 1`] = `
       "intensivne",
     ],
   },
+  "short": "intensivėn",
   "singular": {
     "acc": [
       "intensivnogo / intensivny",
@@ -24173,6 +24514,7 @@ exports[`adjective 2861 1`] = `
       "davne",
     ],
   },
+  "short": "davėn",
   "singular": {
     "acc": [
       "davnogo / davny",
@@ -24242,6 +24584,7 @@ exports[`adjective 2864 1`] = `
       "bělorusske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bělorusskogo / bělorussky",
@@ -24311,6 +24654,7 @@ exports[`adjective 2866 1`] = `
       "makedonske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "makedonskogo / makedonsky",
@@ -24380,6 +24724,7 @@ exports[`adjective 2870 1`] = `
       "meksikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "meksikanskogo / meksikansky",
@@ -24449,6 +24794,7 @@ exports[`adjective 2882 1`] = `
       "dvustrånne",
     ],
   },
+  "short": "dvustrånėn",
   "singular": {
     "acc": [
       "dvustrånnogo / dvustrånny",
@@ -24518,6 +24864,7 @@ exports[`adjective 2889 1`] = `
       "konservativne",
     ],
   },
+  "short": "konservativėn",
   "singular": {
     "acc": [
       "konservativnogo / konservativny",
@@ -24587,6 +24934,7 @@ exports[`adjective 2894 1`] = `
       "zatvorjene",
     ],
   },
+  "short": "zatvorjen",
   "singular": {
     "acc": [
       "zatvorjenogo / zatvorjeny",
@@ -24656,6 +25004,7 @@ exports[`adjective 2903 1`] = `
       "zaslužene",
     ],
   },
+  "short": "zaslužen",
   "singular": {
     "acc": [
       "zasluženogo / zasluženy",
@@ -24725,6 +25074,7 @@ exports[`adjective 2906 1`] = `
       "pasažerske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pasažerskogo / pasažersky",
@@ -24794,6 +25144,7 @@ exports[`adjective 2916 1`] = `
       "minimaľne",
     ],
   },
+  "short": "minimaľėn",
   "singular": {
     "acc": [
       "minimaľnogo / minimaľny",
@@ -24863,6 +25214,7 @@ exports[`adjective 2935 1`] = `
       "poljske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "poljskogo / poljsky",
@@ -24932,6 +25284,7 @@ exports[`adjective 2938 1`] = `
       "osnovateljne",
     ],
   },
+  "short": "osnovateljėn",
   "singular": {
     "acc": [
       "osnovateljnogo / osnovateljny",
@@ -25001,6 +25354,7 @@ exports[`adjective 2941 1`] = `
       "slěpe",
     ],
   },
+  "short": "slěp",
   "singular": {
     "acc": [
       "slěpogo / slěpy",
@@ -25070,6 +25424,7 @@ exports[`adjective 2957 1`] = `
       "tajne",
     ],
   },
+  "short": "tajėn",
   "singular": {
     "acc": [
       "tajnogo / tajny",
@@ -25139,6 +25494,7 @@ exports[`adjective 2973 1`] = `
       "regionaľne",
     ],
   },
+  "short": "regionaľėn",
   "singular": {
     "acc": [
       "regionaľnogo / regionaľny",
@@ -25208,6 +25564,7 @@ exports[`adjective 2985 1`] = `
       "katoličske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "katoličskogo / katoličsky",
@@ -25277,6 +25634,7 @@ exports[`adjective 2993 1`] = `
       "byvše",
     ],
   },
+  "short": "byvš",
   "singular": {
     "acc": [
       "byvšego / byvši",
@@ -25346,6 +25704,7 @@ exports[`adjective 2996 1`] = `
       "poveliteljne",
     ],
   },
+  "short": "poveliteljėn",
   "singular": {
     "acc": [
       "poveliteljnogo / poveliteljny",
@@ -25415,6 +25774,7 @@ exports[`adjective 3013 1`] = `
       "federaľne",
     ],
   },
+  "short": "federaľėn",
   "singular": {
     "acc": [
       "federaľnogo / federaľny",
@@ -25484,6 +25844,7 @@ exports[`adjective 3014 1`] = `
       "prizemne",
     ],
   },
+  "short": "prizemėn",
   "singular": {
     "acc": [
       "prizemnogo / prizemny",
@@ -25553,6 +25914,7 @@ exports[`adjective 3027 1`] = `
       "fizične",
     ],
   },
+  "short": "fizičėn",
   "singular": {
     "acc": [
       "fizičnogo / fizičny",
@@ -25619,6 +25981,7 @@ exports[`adjective 3032 1`] = `
       "daljše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "daljšego / daljši",
@@ -25688,6 +26051,7 @@ exports[`adjective 3036 1`] = `
       "rosijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "rosijskogo / rosijsky",
@@ -25757,6 +26121,7 @@ exports[`adjective 3040 1`] = `
       "nastųpajųće",
     ],
   },
+  "short": "nastųpajųć",
   "singular": {
     "acc": [
       "nastųpajųćego / nastųpajųći",
@@ -25826,6 +26191,7 @@ exports[`adjective 3050 1`] = `
       "prigodne",
     ],
   },
+  "short": "prigodėn",
   "singular": {
     "acc": [
       "prigodnogo / prigodny",
@@ -25895,6 +26261,7 @@ exports[`adjective 3051 1`] = `
       "dȯlge",
     ],
   },
+  "short": "dȯlg",
   "singular": {
     "acc": [
       "dȯlgogo / dȯlgy",
@@ -25964,6 +26331,7 @@ exports[`adjective 3054 1`] = `
       "dostųpne",
     ],
   },
+  "short": "dostųpėn",
   "singular": {
     "acc": [
       "dostųpnogo / dostųpny",
@@ -26033,6 +26401,7 @@ exports[`adjective 3057 1`] = `
       "dostojne",
     ],
   },
+  "short": "dostojėn",
   "singular": {
     "acc": [
       "dostojnogo / dostojny",
@@ -26102,6 +26471,7 @@ exports[`adjective 3059 1`] = `
       "nezgrabne",
     ],
   },
+  "short": "nezgrabėn",
   "singular": {
     "acc": [
       "nezgrabnogo / nezgrabny",
@@ -26171,6 +26541,7 @@ exports[`adjective 3062 1`] = `
       "opačne",
     ],
   },
+  "short": "opačėn",
   "singular": {
     "acc": [
       "opačnogo / opačny",
@@ -26240,6 +26611,7 @@ exports[`adjective 3072 1`] = `
       "universaľne",
     ],
   },
+  "short": "universaľėn",
   "singular": {
     "acc": [
       "universaľnogo / universaľny",
@@ -26309,6 +26681,7 @@ exports[`adjective 3080 1`] = `
       "skeptične",
     ],
   },
+  "short": "skeptičėn",
   "singular": {
     "acc": [
       "skeptičnogo / skeptičny",
@@ -26378,6 +26751,7 @@ exports[`adjective 3088 1`] = `
       "pravoslavne",
     ],
   },
+  "short": "pravoslavėn",
   "singular": {
     "acc": [
       "pravoslavnogo / pravoslavny",
@@ -26447,6 +26821,7 @@ exports[`adjective 3089 1`] = `
       "zle",
     ],
   },
+  "short": "zȯl",
   "singular": {
     "acc": [
       "zlogo / zly",
@@ -26516,6 +26891,7 @@ exports[`adjective 3093 1`] = `
       "trudne",
     ],
   },
+  "short": "trudėn",
   "singular": {
     "acc": [
       "trudnogo / trudny",
@@ -26585,6 +26961,7 @@ exports[`adjective 3099 1`] = `
       "take",
     ],
   },
+  "short": "tak",
   "singular": {
     "acc": [
       "takogo / taky",
@@ -26654,6 +27031,7 @@ exports[`adjective 3124 1`] = `
       "tehnične",
     ],
   },
+  "short": "tehničėn",
   "singular": {
     "acc": [
       "tehničnogo / tehničny",
@@ -26723,6 +27101,7 @@ exports[`adjective 3138 1`] = `
       "simbolične",
     ],
   },
+  "short": "simboličėn",
   "singular": {
     "acc": [
       "simboličnogo / simboličny",
@@ -26792,6 +27171,7 @@ exports[`adjective 3141 1`] = `
       "pȯlne",
     ],
   },
+  "short": "pȯln",
   "singular": {
     "acc": [
       "pȯlnogo / pȯlny",
@@ -26861,6 +27241,7 @@ exports[`adjective 3146 1`] = `
       "praktične",
     ],
   },
+  "short": "praktičėn",
   "singular": {
     "acc": [
       "praktičnogo / praktičny",
@@ -26930,6 +27311,7 @@ exports[`adjective 3167 1`] = `
       "sŕdečne",
     ],
   },
+  "short": "sŕdečėn",
   "singular": {
     "acc": [
       "sŕdečnogo / sŕdečny",
@@ -26999,6 +27381,7 @@ exports[`adjective 3183 1`] = `
       "grėčske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "grėčskogo / grėčsky",
@@ -27068,6 +27451,7 @@ exports[`adjective 3201 1`] = `
       "ostavjene",
     ],
   },
+  "short": "ostavjen",
   "singular": {
     "acc": [
       "ostavjenogo / ostavjeny",
@@ -27137,6 +27521,7 @@ exports[`adjective 3225 1`] = `
       "ljubezne",
     ],
   },
+  "short": "ljubezėn",
   "singular": {
     "acc": [
       "ljubeznogo / ljubezny",
@@ -27206,6 +27591,7 @@ exports[`adjective 3226 1`] = `
       "laskave",
     ],
   },
+  "short": "laskav",
   "singular": {
     "acc": [
       "laskavogo / laskavy",
@@ -27275,6 +27661,7 @@ exports[`adjective 3264 1`] = `
       "psihopatične",
     ],
   },
+  "short": "psihopatičėn",
   "singular": {
     "acc": [
       "psihopatičnogo / psihopatičny",
@@ -27344,6 +27731,7 @@ exports[`adjective 3267 1`] = `
       "separatistične",
     ],
   },
+  "short": "separatističėn",
   "singular": {
     "acc": [
       "separatističnogo / separatističny",
@@ -27407,6 +27795,7 @@ exports[`adjective 3280 1`] = `
       "najlučše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najlučšego / najlučši",
@@ -27470,6 +27859,7 @@ exports[`adjective 3281 1`] = `
       "najzle",
     ],
   },
+  "short": "najzȯl",
   "singular": {
     "acc": [
       "najzlogo / najzly",
@@ -27539,6 +27929,7 @@ exports[`adjective 3287 1`] = `
       "blizke",
     ],
   },
+  "short": "blizȯk",
   "singular": {
     "acc": [
       "blizkogo / blizky",
@@ -27608,6 +27999,7 @@ exports[`adjective 3297 1`] = `
       "ostatne",
     ],
   },
+  "short": "ostatėn",
   "singular": {
     "acc": [
       "ostatnogo / ostatny",
@@ -27677,6 +28069,7 @@ exports[`adjective 3307 1`] = `
       "pravdive",
     ],
   },
+  "short": "pravdiv",
   "singular": {
     "acc": [
       "pravdivogo / pravdivy",
@@ -27746,6 +28139,7 @@ exports[`adjective 3308 1`] = `
       "věrne",
     ],
   },
+  "short": "věrėn",
   "singular": {
     "acc": [
       "věrnogo / věrny",
@@ -27815,6 +28209,7 @@ exports[`adjective 3309 1`] = `
       "istinne",
     ],
   },
+  "short": "istinėn",
   "singular": {
     "acc": [
       "istinnogo / istinny",
@@ -27884,6 +28279,7 @@ exports[`adjective 3311 1`] = `
       "råzsųdne",
     ],
   },
+  "short": "råzsųdėn",
   "singular": {
     "acc": [
       "råzsųdnogo / råzsųdny",
@@ -27953,6 +28349,7 @@ exports[`adjective 3314 1`] = `
       "prijatne",
     ],
   },
+  "short": "prijatėn",
   "singular": {
     "acc": [
       "prijatnogo / prijatny",
@@ -28022,6 +28419,7 @@ exports[`adjective 3315 1`] = `
       "lěpe",
     ],
   },
+  "short": "lěp",
   "singular": {
     "acc": [
       "lěpogo / lěpy",
@@ -28091,6 +28489,7 @@ exports[`adjective 3336 1`] = `
       "možne",
     ],
   },
+  "short": "možėn",
   "singular": {
     "acc": [
       "možnogo / možny",
@@ -28160,6 +28559,7 @@ exports[`adjective 3345 1`] = `
       "nikake",
     ],
   },
+  "short": "nikak",
   "singular": {
     "acc": [
       "nikakogo / nikaky",
@@ -28229,6 +28629,7 @@ exports[`adjective 3364 1`] = `
       "nepraviľne",
     ],
   },
+  "short": "nepraviľėn",
   "singular": {
     "acc": [
       "nepraviľnogo / nepraviľny",
@@ -28298,6 +28699,7 @@ exports[`adjective 3386 1`] = `
       "neščęstne",
     ],
   },
+  "short": "neščęstėn",
   "singular": {
     "acc": [
       "neščęstnogo / neščęstny",
@@ -28367,6 +28769,7 @@ exports[`adjective 3389 1`] = `
       "žalostne",
     ],
   },
+  "short": "žalostėn",
   "singular": {
     "acc": [
       "žalostnogo / žalostny",
@@ -28436,6 +28839,7 @@ exports[`adjective 3393 1`] = `
       "spolȯčne",
     ],
   },
+  "short": "spolȯčėn",
   "singular": {
     "acc": [
       "spolȯčnogo / spolȯčny",
@@ -28505,6 +28909,7 @@ exports[`adjective 3401 1`] = `
       "oženjene",
     ],
   },
+  "short": "oženjen",
   "singular": {
     "acc": [
       "oženjenogo / oženjeny",
@@ -28574,6 +28979,7 @@ exports[`adjective 3404 1`] = `
       "omųžene",
     ],
   },
+  "short": "omųžen",
   "singular": {
     "acc": [
       "omųženogo / omųženy",
@@ -28643,6 +29049,7 @@ exports[`adjective 3405 1`] = `
       "věrojętne",
     ],
   },
+  "short": "věrojętėn",
   "singular": {
     "acc": [
       "věrojętnogo / věrojętny",
@@ -28712,6 +29119,7 @@ exports[`adjective 3409 1`] = `
       "naturaľne",
     ],
   },
+  "short": "naturaľėn",
   "singular": {
     "acc": [
       "naturaľnogo / naturaľny",
@@ -28781,6 +29189,7 @@ exports[`adjective 3411 1`] = `
       "naturalistične",
     ],
   },
+  "short": "naturalističėn",
   "singular": {
     "acc": [
       "naturalističnogo / naturalističny",
@@ -28850,6 +29259,7 @@ exports[`adjective 3420 1`] = `
       "odvažne",
     ],
   },
+  "short": "odvažėn",
   "singular": {
     "acc": [
       "odvažnogo / odvažny",
@@ -28919,6 +29329,7 @@ exports[`adjective 3423 1`] = `
       "aeronavtične",
     ],
   },
+  "short": "aeronavtičėn",
   "singular": {
     "acc": [
       "aeronavtičnogo / aeronavtičny",
@@ -28988,6 +29399,7 @@ exports[`adjective 3433 1`] = `
       "gněvne",
     ],
   },
+  "short": "gněvėn",
   "singular": {
     "acc": [
       "gněvnogo / gněvny",
@@ -29057,6 +29469,7 @@ exports[`adjective 3446 1`] = `
       "loše",
     ],
   },
+  "short": "loš",
   "singular": {
     "acc": [
       "lošego / loši",
@@ -29126,6 +29539,7 @@ exports[`adjective 3462 1`] = `
       "slomjene",
     ],
   },
+  "short": "slomjen",
   "singular": {
     "acc": [
       "slomjenogo / slomjeny",
@@ -29195,6 +29609,7 @@ exports[`adjective 3473 1`] = `
       "råzbite",
     ],
   },
+  "short": "råzbit",
   "singular": {
     "acc": [
       "råzbitogo / råzbity",
@@ -29264,6 +29679,7 @@ exports[`adjective 3478 1`] = `
       "ostråžne",
     ],
   },
+  "short": "ostråžėn",
   "singular": {
     "acc": [
       "ostråžnogo / ostråžny",
@@ -29333,6 +29749,7 @@ exports[`adjective 3493 1`] = `
       "bezpričinne",
     ],
   },
+  "short": "bezpričinėn",
   "singular": {
     "acc": [
       "bezpričinnogo / bezpričinny",
@@ -29402,6 +29819,7 @@ exports[`adjective 3512 1`] = `
       "svęzane",
     ],
   },
+  "short": "svęzan",
   "singular": {
     "acc": [
       "svęzanogo / svęzany",
@@ -29471,6 +29889,7 @@ exports[`adjective 3515 1`] = `
       "prězrave",
     ],
   },
+  "short": "prězrav",
   "singular": {
     "acc": [
       "prězravogo / prězravy",
@@ -29540,6 +29959,7 @@ exports[`adjective 3531 1`] = `
       "divne",
     ],
   },
+  "short": "divėn",
   "singular": {
     "acc": [
       "divnogo / divny",
@@ -29609,6 +30029,7 @@ exports[`adjective 3532 1`] = `
       "sejčasne",
     ],
   },
+  "short": "sejčasėn",
   "singular": {
     "acc": [
       "sejčasnogo / sejčasny",
@@ -29678,6 +30099,7 @@ exports[`adjective 3541 1`] = `
       "hvore",
     ],
   },
+  "short": "hvor",
   "singular": {
     "acc": [
       "hvorogo / hvory",
@@ -29747,6 +30169,7 @@ exports[`adjective 3549 1`] = `
       "nebezpečne",
     ],
   },
+  "short": "nebezpečėn",
   "singular": {
     "acc": [
       "nebezpečnogo / nebezpečny",
@@ -29816,6 +30239,7 @@ exports[`adjective 3556 1`] = `
       "nečiste",
     ],
   },
+  "short": "nečist",
   "singular": {
     "acc": [
       "nečistogo / nečisty",
@@ -29885,6 +30309,7 @@ exports[`adjective 3561 1`] = `
       "mŕzke",
     ],
   },
+  "short": "mŕzȯk",
   "singular": {
     "acc": [
       "mŕzkogo / mŕzky",
@@ -29954,6 +30379,7 @@ exports[`adjective 3573 1`] = `
       "dȯlžne",
     ],
   },
+  "short": "dȯlžėn",
   "singular": {
     "acc": [
       "dȯlžnogo / dȯlžny",
@@ -30023,6 +30449,7 @@ exports[`adjective 3575 1`] = `
       "prědvrěmenne",
     ],
   },
+  "short": "prědvrěmenėn",
   "singular": {
     "acc": [
       "prědvrěmennogo / prědvrěmenny",
@@ -30092,6 +30519,7 @@ exports[`adjective 3581 1`] = `
       "starějše",
     ],
   },
+  "short": "starějš",
   "singular": {
     "acc": [
       "starějšego / starějši",
@@ -30161,6 +30589,7 @@ exports[`adjective 3581-1 1`] = `
       "starše",
     ],
   },
+  "short": "starš",
   "singular": {
     "acc": [
       "staršego / starši",
@@ -30230,6 +30659,7 @@ exports[`adjective 3593 1`] = `
       "točne",
     ],
   },
+  "short": "točėn",
   "singular": {
     "acc": [
       "točnogo / točny",
@@ -30299,6 +30729,7 @@ exports[`adjective 3599 1`] = `
       "izmųčene",
     ],
   },
+  "short": "izmųčen",
   "singular": {
     "acc": [
       "izmųčenogo / izmųčeny",
@@ -30368,6 +30799,7 @@ exports[`adjective 3607 1`] = `
       "izkušene",
     ],
   },
+  "short": "izkušen",
   "singular": {
     "acc": [
       "izkušenogo / izkušeny",
@@ -30437,6 +30869,7 @@ exports[`adjective 3610 1`] = `
       "izmysljene",
     ],
   },
+  "short": "izmysljen",
   "singular": {
     "acc": [
       "izmysljenogo / izmysljeny",
@@ -30506,6 +30939,7 @@ exports[`adjective 3631 1`] = `
       "prinuđene",
     ],
   },
+  "short": "prinuđen",
   "singular": {
     "acc": [
       "prinuđenogo / prinuđeny",
@@ -30575,6 +31009,7 @@ exports[`adjective 3632 1`] = `
       "lěsne",
     ],
   },
+  "short": "lěsėn",
   "singular": {
     "acc": [
       "lěsnogo / lěsny",
@@ -30644,6 +31079,7 @@ exports[`adjective 3639 1`] = `
       "prědnje",
     ],
   },
+  "short": "prědėn",
   "singular": {
     "acc": [
       "prědnjego / prědnji",
@@ -30713,6 +31149,7 @@ exports[`adjective 3639-1 1`] = `
       "prědne",
     ],
   },
+  "short": "prědėn",
   "singular": {
     "acc": [
       "prědnogo / prědny",
@@ -30782,6 +31219,7 @@ exports[`adjective 3666 1`] = `
       "goręće",
     ],
   },
+  "short": "goręć",
   "singular": {
     "acc": [
       "goręćego / goręći",
@@ -30851,6 +31289,7 @@ exports[`adjective 3679 1`] = `
       "nezakonne",
     ],
   },
+  "short": "nezakonėn",
   "singular": {
     "acc": [
       "nezakonnogo / nezakonny",
@@ -30920,6 +31359,7 @@ exports[`adjective 3682 1`] = `
       "netočne",
     ],
   },
+  "short": "netočėn",
   "singular": {
     "acc": [
       "netočnogo / netočny",
@@ -30989,6 +31429,7 @@ exports[`adjective 3711 1`] = `
       "pravne",
     ],
   },
+  "short": "pravėn",
   "singular": {
     "acc": [
       "pravnogo / pravny",
@@ -31058,6 +31499,7 @@ exports[`adjective 3717 1`] = `
       "zakonodateljne",
     ],
   },
+  "short": "zakonodateljėn",
   "singular": {
     "acc": [
       "zakonodateljnogo / zakonodateljny",
@@ -31127,6 +31569,7 @@ exports[`adjective 3719 1`] = `
       "dožitne",
     ],
   },
+  "short": "dožitėn",
   "singular": {
     "acc": [
       "dožitnogo / dožitny",
@@ -31196,6 +31639,7 @@ exports[`adjective 3724 1`] = `
       "obmeđene",
     ],
   },
+  "short": "obmeđen",
   "singular": {
     "acc": [
       "obmeđenogo / obmeđeny",
@@ -31265,6 +31709,7 @@ exports[`adjective 3728 1`] = `
       "městne",
     ],
   },
+  "short": "městėn",
   "singular": {
     "acc": [
       "městnogo / městny",
@@ -31334,6 +31779,7 @@ exports[`adjective 3765 1`] = `
       "zemne",
     ],
   },
+  "short": "zemėn",
   "singular": {
     "acc": [
       "zemnogo / zemny",
@@ -31403,6 +31849,7 @@ exports[`adjective 3766 1`] = `
       "oplačene",
     ],
   },
+  "short": "oplačen",
   "singular": {
     "acc": [
       "oplačenogo / oplačeny",
@@ -31472,6 +31919,7 @@ exports[`adjective 3769 1`] = `
       "prilične",
     ],
   },
+  "short": "priličėn",
   "singular": {
     "acc": [
       "priličnogo / priličny",
@@ -31541,6 +31989,7 @@ exports[`adjective 3774 1`] = `
       "prijemne",
     ],
   },
+  "short": "prijemėn",
   "singular": {
     "acc": [
       "prijemnogo / prijemny",
@@ -31610,6 +32059,7 @@ exports[`adjective 3778 1`] = `
       "upȯlnomoćene",
     ],
   },
+  "short": "upȯlnomoćen",
   "singular": {
     "acc": [
       "upȯlnomoćenogo / upȯlnomoćeny",
@@ -31679,6 +32129,7 @@ exports[`adjective 3782 1`] = `
       "naseljene",
     ],
   },
+  "short": "naseljen",
   "singular": {
     "acc": [
       "naseljenogo / naseljeny",
@@ -31748,6 +32199,7 @@ exports[`adjective 3790 1`] = `
       "krasne",
     ],
   },
+  "short": "krasėn",
   "singular": {
     "acc": [
       "krasnogo / krasny",
@@ -31817,6 +32269,7 @@ exports[`adjective 3828 1`] = `
       "rđave",
     ],
   },
+  "short": "rđav",
   "singular": {
     "acc": [
       "rđavogo / rđavy",
@@ -31886,6 +32339,7 @@ exports[`adjective 3834 1`] = `
       "utomljene",
     ],
   },
+  "short": "utomljen",
   "singular": {
     "acc": [
       "utomljenogo / utomljeny",
@@ -31949,6 +32403,7 @@ exports[`adjective 3841 1`] = `
       "najnovějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najnovějšego / najnovějši",
@@ -32018,6 +32473,7 @@ exports[`adjective 3851 1`] = `
       "jednočasne",
     ],
   },
+  "short": "jednočasėn",
   "singular": {
     "acc": [
       "jednočasnogo / jednočasny",
@@ -32087,6 +32543,7 @@ exports[`adjective 3864 1`] = `
       "ohotne",
     ],
   },
+  "short": "ohotėn",
   "singular": {
     "acc": [
       "ohotnogo / ohotny",
@@ -32156,6 +32613,7 @@ exports[`adjective 3880 1`] = `
       "sekretne",
     ],
   },
+  "short": "sekretėn",
   "singular": {
     "acc": [
       "sekretnogo / sekretny",
@@ -32225,6 +32683,7 @@ exports[`adjective 3884 1`] = `
       "škoľne",
     ],
   },
+  "short": "škoľėn",
   "singular": {
     "acc": [
       "škoľnogo / škoľny",
@@ -32294,6 +32753,7 @@ exports[`adjective 3887 1`] = `
       "sȯlnečne",
     ],
   },
+  "short": "sȯlnečėn",
   "singular": {
     "acc": [
       "sȯlnečnogo / sȯlnečny",
@@ -32363,6 +32823,7 @@ exports[`adjective 3899 1`] = `
       "treningove",
     ],
   },
+  "short": "treningov",
   "singular": {
     "acc": [
       "treningovogo / treningovy",
@@ -32432,6 +32893,7 @@ exports[`adjective 3911 1`] = `
       "uspěšne",
     ],
   },
+  "short": "uspěšėn",
   "singular": {
     "acc": [
       "uspěšnogo / uspěšny",
@@ -32501,6 +32963,7 @@ exports[`adjective 3940 1`] = `
       "želězne",
     ],
   },
+  "short": "želězėn",
   "singular": {
     "acc": [
       "želěznogo / želězny",
@@ -32570,6 +33033,7 @@ exports[`adjective 3941 1`] = `
       "srěbrne",
     ],
   },
+  "short": "srěbrėn",
   "singular": {
     "acc": [
       "srěbrnogo / srěbrny",
@@ -32639,6 +33103,7 @@ exports[`adjective 3943 1`] = `
       "slučajne",
     ],
   },
+  "short": "slučajėn",
   "singular": {
     "acc": [
       "slučajnogo / slučajny",
@@ -32708,6 +33173,7 @@ exports[`adjective 3949 1`] = `
       "anonimne",
     ],
   },
+  "short": "anonimėn",
   "singular": {
     "acc": [
       "anonimnogo / anonimny",
@@ -32777,6 +33243,7 @@ exports[`adjective 3959 1`] = `
       "fantastične",
     ],
   },
+  "short": "fantastičėn",
   "singular": {
     "acc": [
       "fantastičnogo / fantastičny",
@@ -32846,6 +33313,7 @@ exports[`adjective 3961 1`] = `
       "očevidne",
     ],
   },
+  "short": "očevidėn",
   "singular": {
     "acc": [
       "očevidnogo / očevidny",
@@ -32915,6 +33383,7 @@ exports[`adjective 3968 1`] = `
       "alfabetične",
     ],
   },
+  "short": "alfabetičėn",
   "singular": {
     "acc": [
       "alfabetičnogo / alfabetičny",
@@ -32984,6 +33453,7 @@ exports[`adjective 3971 1`] = `
       "bezbarvne",
     ],
   },
+  "short": "bezbarvėn",
   "singular": {
     "acc": [
       "bezbarvnogo / bezbarvny",
@@ -33053,6 +33523,7 @@ exports[`adjective 3972 1`] = `
       "betonne",
     ],
   },
+  "short": "betonėn",
   "singular": {
     "acc": [
       "betonnogo / betonny",
@@ -33122,6 +33593,7 @@ exports[`adjective 3976 1`] = `
       "biologične",
     ],
   },
+  "short": "biologičėn",
   "singular": {
     "acc": [
       "biologičnogo / biologičny",
@@ -33191,6 +33663,7 @@ exports[`adjective 3979 1`] = `
       "bjurokratične",
     ],
   },
+  "short": "bjurokratičėn",
   "singular": {
     "acc": [
       "bjurokratičnogo / bjurokratičny",
@@ -33260,6 +33733,7 @@ exports[`adjective 3981 1`] = `
       "bočne",
     ],
   },
+  "short": "bočėn",
   "singular": {
     "acc": [
       "bočnogo / bočny",
@@ -33329,6 +33803,7 @@ exports[`adjective 3990 1`] = `
       "odděľne",
     ],
   },
+  "short": "odděľėn",
   "singular": {
     "acc": [
       "odděľnogo / odděľny",
@@ -33398,6 +33873,7 @@ exports[`adjective 3997 1`] = `
       "naučne",
     ],
   },
+  "short": "naučėn",
   "singular": {
     "acc": [
       "naučnogo / naučny",
@@ -33467,6 +33943,7 @@ exports[`adjective 4047 1`] = `
       "krěpke",
     ],
   },
+  "short": "krěpȯk",
   "singular": {
     "acc": [
       "krěpkogo / krěpky",
@@ -33536,6 +34013,7 @@ exports[`adjective 4056 1`] = `
       "směle",
     ],
   },
+  "short": "směl",
   "singular": {
     "acc": [
       "smělogo / směly",
@@ -33605,6 +34083,7 @@ exports[`adjective 4060 1`] = `
       "ranše",
     ],
   },
+  "short": "ranš",
   "singular": {
     "acc": [
       "ranšego / ranši",
@@ -33674,6 +34153,7 @@ exports[`adjective 4062 1`] = `
       "neodpovědaľne",
     ],
   },
+  "short": "neodpovědaľėn",
   "singular": {
     "acc": [
       "neodpovědaľnogo / neodpovědaľny",
@@ -33743,6 +34223,7 @@ exports[`adjective 4078 1`] = `
       "revolucijne",
     ],
   },
+  "short": "revolucijėn",
   "singular": {
     "acc": [
       "revolucijnogo / revolucijny",
@@ -33812,6 +34293,7 @@ exports[`adjective 4103 1`] = `
       "nenormaľne",
     ],
   },
+  "short": "nenormaľėn",
   "singular": {
     "acc": [
       "nenormaľnogo / nenormaľny",
@@ -33881,6 +34363,7 @@ exports[`adjective 4115 1`] = `
       "dozrěle",
     ],
   },
+  "short": "dozrěl",
   "singular": {
     "acc": [
       "dozrělogo / dozrěly",
@@ -33950,6 +34433,7 @@ exports[`adjective 4116 1`] = `
       "měsęčne",
     ],
   },
+  "short": "měsęčėn",
   "singular": {
     "acc": [
       "měsęčnogo / měsęčny",
@@ -34019,6 +34503,7 @@ exports[`adjective 4118 1`] = `
       "monumentaľne",
     ],
   },
+  "short": "monumentaľėn",
   "singular": {
     "acc": [
       "monumentaľnogo / monumentaľny",
@@ -34088,6 +34573,7 @@ exports[`adjective 4127 1`] = `
       "voljne",
     ],
   },
+  "short": "voljėn",
   "singular": {
     "acc": [
       "voljnogo / voljny",
@@ -34157,6 +34643,7 @@ exports[`adjective 4128 1`] = `
       "prijateljske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "prijateljskogo / prijateljsky",
@@ -34226,6 +34713,7 @@ exports[`adjective 4135 1`] = `
       "mgliste",
     ],
   },
+  "short": "mglist",
   "singular": {
     "acc": [
       "mglistogo / mglisty",
@@ -34295,6 +34783,7 @@ exports[`adjective 4143 1`] = `
       "cělkovite",
     ],
   },
+  "short": "cělkovit",
   "singular": {
     "acc": [
       "cělkovitogo / cělkovity",
@@ -34364,6 +34853,7 @@ exports[`adjective 4159 1`] = `
       "kontrabandne",
     ],
   },
+  "short": "kontrabandėn",
   "singular": {
     "acc": [
       "kontrabandnogo / kontrabandny",
@@ -34433,6 +34923,7 @@ exports[`adjective 4164 1`] = `
       "čutlive",
     ],
   },
+  "short": "čutliv",
   "singular": {
     "acc": [
       "čutlivogo / čutlivy",
@@ -34502,6 +34993,7 @@ exports[`adjective 4167 1`] = `
       "råzumne",
     ],
   },
+  "short": "råzumėn",
   "singular": {
     "acc": [
       "råzumnogo / råzumny",
@@ -34571,6 +35063,7 @@ exports[`adjective 4172 1`] = `
       "analitične",
     ],
   },
+  "short": "analitičėn",
   "singular": {
     "acc": [
       "analitičnogo / analitičny",
@@ -34640,6 +35133,7 @@ exports[`adjective 4181 1`] = `
       "pitne",
     ],
   },
+  "short": "pitėn",
   "singular": {
     "acc": [
       "pitnogo / pitny",
@@ -34709,6 +35203,7 @@ exports[`adjective 4182 1`] = `
       "sěverne",
     ],
   },
+  "short": "sěverėn",
   "singular": {
     "acc": [
       "sěvernogo / sěverny",
@@ -34778,6 +35273,7 @@ exports[`adjective 4184 1`] = `
       "vȯzhodne",
     ],
   },
+  "short": "vȯzhodėn",
   "singular": {
     "acc": [
       "vȯzhodnogo / vȯzhodny",
@@ -34847,6 +35343,7 @@ exports[`adjective 4206 1`] = `
       "protivpožarne",
     ],
   },
+  "short": "protivpožarėn",
   "singular": {
     "acc": [
       "protivpožarnogo / protivpožarny",
@@ -34916,6 +35413,7 @@ exports[`adjective 4207 1`] = `
       "doskonale",
     ],
   },
+  "short": "doskonal",
   "singular": {
     "acc": [
       "doskonalogo / doskonaly",
@@ -34985,6 +35483,7 @@ exports[`adjective 4212 1`] = `
       "bezusiľne",
     ],
   },
+  "short": "bezusiľėn",
   "singular": {
     "acc": [
       "bezusiľnogo / bezusiľny",
@@ -35054,6 +35553,7 @@ exports[`adjective 4223 1`] = `
       "unižajųće",
     ],
   },
+  "short": "unižajųć",
   "singular": {
     "acc": [
       "unižajųćego / unižajųći",
@@ -35123,6 +35623,7 @@ exports[`adjective 4235 1`] = `
       "odporne",
     ],
   },
+  "short": "odporėn",
   "singular": {
     "acc": [
       "odpornogo / odporny",
@@ -35192,6 +35693,7 @@ exports[`adjective 4236 1`] = `
       "ognjeodporne",
     ],
   },
+  "short": "ognjeodporėn",
   "singular": {
     "acc": [
       "ognjeodpornogo / ognjeodporny",
@@ -35261,6 +35763,7 @@ exports[`adjective 4238 1`] = `
       "velžne",
     ],
   },
+  "short": "velžėn",
   "singular": {
     "acc": [
       "velžnogo / velžny",
@@ -35330,6 +35833,7 @@ exports[`adjective 4252 1`] = `
       "kaprizne",
     ],
   },
+  "short": "kaprizėn",
   "singular": {
     "acc": [
       "kapriznogo / kaprizny",
@@ -35399,6 +35903,7 @@ exports[`adjective 4260 1`] = `
       "trgove",
     ],
   },
+  "short": "trgov",
   "singular": {
     "acc": [
       "trgovogo / trgovy",
@@ -35468,6 +35973,7 @@ exports[`adjective 4272 1`] = `
       "gripove",
     ],
   },
+  "short": "gripov",
   "singular": {
     "acc": [
       "gripovogo / gripovy",
@@ -35537,6 +36043,7 @@ exports[`adjective 4285 1`] = `
       "zlobne",
     ],
   },
+  "short": "zlobėn",
   "singular": {
     "acc": [
       "zlobnogo / zlobny",
@@ -35606,6 +36113,7 @@ exports[`adjective 4287 1`] = `
       "svaťbene",
     ],
   },
+  "short": "svaťben",
   "singular": {
     "acc": [
       "svaťbenogo / svaťbeny",
@@ -35675,6 +36183,7 @@ exports[`adjective 4292 1`] = `
       "osobne",
     ],
   },
+  "short": "osobėn",
   "singular": {
     "acc": [
       "osobnogo / osobny",
@@ -35744,6 +36253,7 @@ exports[`adjective 4305 1`] = `
       "prědposlědnje",
     ],
   },
+  "short": "prědposlědėn",
   "singular": {
     "acc": [
       "prědposlědnjego / prědposlědnji",
@@ -35813,6 +36323,7 @@ exports[`adjective 4305-1 1`] = `
       "prědposlědne",
     ],
   },
+  "short": "prědposlědėn",
   "singular": {
     "acc": [
       "prědposlědnogo / prědposlědny",
@@ -35882,6 +36393,7 @@ exports[`adjective 4306 1`] = `
       "ljudske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ljudskogo / ljudsky",
@@ -35951,6 +36463,7 @@ exports[`adjective 4307 1`] = `
       "narodne",
     ],
   },
+  "short": "narodėn",
   "singular": {
     "acc": [
       "narodnogo / narodny",
@@ -36020,6 +36533,7 @@ exports[`adjective 4317 1`] = `
       "perversne",
     ],
   },
+  "short": "perversėn",
   "singular": {
     "acc": [
       "perversnogo / perversny",
@@ -36089,6 +36603,7 @@ exports[`adjective 4326 1`] = `
       "vśake",
     ],
   },
+  "short": "vśak",
   "singular": {
     "acc": [
       "vśakogo / vśaky",
@@ -36158,6 +36673,7 @@ exports[`adjective 4343 1`] = `
       "noćne",
     ],
   },
+  "short": "noćėn",
   "singular": {
     "acc": [
       "noćnogo / noćny",
@@ -36227,6 +36743,7 @@ exports[`adjective 4345 1`] = `
       "beznadějne",
     ],
   },
+  "short": "beznadějėn",
   "singular": {
     "acc": [
       "beznadějnogo / beznadějny",
@@ -36296,6 +36813,7 @@ exports[`adjective 4346 1`] = `
       "råzumějeme",
     ],
   },
+  "short": "råzumějem",
   "singular": {
     "acc": [
       "råzumějemogo / råzumějemy",
@@ -36365,6 +36883,7 @@ exports[`adjective 4359 1`] = `
       "avtomatične",
     ],
   },
+  "short": "avtomatičėn",
   "singular": {
     "acc": [
       "avtomatičnogo / avtomatičny",
@@ -36434,6 +36953,7 @@ exports[`adjective 4369 1`] = `
       "etimologične",
     ],
   },
+  "short": "etimologičėn",
   "singular": {
     "acc": [
       "etimologičnogo / etimologičny",
@@ -36503,6 +37023,7 @@ exports[`adjective 4373 1`] = `
       "potenciaľne",
     ],
   },
+  "short": "potenciaľėn",
   "singular": {
     "acc": [
       "potenciaľnogo / potenciaľny",
@@ -36572,6 +37093,7 @@ exports[`adjective 4376 1`] = `
       "vygodne",
     ],
   },
+  "short": "vygodėn",
   "singular": {
     "acc": [
       "vygodnogo / vygodny",
@@ -36641,6 +37163,7 @@ exports[`adjective 4377 1`] = `
       "kompletne",
     ],
   },
+  "short": "kompletėn",
   "singular": {
     "acc": [
       "kompletnogo / kompletny",
@@ -36710,6 +37233,7 @@ exports[`adjective 4382 1`] = `
       "arhaične",
     ],
   },
+  "short": "arhaičėn",
   "singular": {
     "acc": [
       "arhaičnogo / arhaičny",
@@ -36779,6 +37303,7 @@ exports[`adjective 4386 1`] = `
       "crkȯvnoslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "crkȯvnoslovjanskogo / crkȯvnoslovjansky",
@@ -36848,6 +37373,7 @@ exports[`adjective 4387 1`] = `
       "praslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "praslovjanskogo / praslovjansky",
@@ -36917,6 +37443,7 @@ exports[`adjective 4388 1`] = `
       "protivne",
     ],
   },
+  "short": "protivėn",
   "singular": {
     "acc": [
       "protivnogo / protivny",
@@ -36986,6 +37513,7 @@ exports[`adjective 4394 1`] = `
       "ortografične",
     ],
   },
+  "short": "ortografičėn",
   "singular": {
     "acc": [
       "ortografičnogo / ortografičny",
@@ -37055,6 +37583,7 @@ exports[`adjective 4398 1`] = `
       "fotografične",
     ],
   },
+  "short": "fotografičėn",
   "singular": {
     "acc": [
       "fotografičnogo / fotografičny",
@@ -37124,6 +37653,7 @@ exports[`adjective 4401 1`] = `
       "tragične",
     ],
   },
+  "short": "tragičėn",
   "singular": {
     "acc": [
       "tragičnogo / tragičny",
@@ -37193,6 +37723,7 @@ exports[`adjective 4403 1`] = `
       "komične",
     ],
   },
+  "short": "komičėn",
   "singular": {
     "acc": [
       "komičnogo / komičny",
@@ -37262,6 +37793,7 @@ exports[`adjective 4404 1`] = `
       "specifične",
     ],
   },
+  "short": "specifičėn",
   "singular": {
     "acc": [
       "specifičnogo / specifičny",
@@ -37331,6 +37863,7 @@ exports[`adjective 4412 1`] = `
       "trikųtne",
     ],
   },
+  "short": "trikųtėn",
   "singular": {
     "acc": [
       "trikųtnogo / trikųtny",
@@ -37400,6 +37933,7 @@ exports[`adjective 4414 1`] = `
       "prěmokųtne",
     ],
   },
+  "short": "prěmokųtėn",
   "singular": {
     "acc": [
       "prěmokųtnogo / prěmokųtny",
@@ -37469,6 +38003,7 @@ exports[`adjective 4416 1`] = `
       "kvadratne",
     ],
   },
+  "short": "kvadratėn",
   "singular": {
     "acc": [
       "kvadratnogo / kvadratny",
@@ -37538,6 +38073,7 @@ exports[`adjective 4420 1`] = `
       "arheologične",
     ],
   },
+  "short": "arheologičėn",
   "singular": {
     "acc": [
       "arheologičnogo / arheologičny",
@@ -37607,6 +38143,7 @@ exports[`adjective 4423 1`] = `
       "zapadnoslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "zapadnoslovjanskogo / zapadnoslovjansky",
@@ -37676,6 +38213,7 @@ exports[`adjective 4424 1`] = `
       "vȯzhodnoslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vȯzhodnoslovjanskogo / vȯzhodnoslovjansky",
@@ -37745,6 +38283,7 @@ exports[`adjective 4425 1`] = `
       "južnoslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "južnoslovjanskogo / južnoslovjansky",
@@ -37814,6 +38353,7 @@ exports[`adjective 4426 1`] = `
       "belgijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "belgijskogo / belgijsky",
@@ -37883,6 +38423,7 @@ exports[`adjective 4427 1`] = `
       "danske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "danskogo / dansky",
@@ -37952,6 +38493,7 @@ exports[`adjective 4429 1`] = `
       "norvežske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "norvežskogo / norvežsky",
@@ -38021,6 +38563,7 @@ exports[`adjective 4431 1`] = `
       "islandske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "islandskogo / islandsky",
@@ -38090,6 +38633,7 @@ exports[`adjective 4432 1`] = `
       "irlandske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "irlandskogo / irlandsky",
@@ -38159,6 +38703,7 @@ exports[`adjective 4433 1`] = `
       "rumunske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "rumunskogo / rumunsky",
@@ -38228,6 +38773,7 @@ exports[`adjective 4434 1`] = `
       "finske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "finskogo / finsky",
@@ -38297,6 +38843,7 @@ exports[`adjective 4435 1`] = `
       "estonske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "estonskogo / estonsky",
@@ -38366,6 +38913,7 @@ exports[`adjective 4436 1`] = `
       "jordanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "jordanskogo / jordansky",
@@ -38435,6 +38983,7 @@ exports[`adjective 4442 1`] = `
       "međuslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "međuslovjanskogo / međuslovjansky",
@@ -38504,6 +39053,7 @@ exports[`adjective 4444 1`] = `
       "električne",
     ],
   },
+  "short": "električėn",
   "singular": {
     "acc": [
       "električnogo / električny",
@@ -38573,6 +39123,7 @@ exports[`adjective 4445 1`] = `
       "elektronične",
     ],
   },
+  "short": "elektroničėn",
   "singular": {
     "acc": [
       "elektroničnogo / elektroničny",
@@ -38642,6 +39193,7 @@ exports[`adjective 4457 1`] = `
       "sezonne",
     ],
   },
+  "short": "sezonėn",
   "singular": {
     "acc": [
       "sezonnogo / sezonny",
@@ -38711,6 +39263,7 @@ exports[`adjective 4459 1`] = `
       "duže",
     ],
   },
+  "short": "duž",
   "singular": {
     "acc": [
       "dužego / duži",
@@ -38780,6 +39333,7 @@ exports[`adjective 4467 1`] = `
       "zimne",
     ],
   },
+  "short": "zimėn",
   "singular": {
     "acc": [
       "zimnogo / zimny",
@@ -38849,6 +39403,7 @@ exports[`adjective 4470 1`] = `
       "strahlive",
     ],
   },
+  "short": "strahliv",
   "singular": {
     "acc": [
       "strahlivogo / strahlivy",
@@ -38918,6 +39473,7 @@ exports[`adjective 4478 1`] = `
       "ptičje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ptičjego / ptičji",
@@ -38987,6 +39543,7 @@ exports[`adjective 4513 1`] = `
       "bogohuľne",
     ],
   },
+  "short": "bogohuľėn",
   "singular": {
     "acc": [
       "bogohuľnogo / bogohuľny",
@@ -39056,6 +39613,7 @@ exports[`adjective 4524 1`] = `
       "krvave",
     ],
   },
+  "short": "krvav",
   "singular": {
     "acc": [
       "krvavogo / krvavy",
@@ -39125,6 +39683,7 @@ exports[`adjective 4530 1`] = `
       "popravne",
     ],
   },
+  "short": "popravėn",
   "singular": {
     "acc": [
       "popravnogo / popravny",
@@ -39194,6 +39753,7 @@ exports[`adjective 4535 1`] = `
       "nevrologične",
     ],
   },
+  "short": "nevrologičėn",
   "singular": {
     "acc": [
       "nevrologičnogo / nevrologičny",
@@ -39263,6 +39823,7 @@ exports[`adjective 4536 1`] = `
       "sųtrudničske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sųtrudničskogo / sųtrudničsky",
@@ -39332,6 +39893,7 @@ exports[`adjective 4539 1`] = `
       "upotrěbime",
     ],
   },
+  "short": "upotrěbim",
   "singular": {
     "acc": [
       "upotrěbimogo / upotrěbimy",
@@ -39401,6 +39963,7 @@ exports[`adjective 4550 1`] = `
       "obdarjene",
     ],
   },
+  "short": "obdarjen",
   "singular": {
     "acc": [
       "obdarjenogo / obdarjeny",
@@ -39470,6 +40033,7 @@ exports[`adjective 4561 1`] = `
       "nemožlive",
     ],
   },
+  "short": "nemožliv",
   "singular": {
     "acc": [
       "nemožlivogo / nemožlivy",
@@ -39539,6 +40103,7 @@ exports[`adjective 4562 1`] = `
       "nevěrojętne",
     ],
   },
+  "short": "nevěrojętėn",
   "singular": {
     "acc": [
       "nevěrojętnogo / nevěrojętny",
@@ -39608,6 +40173,7 @@ exports[`adjective 4620 1`] = `
       "nostalgične",
     ],
   },
+  "short": "nostalgičėn",
   "singular": {
     "acc": [
       "nostalgičnogo / nostalgičny",
@@ -39677,6 +40243,7 @@ exports[`adjective 4621 1`] = `
       "vȯzdušne",
     ],
   },
+  "short": "vȯzdušėn",
   "singular": {
     "acc": [
       "vȯzdušnogo / vȯzdušny",
@@ -39746,6 +40313,7 @@ exports[`adjective 4622 1`] = `
       "vȯzduhonosime",
     ],
   },
+  "short": "vȯzduhonosim",
   "singular": {
     "acc": [
       "vȯzduhonosimogo / vȯzduhonosimy",
@@ -39815,6 +40383,7 @@ exports[`adjective 4648 1`] = `
       "alkohoľne",
     ],
   },
+  "short": "alkohoľėn",
   "singular": {
     "acc": [
       "alkohoľnogo / alkohoľny",
@@ -39884,6 +40453,7 @@ exports[`adjective 4651 1`] = `
       "profesionaľne",
     ],
   },
+  "short": "profesionaľėn",
   "singular": {
     "acc": [
       "profesionaľnogo / profesionaľny",
@@ -39953,6 +40523,7 @@ exports[`adjective 4663 1`] = `
       "hemične",
     ],
   },
+  "short": "hemičėn",
   "singular": {
     "acc": [
       "hemičnogo / hemičny",
@@ -40022,6 +40593,7 @@ exports[`adjective 4681 1`] = `
       "opasne",
     ],
   },
+  "short": "opasėn",
   "singular": {
     "acc": [
       "opasnogo / opasny",
@@ -40091,6 +40663,7 @@ exports[`adjective 4722 1`] = `
       "moskȯvske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "moskȯvskogo / moskȯvsky",
@@ -40160,6 +40733,7 @@ exports[`adjective 4723 1`] = `
       "latyšske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "latyšskogo / latyšsky",
@@ -40229,6 +40803,7 @@ exports[`adjective 4728 1`] = `
       "hrvatske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "hrvatskogo / hrvatsky",
@@ -40298,6 +40873,7 @@ exports[`adjective 4734 1`] = `
       "slęzske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "slęzskogo / slęzsky",
@@ -40367,6 +40943,7 @@ exports[`adjective 4735 1`] = `
       "romanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "romanskogo / romansky",
@@ -40436,6 +41013,7 @@ exports[`adjective 4736 1`] = `
       "germanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "germanskogo / germansky",
@@ -40505,6 +41083,7 @@ exports[`adjective 4737 1`] = `
       "baltičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "baltičskogo / baltičsky",
@@ -40574,6 +41153,7 @@ exports[`adjective 4738 1`] = `
       "keltske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "keltskogo / keltsky",
@@ -40643,6 +41223,7 @@ exports[`adjective 4742 1`] = `
       "izraeľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "izraeľskogo / izraeľsky",
@@ -40712,6 +41293,7 @@ exports[`adjective 4745 1`] = `
       "sěvernoamerikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sěvernoamerikanskogo / sěvernoamerikansky",
@@ -40781,6 +41363,7 @@ exports[`adjective 4747 1`] = `
       "južnoamerikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "južnoamerikanskogo / južnoamerikansky",
@@ -40850,6 +41433,7 @@ exports[`adjective 4749 1`] = `
       "indijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "indijskogo / indijsky",
@@ -40919,6 +41503,7 @@ exports[`adjective 4751 1`] = `
       "vietnamske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vietnamskogo / vietnamsky",
@@ -40988,6 +41573,7 @@ exports[`adjective 4753 1`] = `
       "braziľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "braziľskogo / braziľsky",
@@ -41057,6 +41643,7 @@ exports[`adjective 4755 1`] = `
       "nigerijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "nigerijskogo / nigerijsky",
@@ -41126,6 +41713,7 @@ exports[`adjective 4757 1`] = `
       "egiptske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "egiptskogo / egiptsky",
@@ -41195,6 +41783,7 @@ exports[`adjective 4775 1`] = `
       "tųpe",
     ],
   },
+  "short": "tųp",
   "singular": {
     "acc": [
       "tųpogo / tųpy",
@@ -41264,6 +41853,7 @@ exports[`adjective 4776 1`] = `
       "skaredne",
     ],
   },
+  "short": "skaredėn",
   "singular": {
     "acc": [
       "skarednogo / skaredny",
@@ -41333,6 +41923,7 @@ exports[`adjective 4789 1`] = `
       "instrumentaľne",
     ],
   },
+  "short": "instrumentaľėn",
   "singular": {
     "acc": [
       "instrumentaľnogo / instrumentaľny",
@@ -41402,6 +41993,7 @@ exports[`adjective 4790 1`] = `
       "vokaľne",
     ],
   },
+  "short": "vokaľėn",
   "singular": {
     "acc": [
       "vokaľnogo / vokaľny",
@@ -41471,6 +42063,7 @@ exports[`adjective 4791 1`] = `
       "muzikaľne",
     ],
   },
+  "short": "muzikaľėn",
   "singular": {
     "acc": [
       "muzikaľnogo / muzikaľny",
@@ -41540,6 +42133,7 @@ exports[`adjective 4798 1`] = `
       "izbuhlive",
     ],
   },
+  "short": "izbuhliv",
   "singular": {
     "acc": [
       "izbuhlivogo / izbuhlivy",
@@ -41609,6 +42203,7 @@ exports[`adjective 4799 1`] = `
       "eksplozivne",
     ],
   },
+  "short": "eksplozivėn",
   "singular": {
     "acc": [
       "eksplozivnogo / eksplozivny",
@@ -41678,6 +42273,7 @@ exports[`adjective 4834 1`] = `
       "dětinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dětinskogo / dětinsky",
@@ -41747,6 +42343,7 @@ exports[`adjective 4835 1`] = `
       "dětske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dětskogo / dětsky",
@@ -41816,6 +42413,7 @@ exports[`adjective 4837 1`] = `
       "bezdětne",
     ],
   },
+  "short": "bezdětėn",
   "singular": {
     "acc": [
       "bezdětnogo / bezdětny",
@@ -41885,6 +42483,7 @@ exports[`adjective 4839 1`] = `
       "seriozne",
     ],
   },
+  "short": "seriozėn",
   "singular": {
     "acc": [
       "serioznogo / seriozny",
@@ -41954,6 +42553,7 @@ exports[`adjective 4842 1`] = `
       "umětne",
     ],
   },
+  "short": "umětėn",
   "singular": {
     "acc": [
       "umětnogo / umětny",
@@ -42023,6 +42623,7 @@ exports[`adjective 4862 1`] = `
       "mehanične",
     ],
   },
+  "short": "mehaničėn",
   "singular": {
     "acc": [
       "mehaničnogo / mehaničny",
@@ -42092,6 +42693,7 @@ exports[`adjective 4864 1`] = `
       "hidravlične",
     ],
   },
+  "short": "hidravličėn",
   "singular": {
     "acc": [
       "hidravličnogo / hidravličny",
@@ -42161,6 +42763,7 @@ exports[`adjective 4867 1`] = `
       "jugoslavske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "jugoslavskogo / jugoslavsky",
@@ -42230,6 +42833,7 @@ exports[`adjective 4900 1`] = `
       "vdęčne",
     ],
   },
+  "short": "vdęčėn",
   "singular": {
     "acc": [
       "vdęčnogo / vdęčny",
@@ -42299,6 +42903,7 @@ exports[`adjective 4901 1`] = `
       "nevdęčne",
     ],
   },
+  "short": "nevdęčėn",
   "singular": {
     "acc": [
       "nevdęčnogo / nevdęčny",
@@ -42368,6 +42973,7 @@ exports[`adjective 4903 1`] = `
       "blågodarne",
     ],
   },
+  "short": "blågodarėn",
   "singular": {
     "acc": [
       "blågodarnogo / blågodarny",
@@ -42437,6 +43043,7 @@ exports[`adjective 4904 1`] = `
       "neblågodarne",
     ],
   },
+  "short": "neblågodarėn",
   "singular": {
     "acc": [
       "neblågodarnogo / neblågodarny",
@@ -42506,6 +43113,7 @@ exports[`adjective 4906 1`] = `
       "parižske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "parižskogo / parižsky",
@@ -42575,6 +43183,7 @@ exports[`adjective 4907 1`] = `
       "novozelandske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "novozelandskogo / novozelandsky",
@@ -42644,6 +43253,7 @@ exports[`adjective 4908 1`] = `
       "tajske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "tajskogo / tajsky",
@@ -42713,6 +43323,7 @@ exports[`adjective 4909 1`] = `
       "čuvašske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "čuvašskogo / čuvašsky",
@@ -42782,6 +43393,7 @@ exports[`adjective 4910 1`] = `
       "luksemburžske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "luksemburžskogo / luksemburžsky",
@@ -42851,6 +43463,7 @@ exports[`adjective 4913 1`] = `
       "katastrofične",
     ],
   },
+  "short": "katastrofičėn",
   "singular": {
     "acc": [
       "katastrofičnogo / katastrofičny",
@@ -42920,6 +43533,7 @@ exports[`adjective 5026 1`] = `
       "pokorne",
     ],
   },
+  "short": "pokorėn",
   "singular": {
     "acc": [
       "pokornogo / pokorny",
@@ -42989,6 +43603,7 @@ exports[`adjective 5029 1`] = `
       "skromne",
     ],
   },
+  "short": "skromėn",
   "singular": {
     "acc": [
       "skromnogo / skromny",
@@ -43058,6 +43673,7 @@ exports[`adjective 5031 1`] = `
       "poslušne",
     ],
   },
+  "short": "poslušėn",
   "singular": {
     "acc": [
       "poslušnogo / poslušny",
@@ -43127,6 +43743,7 @@ exports[`adjective 5036 1`] = `
       "nevtraľne",
     ],
   },
+  "short": "nevtraľėn",
   "singular": {
     "acc": [
       "nevtraľnogo / nevtraľny",
@@ -43196,6 +43813,7 @@ exports[`adjective 5039 1`] = `
       "zvųčne",
     ],
   },
+  "short": "zvųčėn",
   "singular": {
     "acc": [
       "zvųčnogo / zvųčny",
@@ -43265,6 +43883,7 @@ exports[`adjective 5040 1`] = `
       "bezzvųčne",
     ],
   },
+  "short": "bezzvųčėn",
   "singular": {
     "acc": [
       "bezzvųčnogo / bezzvųčny",
@@ -43334,6 +43953,7 @@ exports[`adjective 5051 1`] = `
       "bezvěstne",
     ],
   },
+  "short": "bezvěstėn",
   "singular": {
     "acc": [
       "bezvěstnogo / bezvěstny",
@@ -43403,6 +44023,7 @@ exports[`adjective 5060 1`] = `
       "arměnske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "arměnskogo / arměnsky",
@@ -43472,6 +44093,7 @@ exports[`adjective 5068 1`] = `
       "utraćene",
     ],
   },
+  "short": "utraćen",
   "singular": {
     "acc": [
       "utraćenogo / utraćeny",
@@ -43541,6 +44163,7 @@ exports[`adjective 5076 1`] = `
       "druge",
     ],
   },
+  "short": "drug",
   "singular": {
     "acc": [
       "drugogo / drugy",
@@ -43610,6 +44233,7 @@ exports[`adjective 5125 1`] = `
       "aktuaľne",
     ],
   },
+  "short": "aktuaľėn",
   "singular": {
     "acc": [
       "aktuaľnogo / aktuaľny",
@@ -43679,6 +44303,7 @@ exports[`adjective 5131 1`] = `
       "mnogolětne",
     ],
   },
+  "short": "mnogolětėn",
   "singular": {
     "acc": [
       "mnogolětnogo / mnogolětny",
@@ -43748,6 +44373,7 @@ exports[`adjective 5138 1`] = `
       "individuaľne",
     ],
   },
+  "short": "individuaľėn",
   "singular": {
     "acc": [
       "individuaľnogo / individuaľny",
@@ -43817,6 +44443,7 @@ exports[`adjective 5148 1`] = `
       "komerciaľne",
     ],
   },
+  "short": "komerciaľėn",
   "singular": {
     "acc": [
       "komerciaľnogo / komerciaľny",
@@ -43886,6 +44513,7 @@ exports[`adjective 5169 1`] = `
       "ustne",
     ],
   },
+  "short": "ustėn",
   "singular": {
     "acc": [
       "ustnogo / ustny",
@@ -43955,6 +44583,7 @@ exports[`adjective 5173 1`] = `
       "virtuaľne",
     ],
   },
+  "short": "virtuaľėn",
   "singular": {
     "acc": [
       "virtuaľnogo / virtuaľny",
@@ -44024,6 +44653,7 @@ exports[`adjective 5175 1`] = `
       "zainteresovane",
     ],
   },
+  "short": "zainteresovan",
   "singular": {
     "acc": [
       "zainteresovanogo / zainteresovany",
@@ -44093,6 +44723,7 @@ exports[`adjective 5179 1`] = `
       "rade",
     ],
   },
+  "short": "rad",
   "singular": {
     "acc": [
       "radogo / rady",
@@ -44162,6 +44793,7 @@ exports[`adjective 5192 1`] = `
       "zadnje",
     ],
   },
+  "short": "zadėn",
   "singular": {
     "acc": [
       "zadnjego / zadnji",
@@ -44231,6 +44863,7 @@ exports[`adjective 5192-1 1`] = `
       "zadne",
     ],
   },
+  "short": "zadėn",
   "singular": {
     "acc": [
       "zadnogo / zadny",
@@ -44300,6 +44933,7 @@ exports[`adjective 5220 1`] = `
       "ženske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ženskogo / žensky",
@@ -44369,6 +45003,7 @@ exports[`adjective 5224 1`] = `
       "ploske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ploskogo / plosky",
@@ -44438,6 +45073,7 @@ exports[`adjective 5225 1`] = `
       "svěže",
     ],
   },
+  "short": "svěž",
   "singular": {
     "acc": [
       "svěžego / svěži",
@@ -44507,6 +45143,7 @@ exports[`adjective 5227 1`] = `
       "směšne",
     ],
   },
+  "short": "směšėn",
   "singular": {
     "acc": [
       "směšnogo / směšny",
@@ -44576,6 +45213,7 @@ exports[`adjective 5232 1`] = `
       "goriste",
     ],
   },
+  "short": "gorist",
   "singular": {
     "acc": [
       "goristogo / goristy",
@@ -44645,6 +45283,7 @@ exports[`adjective 5233 1`] = `
       "dute",
     ],
   },
+  "short": "dut",
   "singular": {
     "acc": [
       "dutogo / duty",
@@ -44714,6 +45353,7 @@ exports[`adjective 5235 1`] = `
       "glådne",
     ],
   },
+  "short": "glådėn",
   "singular": {
     "acc": [
       "glådnogo / glådny",
@@ -44783,6 +45423,7 @@ exports[`adjective 5246 1`] = `
       "glåsne",
     ],
   },
+  "short": "glåsėn",
   "singular": {
     "acc": [
       "glåsnogo / glåsny",
@@ -44852,6 +45493,7 @@ exports[`adjective 5251 1`] = `
       "mųžske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "mųžskogo / mųžsky",
@@ -44921,6 +45563,7 @@ exports[`adjective 5260 1`] = `
       "normaľne",
     ],
   },
+  "short": "normaľėn",
   "singular": {
     "acc": [
       "normaľnogo / normaľny",
@@ -44990,6 +45633,7 @@ exports[`adjective 5268 1`] = `
       "rozove",
     ],
   },
+  "short": "rozov",
   "singular": {
     "acc": [
       "rozovogo / rozovy",
@@ -45059,6 +45703,7 @@ exports[`adjective 5274 1`] = `
       "fioletove",
     ],
   },
+  "short": "fioletov",
   "singular": {
     "acc": [
       "fioletovogo / fioletovy",
@@ -45128,6 +45773,7 @@ exports[`adjective 5295 1`] = `
       "božske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "božskogo / božsky",
@@ -45197,6 +45843,7 @@ exports[`adjective 5301 1`] = `
       "falšive",
     ],
   },
+  "short": "falšiv",
   "singular": {
     "acc": [
       "falšivogo / falšivy",
@@ -45266,6 +45913,7 @@ exports[`adjective 5307 1`] = `
       "gnile",
     ],
   },
+  "short": "gnil",
   "singular": {
     "acc": [
       "gnilogo / gnily",
@@ -45335,6 +45983,7 @@ exports[`adjective 5308 1`] = `
       "gųste",
     ],
   },
+  "short": "gųst",
   "singular": {
     "acc": [
       "gųstogo / gųsty",
@@ -45404,6 +46053,7 @@ exports[`adjective 5310 1`] = `
       "iste",
     ],
   },
+  "short": "ist",
   "singular": {
     "acc": [
       "istogo / isty",
@@ -45473,6 +46123,7 @@ exports[`adjective 5313 1`] = `
       "lihe",
     ],
   },
+  "short": "lih",
   "singular": {
     "acc": [
       "lihogo / lihy",
@@ -45542,6 +46193,7 @@ exports[`adjective 5317 1`] = `
       "militantne",
     ],
   },
+  "short": "militantėn",
   "singular": {
     "acc": [
       "militantnogo / militantny",
@@ -45611,6 +46263,7 @@ exports[`adjective 5319 1`] = `
       "nage",
     ],
   },
+  "short": "nag",
   "singular": {
     "acc": [
       "nagogo / nagy",
@@ -45680,6 +46333,7 @@ exports[`adjective 5520 1`] = `
       "proletaŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "proletaŕskogo / proletaŕsky",
@@ -45749,6 +46403,7 @@ exports[`adjective 5583 1`] = `
       "brze",
     ],
   },
+  "short": "brz",
   "singular": {
     "acc": [
       "brzogo / brzy",
@@ -45818,6 +46473,7 @@ exports[`adjective 5600 1`] = `
       "mstive",
     ],
   },
+  "short": "mstiv",
   "singular": {
     "acc": [
       "mstivogo / mstivy",
@@ -45887,6 +46543,7 @@ exports[`adjective 5629 1`] = `
       "izvråćene",
     ],
   },
+  "short": "izvråćen",
   "singular": {
     "acc": [
       "izvråćenogo / izvråćeny",
@@ -45956,6 +46613,7 @@ exports[`adjective 5646 1`] = `
       "tělesne",
     ],
   },
+  "short": "tělesėn",
   "singular": {
     "acc": [
       "tělesnogo / tělesny",
@@ -46025,6 +46683,7 @@ exports[`adjective 5652 1`] = `
       "vȯzbudlive",
     ],
   },
+  "short": "vȯzbudliv",
   "singular": {
     "acc": [
       "vȯzbudlivogo / vȯzbudlivy",
@@ -46094,6 +46753,7 @@ exports[`adjective 5654 1`] = `
       "pråzdnověrne",
     ],
   },
+  "short": "pråzdnověrėn",
   "singular": {
     "acc": [
       "pråzdnověrnogo / pråzdnověrny",
@@ -46163,6 +46823,7 @@ exports[`adjective 5664 1`] = `
       "pogrdlive",
     ],
   },
+  "short": "pogrdliv",
   "singular": {
     "acc": [
       "pogrdlivogo / pogrdlivy",
@@ -46232,6 +46893,7 @@ exports[`adjective 5671 1`] = `
       "regularne",
     ],
   },
+  "short": "regularėn",
   "singular": {
     "acc": [
       "regularnogo / regularny",
@@ -46301,6 +46963,7 @@ exports[`adjective 5674 1`] = `
       "jednostajne",
     ],
   },
+  "short": "jednostajėn",
   "singular": {
     "acc": [
       "jednostajnogo / jednostajny",
@@ -46370,6 +47033,7 @@ exports[`adjective 5690 1`] = `
       "samoråzumne",
     ],
   },
+  "short": "samoråzumėn",
   "singular": {
     "acc": [
       "samoråzumnogo / samoråzumny",
@@ -46439,6 +47103,7 @@ exports[`adjective 5692 1`] = `
       "něktore",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "něktorogo / něktory",
@@ -46508,6 +47173,7 @@ exports[`adjective 5697 1`] = `
       "dane",
     ],
   },
+  "short": "dan",
   "singular": {
     "acc": [
       "danogo / dany",
@@ -46577,6 +47243,7 @@ exports[`adjective 5722 1`] = `
       "aristokratične",
     ],
   },
+  "short": "aristokratičėn",
   "singular": {
     "acc": [
       "aristokratičnogo / aristokratičny",
@@ -46646,6 +47313,7 @@ exports[`adjective 5727 1`] = `
       "šokovane",
     ],
   },
+  "short": "šokovan",
   "singular": {
     "acc": [
       "šokovanogo / šokovany",
@@ -46715,6 +47383,7 @@ exports[`adjective 5728 1`] = `
       "šokujųće",
     ],
   },
+  "short": "šokujųć",
   "singular": {
     "acc": [
       "šokujųćego / šokujųći",
@@ -46784,6 +47453,7 @@ exports[`adjective 5731 1`] = `
       "sųsědne",
     ],
   },
+  "short": "sųsědėn",
   "singular": {
     "acc": [
       "sųsědnogo / sųsědny",
@@ -46853,6 +47523,7 @@ exports[`adjective 5732 1`] = `
       "sųsědske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sųsědskogo / sųsědsky",
@@ -46922,6 +47593,7 @@ exports[`adjective 5747 1`] = `
       "osoblive",
     ],
   },
+  "short": "osobliv",
   "singular": {
     "acc": [
       "osoblivogo / osoblivy",
@@ -46991,6 +47663,7 @@ exports[`adjective 5755 1`] = `
       "afganske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "afganskogo / afgansky",
@@ -47060,6 +47733,7 @@ exports[`adjective 5756 1`] = `
       "avstralijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "avstralijskogo / avstralijsky",
@@ -47129,6 +47803,7 @@ exports[`adjective 5760 1`] = `
       "čilijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "čilijskogo / čilijsky",
@@ -47198,6 +47873,7 @@ exports[`adjective 5777 1`] = `
       "izkonavče",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "izkonavčego / izkonavči",
@@ -47267,6 +47943,7 @@ exports[`adjective 5786 1`] = `
       "nepotrěbne",
     ],
   },
+  "short": "nepotrěbėn",
   "singular": {
     "acc": [
       "nepotrěbnogo / nepotrěbny",
@@ -47336,6 +48013,7 @@ exports[`adjective 5797 1`] = `
       "okoľne",
     ],
   },
+  "short": "okoľėn",
   "singular": {
     "acc": [
       "okoľnogo / okoľny",
@@ -47405,6 +48083,7 @@ exports[`adjective 5798 1`] = `
       "neposrědnje",
     ],
   },
+  "short": "neposrědėn",
   "singular": {
     "acc": [
       "neposrědnjego / neposrědnji",
@@ -47474,6 +48153,7 @@ exports[`adjective 5798-1 1`] = `
       "neposrědne",
     ],
   },
+  "short": "neposrědėn",
   "singular": {
     "acc": [
       "neposrědnogo / neposrědny",
@@ -47543,6 +48223,7 @@ exports[`adjective 5804 1`] = `
       "masove",
     ],
   },
+  "short": "masov",
   "singular": {
     "acc": [
       "masovogo / masovy",
@@ -47612,6 +48293,7 @@ exports[`adjective 5826 1`] = `
       "zastarěle",
     ],
   },
+  "short": "zastarěl",
   "singular": {
     "acc": [
       "zastarělogo / zastarěly",
@@ -47681,6 +48363,7 @@ exports[`adjective 5835 1`] = `
       "bezpomoćne",
     ],
   },
+  "short": "bezpomoćėn",
   "singular": {
     "acc": [
       "bezpomoćnogo / bezpomoćny",
@@ -47750,6 +48433,7 @@ exports[`adjective 5844 1`] = `
       "biblijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "biblijskogo / biblijsky",
@@ -47819,6 +48503,7 @@ exports[`adjective 5863 1`] = `
       "priučene",
     ],
   },
+  "short": "priučen",
   "singular": {
     "acc": [
       "priučenogo / priučeny",
@@ -47888,6 +48573,7 @@ exports[`adjective 5864 1`] = `
       "privyknene",
     ],
   },
+  "short": "privyknen",
   "singular": {
     "acc": [
       "privyknenogo / privykneny",
@@ -47957,6 +48643,7 @@ exports[`adjective 5865 1`] = `
       "užasnene",
     ],
   },
+  "short": "užasnen",
   "singular": {
     "acc": [
       "užasnenogo / užasneny",
@@ -48026,6 +48713,7 @@ exports[`adjective 5867 1`] = `
       "glųbše",
     ],
   },
+  "short": "glųbš",
   "singular": {
     "acc": [
       "glųbšego / glųbši",
@@ -48089,6 +48777,7 @@ exports[`adjective 5868 1`] = `
       "najglųbše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najglųbšego / najglųbši",
@@ -48158,6 +48847,7 @@ exports[`adjective 5869 1`] = `
       "blěsklive",
     ],
   },
+  "short": "blěskliv",
   "singular": {
     "acc": [
       "blěsklivogo / blěsklivy",
@@ -48227,6 +48917,7 @@ exports[`adjective 5870 1`] = `
       "dobropoględne",
     ],
   },
+  "short": "dobropoględėn",
   "singular": {
     "acc": [
       "dobropoględnogo / dobropoględny",
@@ -48296,6 +48987,7 @@ exports[`adjective 5892 1`] = `
       "ljubȯvne",
     ],
   },
+  "short": "ljubȯvėn",
   "singular": {
     "acc": [
       "ljubȯvnogo / ljubȯvny",
@@ -48365,6 +49057,7 @@ exports[`adjective 5893 1`] = `
       "omiljene",
     ],
   },
+  "short": "omiljen",
   "singular": {
     "acc": [
       "omiljenogo / omiljeny",
@@ -48434,6 +49127,7 @@ exports[`adjective 5900 1`] = `
       "råzočarovane",
     ],
   },
+  "short": "råzočarovan",
   "singular": {
     "acc": [
       "råzočarovanogo / råzočarovany",
@@ -48503,6 +49197,7 @@ exports[`adjective 5902 1`] = `
       "sȯvrěmenne",
     ],
   },
+  "short": "sȯvrěmenėn",
   "singular": {
     "acc": [
       "sȯvrěmennogo / sȯvrěmenny",
@@ -48572,6 +49267,7 @@ exports[`adjective 5920 1`] = `
       "arktične",
     ],
   },
+  "short": "arktičėn",
   "singular": {
     "acc": [
       "arktičnogo / arktičny",
@@ -48641,6 +49337,7 @@ exports[`adjective 5921 1`] = `
       "čečenske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "čečenskogo / čečensky",
@@ -48710,6 +49407,7 @@ exports[`adjective 5931 1`] = `
       "ujgurske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ujgurskogo / ujgursky",
@@ -48779,6 +49477,7 @@ exports[`adjective 5945 1`] = `
       "prošlogodišnje",
     ],
   },
+  "short": "prošlogodišėn",
   "singular": {
     "acc": [
       "prošlogodišnjego / prošlogodišnji",
@@ -48848,6 +49547,7 @@ exports[`adjective 5945-1 1`] = `
       "prošlogodišne",
     ],
   },
+  "short": "prošlogodišėn",
   "singular": {
     "acc": [
       "prošlogodišnogo / prošlogodišny",
@@ -48917,6 +49617,7 @@ exports[`adjective 5953 1`] = `
       "lanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lanskogo / lansky",
@@ -48986,6 +49687,7 @@ exports[`adjective 5963 1`] = `
       "ponovne",
     ],
   },
+  "short": "ponovėn",
   "singular": {
     "acc": [
       "ponovnogo / ponovny",
@@ -49055,6 +49757,7 @@ exports[`adjective 5966 1`] = `
       "udivjene",
     ],
   },
+  "short": "udivjen",
   "singular": {
     "acc": [
       "udivjenogo / udivjeny",
@@ -49124,6 +49827,7 @@ exports[`adjective 5968 1`] = `
       "otęžene",
     ],
   },
+  "short": "otęžen",
   "singular": {
     "acc": [
       "otęženogo / otęženy",
@@ -49193,6 +49897,7 @@ exports[`adjective 5973 1`] = `
       "råzměšane",
     ],
   },
+  "short": "råzměšan",
   "singular": {
     "acc": [
       "råzměšanogo / råzměšany",
@@ -49262,6 +49967,7 @@ exports[`adjective 5984 1`] = `
       "pisemne",
     ],
   },
+  "short": "pisemėn",
   "singular": {
     "acc": [
       "pisemnogo / pisemny",
@@ -49331,6 +50037,7 @@ exports[`adjective 5999 1`] = `
       "povinne",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "povinnogo / povinen",
@@ -49400,6 +50107,7 @@ exports[`adjective 6021 1`] = `
       "bratske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bratskogo / bratsky",
@@ -49469,6 +50177,7 @@ exports[`adjective 6022 1`] = `
       "materske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "materskogo / matersky",
@@ -49538,6 +50247,7 @@ exports[`adjective 6023 1`] = `
       "dȯćerske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dȯćerskogo / dȯćersky",
@@ -49607,6 +50317,7 @@ exports[`adjective 6024 1`] = `
       "otcevske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "otcevskogo / otcevsky",
@@ -49676,6 +50387,7 @@ exports[`adjective 6025 1`] = `
       "sesterske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sesterskogo / sestersky",
@@ -49745,6 +50457,7 @@ exports[`adjective 6026 1`] = `
       "črnoględne",
     ],
   },
+  "short": "črnoględėn",
   "singular": {
     "acc": [
       "črnoględnogo / črnoględny",
@@ -49814,6 +50527,7 @@ exports[`adjective 6028 1`] = `
       "pesimistične",
     ],
   },
+  "short": "pesimističėn",
   "singular": {
     "acc": [
       "pesimističnogo / pesimističny",
@@ -49883,6 +50597,7 @@ exports[`adjective 6033 1`] = `
       "mråčne",
     ],
   },
+  "short": "mråčėn",
   "singular": {
     "acc": [
       "mråčnogo / mråčny",
@@ -49952,6 +50667,7 @@ exports[`adjective 6047 1`] = `
       "ustųpne",
     ],
   },
+  "short": "ustųpėn",
   "singular": {
     "acc": [
       "ustųpnogo / ustųpny",
@@ -50021,6 +50737,7 @@ exports[`adjective 6078 1`] = `
       "tekųće",
     ],
   },
+  "short": "tekųć",
   "singular": {
     "acc": [
       "tekųćego / tekųći",
@@ -50090,6 +50807,7 @@ exports[`adjective 6086 1`] = `
       "izrođene",
     ],
   },
+  "short": "izrođen",
   "singular": {
     "acc": [
       "izrođenogo / izrođeny",
@@ -50159,6 +50877,7 @@ exports[`adjective 6091 1`] = `
       "pyšne",
     ],
   },
+  "short": "pyšėn",
   "singular": {
     "acc": [
       "pyšnogo / pyšny",
@@ -50228,6 +50947,7 @@ exports[`adjective 6105 1`] = `
       "erotične",
     ],
   },
+  "short": "erotičėn",
   "singular": {
     "acc": [
       "erotičnogo / erotičny",
@@ -50297,6 +51017,7 @@ exports[`adjective 6120 1`] = `
       "absolutne",
     ],
   },
+  "short": "absolutėn",
   "singular": {
     "acc": [
       "absolutnogo / absolutny",
@@ -50366,6 +51087,7 @@ exports[`adjective 6125 1`] = `
       "absurdne",
     ],
   },
+  "short": "absurdėn",
   "singular": {
     "acc": [
       "absurdnogo / absurdny",
@@ -50435,6 +51157,7 @@ exports[`adjective 6145 1`] = `
       "složene",
     ],
   },
+  "short": "složen",
   "singular": {
     "acc": [
       "složenogo / složeny",
@@ -50504,6 +51227,7 @@ exports[`adjective 6149 1`] = `
       "šizofrenične",
     ],
   },
+  "short": "šizofreničėn",
   "singular": {
     "acc": [
       "šizofreničnogo / šizofreničny",
@@ -50573,6 +51297,7 @@ exports[`adjective 6154 1`] = `
       "pokrȯvne",
     ],
   },
+  "short": "pokrȯvėn",
   "singular": {
     "acc": [
       "pokrȯvnogo / pokrȯvny",
@@ -50642,6 +51367,7 @@ exports[`adjective 6203 1`] = `
       "literarne",
     ],
   },
+  "short": "literarėn",
   "singular": {
     "acc": [
       "literarnogo / literarny",
@@ -50711,6 +51437,7 @@ exports[`adjective 6205 1`] = `
       "kniževne",
     ],
   },
+  "short": "kniževėn",
   "singular": {
     "acc": [
       "kniževnogo / kniževny",
@@ -50780,6 +51507,7 @@ exports[`adjective 6213 1`] = `
       "prozråčne",
     ],
   },
+  "short": "prozråčėn",
   "singular": {
     "acc": [
       "prozråčnogo / prozråčny",
@@ -50849,6 +51577,7 @@ exports[`adjective 6218 1`] = `
       "svědome",
     ],
   },
+  "short": "svědom",
   "singular": {
     "acc": [
       "svědomogo / svědomy",
@@ -50918,6 +51647,7 @@ exports[`adjective 6221 1`] = `
       "podsvědome",
     ],
   },
+  "short": "podsvědom",
   "singular": {
     "acc": [
       "podsvědomogo / podsvědomy",
@@ -50987,6 +51717,7 @@ exports[`adjective 6223 1`] = `
       "nesvědome",
     ],
   },
+  "short": "nesvědom",
   "singular": {
     "acc": [
       "nesvědomogo / nesvědomy",
@@ -51056,6 +51787,7 @@ exports[`adjective 6225 1`] = `
       "škodlive",
     ],
   },
+  "short": "škodliv",
   "singular": {
     "acc": [
       "škodlivogo / škodlivy",
@@ -51125,6 +51857,7 @@ exports[`adjective 6238 1`] = `
       "progresivne",
     ],
   },
+  "short": "progresivėn",
   "singular": {
     "acc": [
       "progresivnogo / progresivny",
@@ -51194,6 +51927,7 @@ exports[`adjective 6261 1`] = `
       "člověčje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "člověčjego / člověčji",
@@ -51263,6 +51997,7 @@ exports[`adjective 6262 1`] = `
       "božje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "božjego / božji",
@@ -51332,6 +52067,7 @@ exports[`adjective 6268 1`] = `
       "dŕžavne",
     ],
   },
+  "short": "dŕžavėn",
   "singular": {
     "acc": [
       "dŕžavnogo / dŕžavny",
@@ -51401,6 +52137,7 @@ exports[`adjective 6271 1`] = `
       "koristne",
     ],
   },
+  "short": "koristėn",
   "singular": {
     "acc": [
       "koristnogo / koristny",
@@ -51470,6 +52207,7 @@ exports[`adjective 6281 1`] = `
       "neobyčne",
     ],
   },
+  "short": "neobyčėn",
   "singular": {
     "acc": [
       "neobyčnogo / neobyčny",
@@ -51539,6 +52277,7 @@ exports[`adjective 6290 1`] = `
       "prědsųdne",
     ],
   },
+  "short": "prědsųdėn",
   "singular": {
     "acc": [
       "prědsųdnogo / prědsųdny",
@@ -51608,6 +52347,7 @@ exports[`adjective 6293 1`] = `
       "privatne",
     ],
   },
+  "short": "privatėn",
   "singular": {
     "acc": [
       "privatnogo / privatny",
@@ -51677,6 +52417,7 @@ exports[`adjective 6311 1`] = `
       "takove",
     ],
   },
+  "short": "takov",
   "singular": {
     "acc": [
       "takovogo / takovy",
@@ -51746,6 +52487,7 @@ exports[`adjective 6328 1`] = `
       "gramatične",
     ],
   },
+  "short": "gramatičėn",
   "singular": {
     "acc": [
       "gramatičnogo / gramatičny",
@@ -51815,6 +52557,7 @@ exports[`adjective 6408 1`] = `
       "indijanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "indijanskogo / indijansky",
@@ -51884,6 +52627,7 @@ exports[`adjective 6483 1`] = `
       "basnjeslovene",
     ],
   },
+  "short": "basnjesloven",
   "singular": {
     "acc": [
       "basnjeslovenogo / basnjesloveny",
@@ -51953,6 +52697,7 @@ exports[`adjective 6516 1`] = `
       "bezimenne",
     ],
   },
+  "short": "bezimenėn",
   "singular": {
     "acc": [
       "bezimennogo / bezimenny",
@@ -52022,6 +52767,7 @@ exports[`adjective 6520 1`] = `
       "bezkonečne",
     ],
   },
+  "short": "bezkonečėn",
   "singular": {
     "acc": [
       "bezkonečnogo / bezkonečny",
@@ -52091,6 +52837,7 @@ exports[`adjective 6522 1`] = `
       "bezkoristne",
     ],
   },
+  "short": "bezkoristėn",
   "singular": {
     "acc": [
       "bezkoristnogo / bezkoristny",
@@ -52160,6 +52907,7 @@ exports[`adjective 6524 1`] = `
       "bezlěsne",
     ],
   },
+  "short": "bezlěsėn",
   "singular": {
     "acc": [
       "bezlěsnogo / bezlěsny",
@@ -52229,6 +52977,7 @@ exports[`adjective 6525 1`] = `
       "bezlistne",
     ],
   },
+  "short": "bezlistėn",
   "singular": {
     "acc": [
       "bezlistnogo / bezlistny",
@@ -52298,6 +53047,7 @@ exports[`adjective 6536 1`] = `
       "bezprěryvne",
     ],
   },
+  "short": "bezprěryvėn",
   "singular": {
     "acc": [
       "bezprěryvnogo / bezprěryvny",
@@ -52367,6 +53117,7 @@ exports[`adjective 6540 1`] = `
       "nesųmněne",
     ],
   },
+  "short": "nesųmněn",
   "singular": {
     "acc": [
       "nesųmněnogo / nesųmněny",
@@ -52436,6 +53187,7 @@ exports[`adjective 6546 1`] = `
       "beztęžne",
     ],
   },
+  "short": "beztęžėn",
   "singular": {
     "acc": [
       "beztęžnogo / beztęžny",
@@ -52505,6 +53257,7 @@ exports[`adjective 6588 1`] = `
       "blågoslovne",
     ],
   },
+  "short": "blågoslovėn",
   "singular": {
     "acc": [
       "blågoslovnogo / blågoslovny",
@@ -52574,6 +53327,7 @@ exports[`adjective 6610 1`] = `
       "blizše",
     ],
   },
+  "short": "blizš",
   "singular": {
     "acc": [
       "blizšego / blizši",
@@ -52643,6 +53397,7 @@ exports[`adjective 6629 1`] = `
       "bogatše",
     ],
   },
+  "short": "bogatš",
   "singular": {
     "acc": [
       "bogatšego / bogatši",
@@ -52712,6 +53467,7 @@ exports[`adjective 6642 1`] = `
       "bojazlive",
     ],
   },
+  "short": "bojazliv",
   "singular": {
     "acc": [
       "bojazlivogo / bojazlivy",
@@ -52781,6 +53537,7 @@ exports[`adjective 6645 1`] = `
       "bojazne",
     ],
   },
+  "short": "bojazėn",
   "singular": {
     "acc": [
       "bojaznogo / bojazny",
@@ -52850,6 +53607,7 @@ exports[`adjective 6651 1`] = `
       "bojeve",
     ],
   },
+  "short": "bojev",
   "singular": {
     "acc": [
       "bojevogo / bojevy",
@@ -52919,6 +53677,7 @@ exports[`adjective 6658 1`] = `
       "bolěsne",
     ],
   },
+  "short": "bolěsėn",
   "singular": {
     "acc": [
       "bolěsnogo / bolěsny",
@@ -52988,6 +53747,7 @@ exports[`adjective 6659 1`] = `
       "zahvorěle",
     ],
   },
+  "short": "zahvorěl",
   "singular": {
     "acc": [
       "zahvorělogo / zahvorěly",
@@ -53057,6 +53817,7 @@ exports[`adjective 6707 1`] = `
       "bronzove",
     ],
   },
+  "short": "bronzov",
   "singular": {
     "acc": [
       "bronzovogo / bronzovy",
@@ -53126,6 +53887,7 @@ exports[`adjective 6737 1`] = `
       "buŕlive",
     ],
   },
+  "short": "buŕliv",
   "singular": {
     "acc": [
       "buŕlivogo / buŕlivy",
@@ -53195,6 +53957,7 @@ exports[`adjective 6743 1`] = `
       "byle",
     ],
   },
+  "short": "byl",
   "singular": {
     "acc": [
       "bylogo / byly",
@@ -53264,6 +54027,7 @@ exports[`adjective 6784 1`] = `
       "cibuljevite",
     ],
   },
+  "short": "cibuljevit",
   "singular": {
     "acc": [
       "cibuljevitogo / cibuljevity",
@@ -53333,6 +54097,7 @@ exports[`adjective 6939 1`] = `
       "čuvstvene",
     ],
   },
+  "short": "čuvstven",
   "singular": {
     "acc": [
       "čuvstvenogo / čuvstveny",
@@ -53402,6 +54167,7 @@ exports[`adjective 7053 1`] = `
       "děvičje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "děvičjego / děvičji",
@@ -53468,6 +54234,7 @@ exports[`adjective 7063 1`] = `
       "divnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "divnějšego / divnějši",
@@ -53502,18 +54269,9 @@ exports[`adjective 7063 1`] = `
 exports[`adjective 7097 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "dobro obdarjenějši",
-      "dobro obdarjeněje",
-    ],
-    "positive": [
-      "dobro obdarjeny",
-      "dobro obdarjeno",
-    ],
-    "superlative": [
-      "najdobro obdarjenějši",
-      "najdobro obdarjeněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -53537,6 +54295,7 @@ exports[`adjective 7097 1`] = `
       "dobro obdarjene",
     ],
   },
+  "short": "dobro obdarjen",
   "singular": {
     "acc": [
       "dobro obdarjenogo / dobro obdarjeny",
@@ -53571,18 +54330,9 @@ exports[`adjective 7097 1`] = `
 exports[`adjective 7098 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "dobro orųdovanějši",
-      "dobro orųdovaněje",
-    ],
-    "positive": [
-      "dobro orųdovany",
-      "dobro orųdovano",
-    ],
-    "superlative": [
-      "najdobro orųdovanějši",
-      "najdobro orųdovaněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -53606,6 +54356,7 @@ exports[`adjective 7098 1`] = `
       "dobro orųdovane",
     ],
   },
+  "short": "dobro orųdovan",
   "singular": {
     "acc": [
       "dobro orųdovanogo / dobro orųdovany",
@@ -53675,6 +54426,7 @@ exports[`adjective 7101 1`] = `
       "dobrodušne",
     ],
   },
+  "short": "dobrodušėn",
   "singular": {
     "acc": [
       "dobrodušnogo / dobrodušny",
@@ -53744,6 +54496,7 @@ exports[`adjective 7114 1`] = `
       "dočasne",
     ],
   },
+  "short": "dočasėn",
   "singular": {
     "acc": [
       "dočasnogo / dočasny",
@@ -53813,6 +54566,7 @@ exports[`adjective 7126 1`] = `
       "dodatȯčne",
     ],
   },
+  "short": "dodatȯčėn",
   "singular": {
     "acc": [
       "dodatȯčnogo / dodatȯčny",
@@ -53882,6 +54636,7 @@ exports[`adjective 7175 1`] = `
       "dȯlgověčne",
     ],
   },
+  "short": "dȯlgověčėn",
   "singular": {
     "acc": [
       "dȯlgověčnogo / dȯlgověčny",
@@ -53951,6 +54706,7 @@ exports[`adjective 7179 1`] = `
       "dȯlžne",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dȯlžnogo / dȯlžen",
@@ -54020,6 +54776,7 @@ exports[`adjective 7221 1`] = `
       "dosęgajeme",
     ],
   },
+  "short": "dosęgajem",
   "singular": {
     "acc": [
       "dosęgajemogo / dosęgajemy",
@@ -54089,6 +54846,7 @@ exports[`adjective 7222 1`] = `
       "dosęžene",
     ],
   },
+  "short": "dosęžen",
   "singular": {
     "acc": [
       "dosęženogo / dosęženy",
@@ -54158,6 +54916,7 @@ exports[`adjective 7283 1`] = `
       "dozvolime",
     ],
   },
+  "short": "dozvolim",
   "singular": {
     "acc": [
       "dozvolimogo / dozvolimy",
@@ -54227,6 +54986,7 @@ exports[`adjective 7287 1`] = `
       "dozvoljene",
     ],
   },
+  "short": "dozvoljen",
   "singular": {
     "acc": [
       "dozvoljenogo / dozvoljeny",
@@ -54296,6 +55056,7 @@ exports[`adjective 7308 1`] = `
       "drěvne",
     ],
   },
+  "short": "drěvėn",
   "singular": {
     "acc": [
       "drěvnogo / drěvny",
@@ -54365,6 +55126,7 @@ exports[`adjective 7336 1`] = `
       "družne",
     ],
   },
+  "short": "družėn",
   "singular": {
     "acc": [
       "družnogo / družny",
@@ -54434,6 +55196,7 @@ exports[`adjective 7358 1`] = `
       "dušlive",
     ],
   },
+  "short": "dušliv",
   "singular": {
     "acc": [
       "dušlivogo / dušlivy",
@@ -54503,6 +55266,7 @@ exports[`adjective 7359 1`] = `
       "dušne",
     ],
   },
+  "short": "dušėn",
   "singular": {
     "acc": [
       "dušnogo / dušny",
@@ -54572,6 +55336,7 @@ exports[`adjective 7370 1`] = `
       "dvukolesne",
     ],
   },
+  "short": "dvukolesėn",
   "singular": {
     "acc": [
       "dvukolesnogo / dvukolesny",
@@ -54641,6 +55406,7 @@ exports[`adjective 7371 1`] = `
       "dvustųpne",
     ],
   },
+  "short": "dvustųpėn",
   "singular": {
     "acc": [
       "dvustųpnogo / dvustųpny",
@@ -54710,6 +55476,7 @@ exports[`adjective 7376 1`] = `
       "dvuetažne",
     ],
   },
+  "short": "dvuetažėn",
   "singular": {
     "acc": [
       "dvuetažnogo / dvuetažny",
@@ -54779,6 +55546,7 @@ exports[`adjective 7380 1`] = `
       "dvuliceve",
     ],
   },
+  "short": "dvulicev",
   "singular": {
     "acc": [
       "dvulicevogo / dvulicevy",
@@ -54848,6 +55616,7 @@ exports[`adjective 7381 1`] = `
       "dvumotorove",
     ],
   },
+  "short": "dvumotorov",
   "singular": {
     "acc": [
       "dvumotorovogo / dvumotorovy",
@@ -54917,6 +55686,7 @@ exports[`adjective 7389 1`] = `
       "dvutonove",
     ],
   },
+  "short": "dvutonov",
   "singular": {
     "acc": [
       "dvutonovogo / dvutonovy",
@@ -54986,6 +55756,7 @@ exports[`adjective 7407 1`] = `
       "bliznečske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bliznečskogo / bliznečsky",
@@ -55055,6 +55826,7 @@ exports[`adjective 7410 1`] = `
       "dvukråtne",
     ],
   },
+  "short": "dvukråtėn",
   "singular": {
     "acc": [
       "dvukråtnogo / dvukråtny",
@@ -55124,6 +55896,7 @@ exports[`adjective 7449 1`] = `
       "entuziastične",
     ],
   },
+  "short": "entuziastičėn",
   "singular": {
     "acc": [
       "entuziastičnogo / entuziastičny",
@@ -55193,6 +55966,7 @@ exports[`adjective 7455 1`] = `
       "esperantske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "esperantskogo / esperantsky",
@@ -55262,6 +56036,7 @@ exports[`adjective 7483 1`] = `
       "filiaľne",
     ],
   },
+  "short": "filiaľėn",
   "singular": {
     "acc": [
       "filiaľnogo / filiaľny",
@@ -55331,6 +56106,7 @@ exports[`adjective 7506 1`] = `
       "gaďje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gaďjego / gaďji",
@@ -55400,6 +56176,7 @@ exports[`adjective 7508 1`] = `
       "zmije",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "zmijego / zmiji",
@@ -55469,6 +56246,7 @@ exports[`adjective 7566 1`] = `
       "gliněne",
     ],
   },
+  "short": "gliněn",
   "singular": {
     "acc": [
       "gliněnogo / gliněny",
@@ -55538,6 +56316,7 @@ exports[`adjective 7663 1`] = `
       "gråđanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gråđanskogo / gråđansky",
@@ -55607,6 +56386,7 @@ exports[`adjective 7745 1`] = `
       "hepove",
     ],
   },
+  "short": "hepov",
   "singular": {
     "acc": [
       "hepovogo / hepovy",
@@ -55676,6 +56456,7 @@ exports[`adjective 7750 1`] = `
       "himerske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "himerskogo / himersky",
@@ -55742,6 +56523,7 @@ exports[`adjective 7759 1`] = `
       "hlådnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "hlådnějšego / hlådnějši",
@@ -55811,6 +56593,7 @@ exports[`adjective 7905 1`] = `
       "inake",
     ],
   },
+  "short": "inak",
   "singular": {
     "acc": [
       "inakogo / inaky",
@@ -55880,6 +56663,7 @@ exports[`adjective 7914 1`] = `
       "inozemne",
     ],
   },
+  "short": "inozemėn",
   "singular": {
     "acc": [
       "inozemnogo / inozemny",
@@ -55949,6 +56733,7 @@ exports[`adjective 7937 1`] = `
       "istinlive",
     ],
   },
+  "short": "istinliv",
   "singular": {
     "acc": [
       "istinlivogo / istinlivy",
@@ -56018,6 +56803,7 @@ exports[`adjective 7962 1`] = `
       "izběgome",
     ],
   },
+  "short": "izběgom",
   "singular": {
     "acc": [
       "izběgomogo / izběgomy",
@@ -56087,6 +56873,7 @@ exports[`adjective 7965 1`] = `
       "izbirame",
     ],
   },
+  "short": "izbiram",
   "singular": {
     "acc": [
       "izbiramogo / izbiramy",
@@ -56156,6 +56943,7 @@ exports[`adjective 8026 1`] = `
       "izključiteljne",
     ],
   },
+  "short": "izključiteljėn",
   "singular": {
     "acc": [
       "izključiteljnogo / izključiteljny",
@@ -56225,6 +57013,7 @@ exports[`adjective 8070 1`] = `
       "iznahodlive",
     ],
   },
+  "short": "iznahodliv",
   "singular": {
     "acc": [
       "iznahodlivogo / iznahodlivy",
@@ -56294,6 +57083,7 @@ exports[`adjective 8073 1`] = `
       "niščime",
     ],
   },
+  "short": "niščim",
   "singular": {
     "acc": [
       "niščimogo / niščimy",
@@ -56363,6 +57153,7 @@ exports[`adjective 8077 1`] = `
       "niščive",
     ],
   },
+  "short": "niščiv",
   "singular": {
     "acc": [
       "niščivogo / niščivy",
@@ -56432,6 +57223,7 @@ exports[`adjective 8157 1`] = `
       "izvodlive",
     ],
   },
+  "short": "izvodliv",
   "singular": {
     "acc": [
       "izvodlivogo / izvodlivy",
@@ -56501,6 +57293,7 @@ exports[`adjective 8159 1`] = `
       "izvolime",
     ],
   },
+  "short": "izvolim",
   "singular": {
     "acc": [
       "izvolimogo / izvolimy",
@@ -56570,6 +57363,7 @@ exports[`adjective 8168 1`] = `
       "izvoljene",
     ],
   },
+  "short": "izvoljen",
   "singular": {
     "acc": [
       "izvoljenogo / izvoljeny",
@@ -56639,6 +57433,7 @@ exports[`adjective 8241 1`] = `
       "javne",
     ],
   },
+  "short": "javėn",
   "singular": {
     "acc": [
       "javnogo / javny",
@@ -56708,6 +57503,7 @@ exports[`adjective 8248 1`] = `
       "jebane",
     ],
   },
+  "short": "jeban",
   "singular": {
     "acc": [
       "jebanogo / jebany",
@@ -56777,6 +57573,7 @@ exports[`adjective 8255 1`] = `
       "jedlive",
     ],
   },
+  "short": "jedliv",
   "singular": {
     "acc": [
       "jedlivogo / jedlivy",
@@ -56846,6 +57643,7 @@ exports[`adjective 8260 1`] = `
       "sjedene",
     ],
   },
+  "short": "sjeden",
   "singular": {
     "acc": [
       "sjedenogo / sjedeny",
@@ -56915,6 +57713,7 @@ exports[`adjective 8274 1`] = `
       "jednonočne",
     ],
   },
+  "short": "jednonočėn",
   "singular": {
     "acc": [
       "jednonočnogo / jednonočny",
@@ -56984,6 +57783,7 @@ exports[`adjective 8282 1`] = `
       "jedinstvene",
     ],
   },
+  "short": "jedinstven",
   "singular": {
     "acc": [
       "jedinstvenogo / jedinstveny",
@@ -57053,6 +57853,7 @@ exports[`adjective 8301 1`] = `
       "jednosměrne",
     ],
   },
+  "short": "jednosměrėn",
   "singular": {
     "acc": [
       "jednosměrnogo / jednosměrny",
@@ -57122,6 +57923,7 @@ exports[`adjective 8349 1`] = `
       "jezerne",
     ],
   },
+  "short": "jezerėn",
   "singular": {
     "acc": [
       "jezernogo / jezerny",
@@ -57191,6 +57993,7 @@ exports[`adjective 8364 1`] = `
       "jutrišnje",
     ],
   },
+  "short": "jutrišėn",
   "singular": {
     "acc": [
       "jutrišnjego / jutrišnji",
@@ -57260,6 +58063,7 @@ exports[`adjective 8364-1 1`] = `
       "jutrišne",
     ],
   },
+  "short": "jutrišėn",
   "singular": {
     "acc": [
       "jutrišnogo / jutrišny",
@@ -57329,6 +58133,7 @@ exports[`adjective 8365 1`] = `
       "utrišnje",
     ],
   },
+  "short": "utrišėn",
   "singular": {
     "acc": [
       "utrišnjego / utrišnji",
@@ -57398,6 +58203,7 @@ exports[`adjective 8365-1 1`] = `
       "utrišne",
     ],
   },
+  "short": "utrišėn",
   "singular": {
     "acc": [
       "utrišnogo / utrišny",
@@ -57467,6 +58273,7 @@ exports[`adjective 8428 1`] = `
       "každodenne",
     ],
   },
+  "short": "každodenėn",
   "singular": {
     "acc": [
       "každodennogo / každodenny",
@@ -57536,6 +58343,7 @@ exports[`adjective 8430 1`] = `
       "godišnje",
     ],
   },
+  "short": "godišėn",
   "singular": {
     "acc": [
       "godišnjego / godišnji",
@@ -57605,6 +58413,7 @@ exports[`adjective 8430-1 1`] = `
       "godišne",
     ],
   },
+  "short": "godišėn",
   "singular": {
     "acc": [
       "godišnogo / godišny",
@@ -57674,6 +58483,7 @@ exports[`adjective 8432 1`] = `
       "každoročne",
     ],
   },
+  "short": "každoročėn",
   "singular": {
     "acc": [
       "každoročnogo / každoročny",
@@ -57743,6 +58553,7 @@ exports[`adjective 8459 1`] = `
       "klasične",
     ],
   },
+  "short": "klasičėn",
   "singular": {
     "acc": [
       "klasičnogo / klasičny",
@@ -57812,6 +58623,7 @@ exports[`adjective 8473 1`] = `
       "klětȯčne",
     ],
   },
+  "short": "klětȯčėn",
   "singular": {
     "acc": [
       "klětȯčnogo / klětȯčny",
@@ -57881,6 +58693,7 @@ exports[`adjective 8481 1`] = `
       "klimatske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "klimatskogo / klimatsky",
@@ -57950,6 +58763,7 @@ exports[`adjective 8557 1`] = `
       "konečne",
     ],
   },
+  "short": "konečėn",
   "singular": {
     "acc": [
       "konečnogo / konečny",
@@ -58019,6 +58833,7 @@ exports[`adjective 8584 1`] = `
       "konservovane",
     ],
   },
+  "short": "konservovan",
   "singular": {
     "acc": [
       "konservovanogo / konservovany",
@@ -58088,6 +58903,7 @@ exports[`adjective 8637 1`] = `
       "kozačske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kozačskogo / kozačsky",
@@ -58122,18 +58938,9 @@ exports[`adjective 8637 1`] = `
 exports[`adjective 8650 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "krajno opasnějši",
-      "krajno opasněje",
-    ],
-    "positive": [
-      "krajno opasny",
-      "krajno opasno",
-    ],
-    "superlative": [
-      "najkrajno opasnějši",
-      "najkrajno opasněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -58157,6 +58964,7 @@ exports[`adjective 8650 1`] = `
       "krajno opasne",
     ],
   },
+  "short": "krajno opasėn",
   "singular": {
     "acc": [
       "krajno opasnogo / krajno opasny",
@@ -58226,6 +59034,7 @@ exports[`adjective 8660 1`] = `
       "krasivše",
     ],
   },
+  "short": "krasivš",
   "singular": {
     "acc": [
       "krasivšego / krasivši",
@@ -58292,6 +59101,7 @@ exports[`adjective 8662 1`] = `
       "krasnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "krasnějšego / krasnějši",
@@ -58361,6 +59171,7 @@ exports[`adjective 8673 1`] = `
       "kråtkovidne",
     ],
   },
+  "short": "kråtkovidėn",
   "singular": {
     "acc": [
       "kråtkovidnogo / kråtkovidny",
@@ -58430,6 +59241,7 @@ exports[`adjective 8738 1`] = `
       "krvavše",
     ],
   },
+  "short": "krvavš",
   "singular": {
     "acc": [
       "krvavšego / krvavši",
@@ -58499,6 +59311,7 @@ exports[`adjective 8758 1`] = `
       "kuhenne",
     ],
   },
+  "short": "kuhenėn",
   "singular": {
     "acc": [
       "kuhennogo / kuhenny",
@@ -58568,6 +59381,7 @@ exports[`adjective 8793 1`] = `
       "cvětųće",
     ],
   },
+  "short": "cvětųć",
   "singular": {
     "acc": [
       "cvětųćego / cvětųći",
@@ -58637,6 +59451,7 @@ exports[`adjective 8817 1`] = `
       "lędvične",
     ],
   },
+  "short": "lędvičėn",
   "singular": {
     "acc": [
       "lędvičnogo / lędvičny",
@@ -58706,6 +59521,7 @@ exports[`adjective 8831 1`] = `
       "lěkaŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lěkaŕskogo / lěkaŕsky",
@@ -58775,6 +59591,7 @@ exports[`adjective 8837 1`] = `
       "lěnive",
     ],
   },
+  "short": "lěniv",
   "singular": {
     "acc": [
       "lěnivogo / lěnivy",
@@ -58844,6 +59661,7 @@ exports[`adjective 8859 1`] = `
       "levje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "levjego / levji",
@@ -58913,6 +59731,7 @@ exports[`adjective 8878 1`] = `
       "liceměrne",
     ],
   },
+  "short": "liceměrėn",
   "singular": {
     "acc": [
       "liceměrnogo / liceměrny",
@@ -58982,6 +59801,7 @@ exports[`adjective 8982 1`] = `
       "malenjke",
     ],
   },
+  "short": "malenjėk",
   "singular": {
     "acc": [
       "malenjkogo / malenjky",
@@ -59051,6 +59871,7 @@ exports[`adjective 9001 1`] = `
       "maslinove",
     ],
   },
+  "short": "maslinov",
   "singular": {
     "acc": [
       "maslinovogo / maslinovy",
@@ -59120,6 +59941,7 @@ exports[`adjective 9035 1`] = `
       "medvědne",
     ],
   },
+  "short": "medvědėn",
   "singular": {
     "acc": [
       "medvědnogo / medvědny",
@@ -59189,6 +60011,7 @@ exports[`adjective 9046 1`] = `
       "měhurne",
     ],
   },
+  "short": "měhurėn",
   "singular": {
     "acc": [
       "měhurnogo / měhurny",
@@ -59258,6 +60081,7 @@ exports[`adjective 9110 1`] = `
       "milovane",
     ],
   },
+  "short": "milovan",
   "singular": {
     "acc": [
       "milovanogo / milovany",
@@ -59327,6 +60151,7 @@ exports[`adjective 9135 1`] = `
       "mlådostne",
     ],
   },
+  "short": "mlådostėn",
   "singular": {
     "acc": [
       "mlådostnogo / mlådostny",
@@ -59396,6 +60221,7 @@ exports[`adjective 9137 1`] = `
       "mlådše",
     ],
   },
+  "short": "mlådš",
   "singular": {
     "acc": [
       "mlådšego / mlådši",
@@ -59465,6 +60291,7 @@ exports[`adjective 9142 1`] = `
       "mlěčne",
     ],
   },
+  "short": "mlěčėn",
   "singular": {
     "acc": [
       "mlěčnogo / mlěčny",
@@ -59534,6 +60361,7 @@ exports[`adjective 9169 1`] = `
       "modne",
     ],
   },
+  "short": "modėn",
   "singular": {
     "acc": [
       "modnogo / modny",
@@ -59603,6 +60431,7 @@ exports[`adjective 9188 1`] = `
       "mȯlčne",
     ],
   },
+  "short": "mȯlčėn",
   "singular": {
     "acc": [
       "mȯlčnogo / mȯlčny",
@@ -59672,6 +60501,7 @@ exports[`adjective 9229 1`] = `
       "mozgove",
     ],
   },
+  "short": "mozgov",
   "singular": {
     "acc": [
       "mozgovogo / mozgovy",
@@ -59741,6 +60571,7 @@ exports[`adjective 9270 1`] = `
       "mråzosušene",
     ],
   },
+  "short": "mråzosušen",
   "singular": {
     "acc": [
       "mråzosušenogo / mråzosušeny",
@@ -59804,6 +60635,7 @@ exports[`adjective 9359 1`] = `
       "najblizše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najblizšego / najblizši",
@@ -59867,6 +60699,7 @@ exports[`adjective 9360 1`] = `
       "najbogatše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najbogatšego / najbogatši",
@@ -59930,6 +60763,7 @@ exports[`adjective 9361 1`] = `
       "najdivnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najdivnějšego / najdivnějši",
@@ -59993,6 +60827,7 @@ exports[`adjective 9364 1`] = `
       "najvęćše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najvęćšego / najvęćši",
@@ -60056,6 +60891,7 @@ exports[`adjective 9371 1`] = `
       "najhlådnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najhlådnějšego / najhlådnějši",
@@ -60119,6 +60955,7 @@ exports[`adjective 9372 1`] = `
       "najkrasivše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najkrasivšego / najkrasivši",
@@ -60182,6 +61019,7 @@ exports[`adjective 9373 1`] = `
       "najkrasnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najkrasnějšego / najkrasnějši",
@@ -60245,6 +61083,7 @@ exports[`adjective 9374 1`] = `
       "najkrvavše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najkrvavšego / najkrvavši",
@@ -60308,6 +61147,7 @@ exports[`adjective 9379 1`] = `
       "najmękše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najmękšego / najmękši",
@@ -60371,6 +61211,7 @@ exports[`adjective 9381 1`] = `
       "najmenše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najmenšego / najmenši",
@@ -60434,6 +61275,7 @@ exports[`adjective 9382 1`] = `
       "najnizše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najnizšego / najnizši",
@@ -60497,6 +61339,7 @@ exports[`adjective 9383 1`] = `
       "najpozdnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najpozdnějšego / najpozdnějši",
@@ -60560,6 +61403,7 @@ exports[`adjective 9384 1`] = `
       "najranše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najranšego / najranši",
@@ -60629,6 +61473,7 @@ exports[`adjective 9386 1`] = `
       "najstarějše",
     ],
   },
+  "short": "najstarějš",
   "singular": {
     "acc": [
       "najstarějšego / najstarějši",
@@ -60698,6 +61543,7 @@ exports[`adjective 9386-1 1`] = `
       "najstarše",
     ],
   },
+  "short": "najstarš",
   "singular": {
     "acc": [
       "najstaršego / najstarši",
@@ -60761,6 +61607,7 @@ exports[`adjective 9390 1`] = `
       "najzimnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najzimnějšego / najzimnějši",
@@ -60830,6 +61677,7 @@ exports[`adjective 9455 1`] = `
       "nasiľne",
     ],
   },
+  "short": "nasiľėn",
   "singular": {
     "acc": [
       "nasiľnogo / nasiľny",
@@ -60899,6 +61747,7 @@ exports[`adjective 9472 1`] = `
       "nastrojeve",
     ],
   },
+  "short": "nastrojev",
   "singular": {
     "acc": [
       "nastrojevogo / nastrojevy",
@@ -60968,6 +61817,7 @@ exports[`adjective 9474 1`] = `
       "nastųpne",
     ],
   },
+  "short": "nastųpėn",
   "singular": {
     "acc": [
       "nastųpnogo / nastųpny",
@@ -61037,6 +61887,7 @@ exports[`adjective 9496 1`] = `
       "nazadne",
     ],
   },
+  "short": "nazadėn",
   "singular": {
     "acc": [
       "nazadnogo / nazadny",
@@ -61106,6 +61957,7 @@ exports[`adjective 9530 1`] = `
       "nebesne",
     ],
   },
+  "short": "nebesėn",
   "singular": {
     "acc": [
       "nebesnogo / nebesny",
@@ -61175,6 +62027,7 @@ exports[`adjective 9540 1`] = `
       "nebojazlive",
     ],
   },
+  "short": "nebojazliv",
   "singular": {
     "acc": [
       "nebojazlivogo / nebojazlivy",
@@ -61244,6 +62097,7 @@ exports[`adjective 9555 1`] = `
       "negotove",
     ],
   },
+  "short": "negotov",
   "singular": {
     "acc": [
       "negotovogo / negotovy",
@@ -61313,6 +62167,7 @@ exports[`adjective 9588 1`] = `
       "nemožne",
     ],
   },
+  "short": "nemožėn",
   "singular": {
     "acc": [
       "nemožnogo / nemožny",
@@ -61382,6 +62237,7 @@ exports[`adjective 9599 1`] = `
       "neočekyvane",
     ],
   },
+  "short": "neočekyvan",
   "singular": {
     "acc": [
       "neočekyvanogo / neočekyvany",
@@ -61451,6 +62307,7 @@ exports[`adjective 9603 1`] = `
       "neodgovorne",
     ],
   },
+  "short": "neodgovorėn",
   "singular": {
     "acc": [
       "neodgovornogo / neodgovorny",
@@ -61520,6 +62377,7 @@ exports[`adjective 9607 1`] = `
       "neohotne",
     ],
   },
+  "short": "neohotėn",
   "singular": {
     "acc": [
       "neohotnogo / neohotny",
@@ -61589,6 +62447,7 @@ exports[`adjective 9609 1`] = `
       "neoprěděljene",
     ],
   },
+  "short": "neoprěděljen",
   "singular": {
     "acc": [
       "neoprěděljenogo / neoprěděljeny",
@@ -61658,6 +62517,7 @@ exports[`adjective 9610 1`] = `
       "neosnovane",
     ],
   },
+  "short": "neosnovan",
   "singular": {
     "acc": [
       "neosnovanogo / neosnovany",
@@ -61727,6 +62587,7 @@ exports[`adjective 9614 1`] = `
       "nepopravne",
     ],
   },
+  "short": "nepopravėn",
   "singular": {
     "acc": [
       "nepopravnogo / nepopravny",
@@ -61796,6 +62657,7 @@ exports[`adjective 9631 1`] = `
       "neprozråčne",
     ],
   },
+  "short": "neprozråčėn",
   "singular": {
     "acc": [
       "neprozråčnogo / neprozråčny",
@@ -61865,6 +62727,7 @@ exports[`adjective 9637 1`] = `
       "neprirodne",
     ],
   },
+  "short": "neprirodėn",
   "singular": {
     "acc": [
       "neprirodnogo / neprirodny",
@@ -61934,6 +62797,7 @@ exports[`adjective 9638 1`] = `
       "neoriginaľne",
     ],
   },
+  "short": "neoriginaľėn",
   "singular": {
     "acc": [
       "neoriginaľnogo / neoriginaľny",
@@ -62003,6 +62867,7 @@ exports[`adjective 9639 1`] = `
       "neråvne",
     ],
   },
+  "short": "neråvėn",
   "singular": {
     "acc": [
       "neråvnogo / neråvny",
@@ -62072,6 +62937,7 @@ exports[`adjective 9640 1`] = `
       "nesměle",
     ],
   },
+  "short": "nesměl",
   "singular": {
     "acc": [
       "nesmělogo / nesměly",
@@ -62141,6 +63007,7 @@ exports[`adjective 9641 1`] = `
       "nesmysľne",
     ],
   },
+  "short": "nesmysľėn",
   "singular": {
     "acc": [
       "nesmysľnogo / nesmysľny",
@@ -62210,6 +63077,7 @@ exports[`adjective 9642 1`] = `
       "nespokojne",
     ],
   },
+  "short": "nespokojėn",
   "singular": {
     "acc": [
       "nespokojnogo / nespokojny",
@@ -62279,6 +63147,7 @@ exports[`adjective 9644 1`] = `
       "nestale",
     ],
   },
+  "short": "nestal",
   "singular": {
     "acc": [
       "nestalogo / nestaly",
@@ -62348,6 +63217,7 @@ exports[`adjective 9653 1`] = `
       "neščęstlive",
     ],
   },
+  "short": "neščęstliv",
   "singular": {
     "acc": [
       "neščęstlivogo / neščęstlivy",
@@ -62417,6 +63287,7 @@ exports[`adjective 9661 1`] = `
       "neubojazne",
     ],
   },
+  "short": "neubojazėn",
   "singular": {
     "acc": [
       "neubojaznogo / neubojazny",
@@ -62486,6 +63357,7 @@ exports[`adjective 9664 1`] = `
       "neumorjene",
     ],
   },
+  "short": "neumorjen",
   "singular": {
     "acc": [
       "neumorjenogo / neumorjeny",
@@ -62555,6 +63427,7 @@ exports[`adjective 9667 1`] = `
       "neustale",
     ],
   },
+  "short": "neustal",
   "singular": {
     "acc": [
       "neustalogo / neustaly",
@@ -62624,6 +63497,7 @@ exports[`adjective 9672 1`] = `
       "neustrašne",
     ],
   },
+  "short": "neustrašėn",
   "singular": {
     "acc": [
       "neustrašnogo / neustrašny",
@@ -62693,6 +63567,7 @@ exports[`adjective 9677 1`] = `
       "nevěstinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "nevěstinskogo / nevěstinsky",
@@ -62762,6 +63637,7 @@ exports[`adjective 9679 1`] = `
       "nevojnove",
     ],
   },
+  "short": "nevojnov",
   "singular": {
     "acc": [
       "nevojnovogo / nevojnovy",
@@ -62831,6 +63707,7 @@ exports[`adjective 9680 1`] = `
       "nevromorfne",
     ],
   },
+  "short": "nevromorfėn",
   "singular": {
     "acc": [
       "nevromorfnogo / nevromorfny",
@@ -62900,6 +63777,7 @@ exports[`adjective 9684 1`] = `
       "nezaslužene",
     ],
   },
+  "short": "nezaslužen",
   "singular": {
     "acc": [
       "nezasluženogo / nezasluženy",
@@ -62969,6 +63847,7 @@ exports[`adjective 9686 1`] = `
       "neznačne",
     ],
   },
+  "short": "neznačėn",
   "singular": {
     "acc": [
       "neznačnogo / neznačny",
@@ -63038,6 +63917,7 @@ exports[`adjective 9719 1`] = `
       "nizše",
     ],
   },
+  "short": "nizš",
   "singular": {
     "acc": [
       "nizšego / nizši",
@@ -63107,6 +63987,7 @@ exports[`adjective 9739 1`] = `
       "novoslověnske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "novoslověnskogo / novoslověnsky",
@@ -63176,6 +64057,7 @@ exports[`adjective 9755 1`] = `
       "nyrkove",
     ],
   },
+  "short": "nyrkov",
   "singular": {
     "acc": [
       "nyrkovogo / nyrkovy",
@@ -63245,6 +64127,7 @@ exports[`adjective 9810 1`] = `
       "objedinjene",
     ],
   },
+  "short": "objedinjen",
   "singular": {
     "acc": [
       "objedinjenogo / objedinjeny",
@@ -63314,6 +64197,7 @@ exports[`adjective 9822 1`] = `
       "oblastne",
     ],
   },
+  "short": "oblastėn",
   "singular": {
     "acc": [
       "oblastnogo / oblastny",
@@ -63383,6 +64267,7 @@ exports[`adjective 9853 1`] = `
       "oboråvne",
     ],
   },
+  "short": "oboråvėn",
   "singular": {
     "acc": [
       "oboråvnogo / oboråvny",
@@ -63452,6 +64337,7 @@ exports[`adjective 9872 1`] = `
       "obrazovane",
     ],
   },
+  "short": "obrazovan",
   "singular": {
     "acc": [
       "obrazovanogo / obrazovany",
@@ -63521,6 +64407,7 @@ exports[`adjective 9921 1`] = `
       "očarovane",
     ],
   },
+  "short": "očarovan",
   "singular": {
     "acc": [
       "očarovanogo / očarovany",
@@ -63590,6 +64477,7 @@ exports[`adjective 9955 1`] = `
       "odgovorne",
     ],
   },
+  "short": "odgovorėn",
   "singular": {
     "acc": [
       "odgovornogo / odgovorny",
@@ -63659,6 +64547,7 @@ exports[`adjective 10071 1`] = `
       "odučene",
     ],
   },
+  "short": "odučen",
   "singular": {
     "acc": [
       "odučenogo / odučeny",
@@ -63728,6 +64617,7 @@ exports[`adjective 10107 1`] = `
       "odvråtlive",
     ],
   },
+  "short": "odvråtliv",
   "singular": {
     "acc": [
       "odvråtlivogo / odvråtlivy",
@@ -63797,6 +64687,7 @@ exports[`adjective 10110 1`] = `
       "odvråtne",
     ],
   },
+  "short": "odvråtėn",
   "singular": {
     "acc": [
       "odvråtnogo / odvråtny",
@@ -63866,6 +64757,7 @@ exports[`adjective 10139 1`] = `
       "ogrožene",
     ],
   },
+  "short": "ogrožen",
   "singular": {
     "acc": [
       "ogroženogo / ogroženy",
@@ -63935,6 +64827,7 @@ exports[`adjective 10172 1`] = `
       "obljubjene",
     ],
   },
+  "short": "obljubjen",
   "singular": {
     "acc": [
       "obljubjenogo / obljubjeny",
@@ -64004,6 +64897,7 @@ exports[`adjective 10173 1`] = `
       "olovne",
     ],
   },
+  "short": "olovėn",
   "singular": {
     "acc": [
       "olovnogo / olovny",
@@ -64073,6 +64967,7 @@ exports[`adjective 10178 1`] = `
       "omŕzlive",
     ],
   },
+  "short": "omŕzliv",
   "singular": {
     "acc": [
       "omŕzlivogo / omŕzlivy",
@@ -64142,6 +65037,7 @@ exports[`adjective 10180 1`] = `
       "omŕzne",
     ],
   },
+  "short": "omŕzėn",
   "singular": {
     "acc": [
       "omŕznogo / omŕzny",
@@ -64211,6 +65107,7 @@ exports[`adjective 10238 1`] = `
       "oprěděljene",
     ],
   },
+  "short": "oprěděljen",
   "singular": {
     "acc": [
       "oprěděljenogo / oprěděljeny",
@@ -64280,6 +65177,7 @@ exports[`adjective 10241 1`] = `
       "oprętne",
     ],
   },
+  "short": "oprętėn",
   "singular": {
     "acc": [
       "oprętnogo / oprętny",
@@ -64349,6 +65247,7 @@ exports[`adjective 10243 1`] = `
       "opuhle",
     ],
   },
+  "short": "opuhl",
   "singular": {
     "acc": [
       "opuhlogo / opuhly",
@@ -64418,6 +65317,7 @@ exports[`adjective 10245 1`] = `
       "opuhnene",
     ],
   },
+  "short": "opuhnen",
   "singular": {
     "acc": [
       "opuhnenogo / opuhneny",
@@ -64487,6 +65387,7 @@ exports[`adjective 10249 1`] = `
       "opušćene",
     ],
   },
+  "short": "opušćen",
   "singular": {
     "acc": [
       "opušćenogo / opušćeny",
@@ -64556,6 +65457,7 @@ exports[`adjective 10263 1`] = `
       "orųdovane",
     ],
   },
+  "short": "orųdovan",
   "singular": {
     "acc": [
       "orųdovanogo / orųdovany",
@@ -64625,6 +65527,7 @@ exports[`adjective 10301 1`] = `
       "osmysljene",
     ],
   },
+  "short": "osmysljen",
   "singular": {
     "acc": [
       "osmysljenogo / osmysljeny",
@@ -64694,6 +65597,7 @@ exports[`adjective 10362 1`] = `
       "hybne",
     ],
   },
+  "short": "hybėn",
   "singular": {
     "acc": [
       "hybnogo / hybny",
@@ -64763,6 +65667,7 @@ exports[`adjective 10378 1`] = `
       "odlične",
     ],
   },
+  "short": "odličėn",
   "singular": {
     "acc": [
       "odličnogo / odličny",
@@ -64832,6 +65737,7 @@ exports[`adjective 10390 1`] = `
       "ověrjene",
     ],
   },
+  "short": "ověrjen",
   "singular": {
     "acc": [
       "ověrjenogo / ověrjeny",
@@ -64901,6 +65807,7 @@ exports[`adjective 10404 1`] = `
       "ozemiske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ozemiskogo / ozemisky",
@@ -64970,6 +65877,7 @@ exports[`adjective 10438 1`] = `
       "pamętne",
     ],
   },
+  "short": "pamętėn",
   "singular": {
     "acc": [
       "pamętnogo / pamętny",
@@ -65039,6 +65947,7 @@ exports[`adjective 10488 1`] = `
       "pěnęžne",
     ],
   },
+  "short": "pěnęžėn",
   "singular": {
     "acc": [
       "pěnęžnogo / pěnęžny",
@@ -65108,6 +66017,7 @@ exports[`adjective 10490 1`] = `
       "pepelave",
     ],
   },
+  "short": "pepelav",
   "singular": {
     "acc": [
       "pepelavogo / pepelavy",
@@ -65177,6 +66087,7 @@ exports[`adjective 10496 1`] = `
       "perove",
     ],
   },
+  "short": "perov",
   "singular": {
     "acc": [
       "perovogo / perovy",
@@ -65246,6 +66157,7 @@ exports[`adjective 10509 1`] = `
       "pŕvonačęľne",
     ],
   },
+  "short": "pŕvonačęľėn",
   "singular": {
     "acc": [
       "pŕvonačęľnogo / pŕvonačęľny",
@@ -65315,6 +66227,7 @@ exports[`adjective 10556 1`] = `
       "piramidove",
     ],
   },
+  "short": "piramidov",
   "singular": {
     "acc": [
       "piramidovogo / piramidovy",
@@ -65384,6 +66297,7 @@ exports[`adjective 10560 1`] = `
       "piromanične",
     ],
   },
+  "short": "piromaničėn",
   "singular": {
     "acc": [
       "piromaničnogo / piromaničny",
@@ -65453,6 +66367,7 @@ exports[`adjective 10562 1`] = `
       "pirotehnične",
     ],
   },
+  "short": "pirotehničėn",
   "singular": {
     "acc": [
       "pirotehničnogo / pirotehničny",
@@ -65522,6 +66437,7 @@ exports[`adjective 10591 1`] = `
       "pijeme",
     ],
   },
+  "short": "pijem",
   "singular": {
     "acc": [
       "pijemogo / pijemy",
@@ -65591,6 +66507,7 @@ exports[`adjective 10592 1`] = `
       "pytlive",
     ],
   },
+  "short": "pytliv",
   "singular": {
     "acc": [
       "pytlivogo / pytlivy",
@@ -65660,6 +66577,7 @@ exports[`adjective 10601 1`] = `
       "plačlive",
     ],
   },
+  "short": "plačliv",
   "singular": {
     "acc": [
       "plačlivogo / plačlivy",
@@ -65729,6 +66647,7 @@ exports[`adjective 10617 1`] = `
       "plaťbove",
     ],
   },
+  "short": "plaťbov",
   "singular": {
     "acc": [
       "plaťbovogo / plaťbovy",
@@ -65798,6 +66717,7 @@ exports[`adjective 10653 1`] = `
       "pobite",
     ],
   },
+  "short": "pobit",
   "singular": {
     "acc": [
       "pobitogo / pobity",
@@ -65867,6 +66787,7 @@ exports[`adjective 10670 1`] = `
       "počętkove",
     ],
   },
+  "short": "počętkov",
   "singular": {
     "acc": [
       "počętkovogo / počętkovy",
@@ -65936,6 +66857,7 @@ exports[`adjective 10694 1`] = `
       "poddavajeme",
     ],
   },
+  "short": "poddavajem",
   "singular": {
     "acc": [
       "poddavajemogo / poddavajemy",
@@ -66005,6 +66927,7 @@ exports[`adjective 10740 1`] = `
       "podzrěne",
     ],
   },
+  "short": "podzrěn",
   "singular": {
     "acc": [
       "podzrěnogo / podzrěny",
@@ -66074,6 +66997,7 @@ exports[`adjective 10742 1`] = `
       "podzirlive",
     ],
   },
+  "short": "podzirliv",
   "singular": {
     "acc": [
       "podzirlivogo / podzirlivy",
@@ -66143,6 +67067,7 @@ exports[`adjective 10760 1`] = `
       "podporne",
     ],
   },
+  "short": "podporėn",
   "singular": {
     "acc": [
       "podpornogo / podporny",
@@ -66177,67 +67102,59 @@ exports[`adjective 10760 1`] = `
 exports[`adjective 10761 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "ši",
-      "je",
-    ],
-    "positive": [
-      "y",
-      "o",
-    ],
-    "superlative": [
-      "najši",
-      "najje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
-      "yh / e",
-      "e",
+      "podpiranyh od / podpirane od",
+      "podpirane od",
     ],
     "dat": [
-      "ym",
+      "podpiranym od",
     ],
     "gen": [
-      "yh",
+      "podpiranyh od",
     ],
     "ins": [
-      "ymi",
+      "podpiranymi od",
     ],
     "loc": [
-      "yh",
+      "podpiranyh od",
     ],
     "nom": [
-      "i / e",
-      "e",
+      "podpirani od / podpirane od",
+      "podpirane od",
     ],
   },
+  "short": "podpiran",
   "singular": {
     "acc": [
-      "ogo / podpirany od",
-      "o",
-      "ų",
+      "podpiranogo od / podpirany od",
+      "podpirano od",
+      "podpiranų od",
     ],
     "dat": [
-      "omu",
-      "oj",
+      "podpiranomu od",
+      "podpiranoj od",
     ],
     "gen": [
-      "ogo",
-      "oj",
+      "podpiranogo od",
+      "podpiranoj od",
     ],
     "ins": [
-      "ym",
-      "ojų",
+      "podpiranym od",
+      "podpiranojų od",
     ],
     "loc": [
-      "om",
-      "oj",
+      "podpiranom od",
+      "podpiranoj od",
     ],
     "nom": [
-      "y",
-      "o",
-      "a",
+      "podpirany od",
+      "podpirano od",
+      "podpirana od",
     ],
   },
 }
@@ -66281,6 +67198,7 @@ exports[`adjective 10763 1`] = `
       "podrųčne",
     ],
   },
+  "short": "podrųčėn",
   "singular": {
     "acc": [
       "podrųčnogo / podrųčny",
@@ -66350,6 +67268,7 @@ exports[`adjective 10809 1`] = `
       "pohyćene",
     ],
   },
+  "short": "pohyćen",
   "singular": {
     "acc": [
       "pohyćenogo / pohyćeny",
@@ -66419,6 +67338,7 @@ exports[`adjective 10855 1`] = `
       "policijne",
     ],
   },
+  "short": "policijėn",
   "singular": {
     "acc": [
       "policijnogo / policijny",
@@ -66488,6 +67408,7 @@ exports[`adjective 10871 1`] = `
       "avtoritativne",
     ],
   },
+  "short": "avtoritativėn",
   "singular": {
     "acc": [
       "avtoritativnogo / avtoritativny",
@@ -66557,6 +67478,7 @@ exports[`adjective 10875 1`] = `
       "položene",
     ],
   },
+  "short": "položen",
   "singular": {
     "acc": [
       "položenogo / položeny",
@@ -66626,6 +67548,7 @@ exports[`adjective 10888 1`] = `
       "poluostrovne",
     ],
   },
+  "short": "poluostrovėn",
   "singular": {
     "acc": [
       "poluostrovnogo / poluostrovny",
@@ -66695,6 +67618,7 @@ exports[`adjective 10893 1`] = `
       "pomarančeve",
     ],
   },
+  "short": "pomarančev",
   "singular": {
     "acc": [
       "pomarančevogo / pomarančevy",
@@ -66764,6 +67688,7 @@ exports[`adjective 10912 1`] = `
       "popelave",
     ],
   },
+  "short": "popelav",
   "singular": {
     "acc": [
       "popelavogo / popelavy",
@@ -66833,6 +67758,7 @@ exports[`adjective 10920 1`] = `
       "popoldenne",
     ],
   },
+  "short": "popoldenėn",
   "singular": {
     "acc": [
       "popoldennogo / popoldenny",
@@ -66902,6 +67828,7 @@ exports[`adjective 10923 1`] = `
       "popȯlne",
     ],
   },
+  "short": "popȯln",
   "singular": {
     "acc": [
       "popȯlnogo / popȯlny",
@@ -66971,6 +67898,7 @@ exports[`adjective 10955 1`] = `
       "porųčene",
     ],
   },
+  "short": "porųčen",
   "singular": {
     "acc": [
       "porųčenogo / porųčeny",
@@ -67040,6 +67968,7 @@ exports[`adjective 10964 1`] = `
       "posědlive",
     ],
   },
+  "short": "posědliv",
   "singular": {
     "acc": [
       "posědlivogo / posědlivy",
@@ -67109,6 +68038,7 @@ exports[`adjective 11039 1`] = `
       "poškođene",
     ],
   },
+  "short": "poškođen",
   "singular": {
     "acc": [
       "poškođenogo / poškođeny",
@@ -67178,6 +68108,7 @@ exports[`adjective 11098 1`] = `
       "povyše",
     ],
   },
+  "short": "povyš",
   "singular": {
     "acc": [
       "povyšego / povyši",
@@ -67244,6 +68175,7 @@ exports[`adjective 11106 1`] = `
       "pozdnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pozdnějšego / pozdnějši",
@@ -67313,6 +68245,7 @@ exports[`adjective 11111 1`] = `
       "pozemne",
     ],
   },
+  "short": "pozemėn",
   "singular": {
     "acc": [
       "pozemnogo / pozemny",
@@ -67382,6 +68315,7 @@ exports[`adjective 11117 1`] = `
       "pozvolime",
     ],
   },
+  "short": "pozvolim",
   "singular": {
     "acc": [
       "pozvolimogo / pozvolimy",
@@ -67451,6 +68385,7 @@ exports[`adjective 11128 1`] = `
       "požarne",
     ],
   },
+  "short": "požarėn",
   "singular": {
     "acc": [
       "požarnogo / požarny",
@@ -67520,6 +68455,7 @@ exports[`adjective 11143 1`] = `
       "pracovite",
     ],
   },
+  "short": "pracovit",
   "singular": {
     "acc": [
       "pracovitogo / pracovity",
@@ -67589,6 +68525,7 @@ exports[`adjective 11162 1`] = `
       "pravdopodobne",
     ],
   },
+  "short": "pravdopodobėn",
   "singular": {
     "acc": [
       "pravdopodobnogo / pravdopodobny",
@@ -67658,6 +68595,7 @@ exports[`adjective 11211 1`] = `
       "prědčasne",
     ],
   },
+  "short": "prědčasėn",
   "singular": {
     "acc": [
       "prědčasnogo / prědčasny",
@@ -67727,6 +68665,7 @@ exports[`adjective 11216 1`] = `
       "prědgrådne",
     ],
   },
+  "short": "prědgrådėn",
   "singular": {
     "acc": [
       "prědgrådnogo / prědgrådny",
@@ -67796,6 +68735,7 @@ exports[`adjective 11228 1`] = `
       "prědložlive",
     ],
   },
+  "short": "prědložliv",
   "singular": {
     "acc": [
       "prědložlivogo / prědložlivy",
@@ -67865,6 +68805,7 @@ exports[`adjective 11231 1`] = `
       "prědměstne",
     ],
   },
+  "short": "prědměstėn",
   "singular": {
     "acc": [
       "prědměstnogo / prědměstny",
@@ -67934,6 +68875,7 @@ exports[`adjective 11298 1`] = `
       "prěhodne",
     ],
   },
+  "short": "prěhodėn",
   "singular": {
     "acc": [
       "prěhodnogo / prěhodny",
@@ -68003,6 +68945,7 @@ exports[`adjective 11325 1`] = `
       "prěpisane",
     ],
   },
+  "short": "prěpisan",
   "singular": {
     "acc": [
       "prěpisanogo / prěpisany",
@@ -68072,6 +69015,7 @@ exports[`adjective 11403 1`] = `
       "prěživime",
     ],
   },
+  "short": "prěživim",
   "singular": {
     "acc": [
       "prěživimogo / prěživimy",
@@ -68141,6 +69085,7 @@ exports[`adjective 11445 1`] = `
       "prijatlive",
     ],
   },
+  "short": "prijatliv",
   "singular": {
     "acc": [
       "prijatlivogo / prijatlivy",
@@ -68210,6 +69155,7 @@ exports[`adjective 11482 1`] = `
       "prirodnične",
     ],
   },
+  "short": "prirodničėn",
   "singular": {
     "acc": [
       "prirodničnogo / prirodničny",
@@ -68279,6 +69225,7 @@ exports[`adjective 11486 1`] = `
       "prirųčne",
     ],
   },
+  "short": "prirųčėn",
   "singular": {
     "acc": [
       "prirųčnogo / prirųčny",
@@ -68348,6 +69295,7 @@ exports[`adjective 11515 1`] = `
       "privitane",
     ],
   },
+  "short": "privitan",
   "singular": {
     "acc": [
       "privitanogo / privitany",
@@ -68417,6 +69365,7 @@ exports[`adjective 11622 1`] = `
       "prošloročne",
     ],
   },
+  "short": "prošloročėn",
   "singular": {
     "acc": [
       "prošloročnogo / prošloročny",
@@ -68486,6 +69435,7 @@ exports[`adjective 11624 1`] = `
       "prošle",
     ],
   },
+  "short": "prošl",
   "singular": {
     "acc": [
       "prošlogo / prošly",
@@ -68555,6 +69505,7 @@ exports[`adjective 11670 1`] = `
       "puhove",
     ],
   },
+  "short": "puhov",
   "singular": {
     "acc": [
       "puhovogo / puhovy",
@@ -68624,6 +69575,7 @@ exports[`adjective 11729 1`] = `
       "rasove",
     ],
   },
+  "short": "rasov",
   "singular": {
     "acc": [
       "rasovogo / rasovy",
@@ -68693,6 +69645,7 @@ exports[`adjective 11791 1`] = `
       "råzjebane",
     ],
   },
+  "short": "råzjeban",
   "singular": {
     "acc": [
       "råzjebanogo / råzjebany",
@@ -68762,6 +69715,7 @@ exports[`adjective 11859 1`] = `
       "råzsypane",
     ],
   },
+  "short": "råzsypan",
   "singular": {
     "acc": [
       "råzsypanogo / råzsypany",
@@ -68831,6 +69785,7 @@ exports[`adjective 11873 1`] = `
       "råzširjene",
     ],
   },
+  "short": "råzširjen",
   "singular": {
     "acc": [
       "råzširjenogo / råzširjeny",
@@ -68900,6 +69855,7 @@ exports[`adjective 11896 1`] = `
       "råzumlive",
     ],
   },
+  "short": "råzumliv",
   "singular": {
     "acc": [
       "råzumlivogo / råzumlivy",
@@ -68969,6 +69925,7 @@ exports[`adjective 11909 1`] = `
       "råzvivajųće",
     ],
   },
+  "short": "råzvivajųć",
   "singular": {
     "acc": [
       "råzvivajųćego / råzvivajųći",
@@ -69038,6 +69995,7 @@ exports[`adjective 11941 1`] = `
       "reklamne",
     ],
   },
+  "short": "reklamėn",
   "singular": {
     "acc": [
       "reklamnogo / reklamny",
@@ -69107,6 +70065,7 @@ exports[`adjective 11952 1`] = `
       "rěšajųće",
     ],
   },
+  "short": "rěšajųć",
   "singular": {
     "acc": [
       "rěšajųćego / rěšajųći",
@@ -69176,6 +70135,7 @@ exports[`adjective 11955 1`] = `
       "rěšiteljne",
     ],
   },
+  "short": "rěšiteljėn",
   "singular": {
     "acc": [
       "rěšiteljnogo / rěšiteljny",
@@ -69245,6 +70205,7 @@ exports[`adjective 11987 1`] = `
       "råbime",
     ],
   },
+  "short": "råbim",
   "singular": {
     "acc": [
       "råbimogo / råbimy",
@@ -69314,6 +70275,7 @@ exports[`adjective 11996 1`] = `
       "ročne",
     ],
   },
+  "short": "ročėn",
   "singular": {
     "acc": [
       "ročnogo / ročny",
@@ -69383,6 +70345,7 @@ exports[`adjective 12035 1`] = `
       "roževe",
     ],
   },
+  "short": "rožev",
   "singular": {
     "acc": [
       "roževogo / roževy",
@@ -69452,6 +70415,7 @@ exports[`adjective 12181 1`] = `
       "sěvernoirlandske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sěvernoirlandskogo / sěvernoirlandsky",
@@ -69521,6 +70485,7 @@ exports[`adjective 12200 1`] = `
       "sěveroiztočne",
     ],
   },
+  "short": "sěveroiztočėn",
   "singular": {
     "acc": [
       "sěveroiztočnogo / sěveroiztočny",
@@ -69590,6 +70555,7 @@ exports[`adjective 12205 1`] = `
       "sěverovȯzhodne",
     ],
   },
+  "short": "sěverovȯzhodėn",
   "singular": {
     "acc": [
       "sěverovȯzhodnogo / sěverovȯzhodny",
@@ -69659,6 +70625,7 @@ exports[`adjective 12208 1`] = `
       "sěverozapadne",
     ],
   },
+  "short": "sěverozapadėn",
   "singular": {
     "acc": [
       "sěverozapadnogo / sěverozapadny",
@@ -69728,6 +70695,7 @@ exports[`adjective 12231 1`] = `
       "sive",
     ],
   },
+  "short": "siv",
   "singular": {
     "acc": [
       "sivogo / sivy",
@@ -69797,6 +70765,7 @@ exports[`adjective 12250 1`] = `
       "slizke",
     ],
   },
+  "short": "slizȯk",
   "singular": {
     "acc": [
       "slizkogo / slizky",
@@ -69866,6 +70835,7 @@ exports[`adjective 12255 1`] = `
       "sklonne",
     ],
   },
+  "short": "sklonėn",
   "singular": {
     "acc": [
       "sklonnogo / sklonny",
@@ -69935,6 +70905,7 @@ exports[`adjective 12280 1`] = `
       "skųpe",
     ],
   },
+  "short": "skųp",
   "singular": {
     "acc": [
       "skųpogo / skųpy",
@@ -70004,6 +70975,7 @@ exports[`adjective 12301 1`] = `
       "slědne",
     ],
   },
+  "short": "slědėn",
   "singular": {
     "acc": [
       "slědnogo / slědny",
@@ -70073,6 +71045,7 @@ exports[`adjective 12372 1`] = `
       "směšane",
     ],
   },
+  "short": "směšan",
   "singular": {
     "acc": [
       "směšanogo / směšany",
@@ -70142,6 +71115,7 @@ exports[`adjective 12382 1`] = `
       "smŕtne",
     ],
   },
+  "short": "smŕtėn",
   "singular": {
     "acc": [
       "smŕtnogo / smŕtny",
@@ -70211,6 +71185,7 @@ exports[`adjective 12384 1`] = `
       "smŕtonosne",
     ],
   },
+  "short": "smŕtonosėn",
   "singular": {
     "acc": [
       "smŕtonosnogo / smŕtonosny",
@@ -70280,6 +71255,7 @@ exports[`adjective 12432 1`] = `
       "sjedinjene",
     ],
   },
+  "short": "sjedinjen",
   "singular": {
     "acc": [
       "sjedinjenogo / sjedinjeny",
@@ -70349,6 +71325,7 @@ exports[`adjective 12441 1`] = `
       "solarne",
     ],
   },
+  "short": "solarėn",
   "singular": {
     "acc": [
       "solarnogo / solarny",
@@ -70418,6 +71395,7 @@ exports[`adjective 12490 1`] = `
       "spěšne",
     ],
   },
+  "short": "spěšėn",
   "singular": {
     "acc": [
       "spěšnogo / spěšny",
@@ -70487,6 +71465,7 @@ exports[`adjective 12521 1`] = `
       "sporlive",
     ],
   },
+  "short": "sporliv",
   "singular": {
     "acc": [
       "sporlivogo / sporlivy",
@@ -70556,6 +71535,7 @@ exports[`adjective 12578 1`] = `
       "srodne",
     ],
   },
+  "short": "srodėn",
   "singular": {
     "acc": [
       "srodnogo / srodny",
@@ -70625,6 +71605,7 @@ exports[`adjective 12591 1`] = `
       "starinne",
     ],
   },
+  "short": "starinėn",
   "singular": {
     "acc": [
       "starinnogo / starinny",
@@ -70694,6 +71675,7 @@ exports[`adjective 12655 1`] = `
       "strašene",
     ],
   },
+  "short": "strašen",
   "singular": {
     "acc": [
       "strašenogo / strašeny",
@@ -70763,6 +71745,7 @@ exports[`adjective 12676 1`] = `
       "stroge",
     ],
   },
+  "short": "strog",
   "singular": {
     "acc": [
       "strogogo / strogy",
@@ -70832,6 +71815,7 @@ exports[`adjective 12710 1`] = `
       "sųmnlive",
     ],
   },
+  "short": "sųmnliv",
   "singular": {
     "acc": [
       "sųmnlivogo / sųmnlivy",
@@ -70901,6 +71885,7 @@ exports[`adjective 12763 1`] = `
       "svŕhne",
     ],
   },
+  "short": "svŕhėn",
   "singular": {
     "acc": [
       "svŕhnogo / svŕhny",
@@ -70970,6 +71955,7 @@ exports[`adjective 12772 1`] = `
       "světske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "světskogo / světsky",
@@ -71039,6 +72025,7 @@ exports[`adjective 12792 1`] = `
       "svobodnomysljne",
     ],
   },
+  "short": "svobodnomysljėn",
   "singular": {
     "acc": [
       "svobodnomysljnogo / svobodnomysljny",
@@ -71108,6 +72095,7 @@ exports[`adjective 12803 1`] = `
       "ščęstne",
     ],
   },
+  "short": "ščęstėn",
   "singular": {
     "acc": [
       "ščęstnogo / ščęstny",
@@ -71177,6 +72165,7 @@ exports[`adjective 12818 1`] = `
       "sěde",
     ],
   },
+  "short": "sěd",
   "singular": {
     "acc": [
       "sědogo / sědy",
@@ -71246,6 +72235,7 @@ exports[`adjective 12840 1`] = `
       "šifrovane",
     ],
   },
+  "short": "šifrovan",
   "singular": {
     "acc": [
       "šifrovanogo / šifrovany",
@@ -71280,18 +72270,9 @@ exports[`adjective 12840 1`] = `
 exports[`adjective 12915 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "tako zvanějši",
-      "tako zvaněje",
-    ],
-    "positive": [
-      "tako zvany",
-      "tako zvano",
-    ],
-    "superlative": [
-      "najtako zvanějši",
-      "najtako zvaněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -71315,6 +72296,7 @@ exports[`adjective 12915 1`] = `
       "tako zvane",
     ],
   },
+  "short": "tako zvan",
   "singular": {
     "acc": [
       "tako zvanogo / tako zvany",
@@ -71384,6 +72366,7 @@ exports[`adjective 12938 1`] = `
       "tečne",
     ],
   },
+  "short": "tečėn",
   "singular": {
     "acc": [
       "tečnogo / tečny",
@@ -71453,6 +72436,7 @@ exports[`adjective 12981 1`] = `
       "tydnjeve",
     ],
   },
+  "short": "tydnjev",
   "singular": {
     "acc": [
       "tydnjevogo / tydnjevy",
@@ -71522,6 +72506,7 @@ exports[`adjective 12991 1`] = `
       "tipične",
     ],
   },
+  "short": "tipičėn",
   "singular": {
     "acc": [
       "tipičnogo / tipičny",
@@ -71591,6 +72576,7 @@ exports[`adjective 13041 1`] = `
       "tŕbušne",
     ],
   },
+  "short": "tŕbušėn",
   "singular": {
     "acc": [
       "tŕbušnogo / tŕbušny",
@@ -71660,6 +72646,7 @@ exports[`adjective 13142 1`] = `
       "ubědime",
     ],
   },
+  "short": "ubědim",
   "singular": {
     "acc": [
       "ubědimogo / ubědimy",
@@ -71729,6 +72716,7 @@ exports[`adjective 13145 1`] = `
       "ubědlive",
     ],
   },
+  "short": "ubědliv",
   "singular": {
     "acc": [
       "ubědlivogo / ubědlivy",
@@ -71798,6 +72786,7 @@ exports[`adjective 13160 1`] = `
       "učebne",
     ],
   },
+  "short": "učebėn",
   "singular": {
     "acc": [
       "učebnogo / učebny",
@@ -71867,6 +72856,7 @@ exports[`adjective 13167 1`] = `
       "učeničske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "učeničskogo / učeničsky",
@@ -71936,6 +72926,7 @@ exports[`adjective 13199 1`] = `
       "udivjajųće",
     ],
   },
+  "short": "udivjajųć",
   "singular": {
     "acc": [
       "udivjajųćego / udivjajųći",
@@ -72005,6 +72996,7 @@ exports[`adjective 13203 1`] = `
       "udvojene",
     ],
   },
+  "short": "udvojen",
   "singular": {
     "acc": [
       "udvojenogo / udvojeny",
@@ -72074,6 +73066,7 @@ exports[`adjective 13236 1`] = `
       "ukryte",
     ],
   },
+  "short": "ukryt",
   "singular": {
     "acc": [
       "ukrytogo / ukryty",
@@ -72143,6 +73136,7 @@ exports[`adjective 13267 1`] = `
       "umětničske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "umětničskogo / umětničsky",
@@ -72212,6 +73206,7 @@ exports[`adjective 13274 1`] = `
       "umne",
     ],
   },
+  "short": "umėn",
   "singular": {
     "acc": [
       "umnogo / umny",
@@ -72281,6 +73276,7 @@ exports[`adjective 13334 1`] = `
       "uprošćene",
     ],
   },
+  "short": "uprošćen",
   "singular": {
     "acc": [
       "uprošćenogo / uprošćeny",
@@ -72350,6 +73346,7 @@ exports[`adjective 13353 1`] = `
       "vslědne",
     ],
   },
+  "short": "vslědėn",
   "singular": {
     "acc": [
       "vslědnogo / vslědny",
@@ -72419,6 +73416,7 @@ exports[`adjective 13362 1`] = `
       "uspěhlive",
     ],
   },
+  "short": "uspěhliv",
   "singular": {
     "acc": [
       "uspěhlivogo / uspěhlivy",
@@ -72488,6 +73486,7 @@ exports[`adjective 13373 1`] = `
       "uspokojene",
     ],
   },
+  "short": "uspokojen",
   "singular": {
     "acc": [
       "uspokojenogo / uspokojeny",
@@ -72557,6 +73556,7 @@ exports[`adjective 13384 1`] = `
       "ustanovjene",
     ],
   },
+  "short": "ustanovjen",
   "singular": {
     "acc": [
       "ustanovjenogo / ustanovjeny",
@@ -72626,6 +73626,7 @@ exports[`adjective 13387 1`] = `
       "ustale",
     ],
   },
+  "short": "ustal",
   "singular": {
     "acc": [
       "ustalogo / ustaly",
@@ -72695,6 +73696,7 @@ exports[`adjective 13450 1`] = `
       "vȯzbudime",
     ],
   },
+  "short": "vȯzbudim",
   "singular": {
     "acc": [
       "vȯzbudimogo / vȯzbudimy",
@@ -72764,6 +73766,7 @@ exports[`adjective 13465 1`] = `
       "užasne",
     ],
   },
+  "short": "užasėn",
   "singular": {
     "acc": [
       "užasnogo / užasny",
@@ -72830,6 +73833,7 @@ exports[`adjective 13545 1`] = `
       "veličejše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "veličejšego / veličejši",
@@ -72899,6 +73903,7 @@ exports[`adjective 13558 1`] = `
       "vele",
     ],
   },
+  "short": "vel",
   "singular": {
     "acc": [
       "velogo / vely",
@@ -72968,6 +73973,7 @@ exports[`adjective 13578 1`] = `
       "věrozakonne",
     ],
   },
+  "short": "věrozakonėn",
   "singular": {
     "acc": [
       "věrozakonnogo / věrozakonny",
@@ -73037,6 +74043,7 @@ exports[`adjective 13595 1`] = `
       "větrne",
     ],
   },
+  "short": "větrėn",
   "singular": {
     "acc": [
       "větrnogo / větrny",
@@ -73106,6 +74113,7 @@ exports[`adjective 13616 1`] = `
       "viděne",
     ],
   },
+  "short": "viděn",
   "singular": {
     "acc": [
       "viděnogo / viděny",
@@ -73175,6 +74183,7 @@ exports[`adjective 13619 1`] = `
       "vidne",
     ],
   },
+  "short": "vidėn",
   "singular": {
     "acc": [
       "vidnogo / vidny",
@@ -73244,6 +74253,7 @@ exports[`adjective 13628 1`] = `
       "vinogrådne",
     ],
   },
+  "short": "vinogrådėn",
   "singular": {
     "acc": [
       "vinogrådnogo / vinogrådny",
@@ -73313,6 +74323,7 @@ exports[`adjective 13633 1`] = `
       "vysokogorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vysokogorskogo / vysokogorsky",
@@ -73382,6 +74393,7 @@ exports[`adjective 13636 1`] = `
       "iztočne",
     ],
   },
+  "short": "iztočėn",
   "singular": {
     "acc": [
       "iztočnogo / iztočny",
@@ -73451,6 +74463,7 @@ exports[`adjective 13642 1`] = `
       "vędnene",
     ],
   },
+  "short": "vędnen",
   "singular": {
     "acc": [
       "vędnenogo / vędneny",
@@ -73520,6 +74533,7 @@ exports[`adjective 13761 1`] = `
       "vȯzbuđene",
     ],
   },
+  "short": "vȯzbuđen",
   "singular": {
     "acc": [
       "vȯzbuđenogo / vȯzbuđeny",
@@ -73589,6 +74603,7 @@ exports[`adjective 13854 1`] = `
       "vśakogodišnje",
     ],
   },
+  "short": "vśakogodišėn",
   "singular": {
     "acc": [
       "vśakogodišnjego / vśakogodišnji",
@@ -73658,6 +74673,7 @@ exports[`adjective 13854-1 1`] = `
       "vśakogodišne",
     ],
   },
+  "short": "vśakogodišėn",
   "singular": {
     "acc": [
       "vśakogodišnogo / vśakogodišny",
@@ -73727,6 +74743,7 @@ exports[`adjective 13952 1`] = `
       "izpųkle",
     ],
   },
+  "short": "izpųkl",
   "singular": {
     "acc": [
       "izpųklogo / izpųkly",
@@ -73796,6 +74813,7 @@ exports[`adjective 13953 1`] = `
       "izsunųte",
     ],
   },
+  "short": "izsunųt",
   "singular": {
     "acc": [
       "izsunųtogo / izsunųty",
@@ -73865,6 +74883,7 @@ exports[`adjective 14025 1`] = `
       "zablųdne",
     ],
   },
+  "short": "zablųdėn",
   "singular": {
     "acc": [
       "zablųdnogo / zablųdny",
@@ -73934,6 +74953,7 @@ exports[`adjective 14028 1`] = `
       "bolěznjetvorne",
     ],
   },
+  "short": "bolěznjetvorėn",
   "singular": {
     "acc": [
       "bolěznjetvornogo / bolěznjetvorny",
@@ -74003,6 +75023,7 @@ exports[`adjective 14029 1`] = `
       "zabolěvše",
     ],
   },
+  "short": "zabolěvš",
   "singular": {
     "acc": [
       "zabolěvšego / zabolěvši",
@@ -74072,6 +75093,7 @@ exports[`adjective 14037 1`] = `
       "začarovane",
     ],
   },
+  "short": "začarovan",
   "singular": {
     "acc": [
       "začarovanogo / začarovany",
@@ -74141,6 +75163,7 @@ exports[`adjective 14039 1`] = `
       "začasne",
     ],
   },
+  "short": "začasėn",
   "singular": {
     "acc": [
       "začasnogo / začasny",
@@ -74210,6 +75233,7 @@ exports[`adjective 14066 1`] = `
       "smųćene",
     ],
   },
+  "short": "smųćen",
   "singular": {
     "acc": [
       "smųćenogo / smųćeny",
@@ -74279,6 +75303,7 @@ exports[`adjective 14068 1`] = `
       "zagadȯčne",
     ],
   },
+  "short": "zagadȯčėn",
   "singular": {
     "acc": [
       "zagadȯčnogo / zagadȯčny",
@@ -74348,6 +75373,7 @@ exports[`adjective 14071 1`] = `
       "zagranične",
     ],
   },
+  "short": "zagraničėn",
   "singular": {
     "acc": [
       "zagraničnogo / zagraničny",
@@ -74417,6 +75443,7 @@ exports[`adjective 14082 1`] = `
       "zajęčlive",
     ],
   },
+  "short": "zajęčliv",
   "singular": {
     "acc": [
       "zajęčlivogo / zajęčlivy",
@@ -74486,6 +75513,7 @@ exports[`adjective 14105 1`] = `
       "zakrvavjene",
     ],
   },
+  "short": "zakrvavjen",
   "singular": {
     "acc": [
       "zakrvavjenogo / zakrvavjeny",
@@ -74555,6 +75583,7 @@ exports[`adjective 14107 1`] = `
       "zakulisne",
     ],
   },
+  "short": "zakulisėn",
   "singular": {
     "acc": [
       "zakulisnogo / zakulisny",
@@ -74624,6 +75653,7 @@ exports[`adjective 14113 1`] = `
       "založne",
     ],
   },
+  "short": "založėn",
   "singular": {
     "acc": [
       "založnogo / založny",
@@ -74693,6 +75723,7 @@ exports[`adjective 14126 1`] = `
       "zamysljene",
     ],
   },
+  "short": "zamysljen",
   "singular": {
     "acc": [
       "zamysljenogo / zamysljeny",
@@ -74762,6 +75793,7 @@ exports[`adjective 14129 1`] = `
       "zajmlive",
     ],
   },
+  "short": "zajmliv",
   "singular": {
     "acc": [
       "zajmlivogo / zajmlivy",
@@ -74831,6 +75863,7 @@ exports[`adjective 14163 1`] = `
       "zarazne",
     ],
   },
+  "short": "zarazėn",
   "singular": {
     "acc": [
       "zaraznogo / zarazny",
@@ -74900,6 +75933,7 @@ exports[`adjective 14195 1`] = `
       "zautrišnje",
     ],
   },
+  "short": "zautrišėn",
   "singular": {
     "acc": [
       "zautrišnjego / zautrišnji",
@@ -74969,6 +76003,7 @@ exports[`adjective 14195-1 1`] = `
       "zautrišne",
     ],
   },
+  "short": "zautrišėn",
   "singular": {
     "acc": [
       "zautrišnogo / zautrišny",
@@ -75038,6 +76073,7 @@ exports[`adjective 14217 1`] = `
       "zemiste",
     ],
   },
+  "short": "zemist",
   "singular": {
     "acc": [
       "zemistogo / zemisty",
@@ -75107,6 +76143,7 @@ exports[`adjective 14222 1`] = `
       "zemjane",
     ],
   },
+  "short": "zemjan",
   "singular": {
     "acc": [
       "zemjanogo / zemjany",
@@ -75173,6 +76210,7 @@ exports[`adjective 14234 1`] = `
       "zimnějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "zimnějšego / zimnějši",
@@ -75242,6 +76280,7 @@ exports[`adjective 14238 1`] = `
       "zimove",
     ],
   },
+  "short": "zimov",
   "singular": {
     "acc": [
       "zimovogo / zimovy",
@@ -75311,6 +76350,7 @@ exports[`adjective 14264 1`] = `
       "zlověstne",
     ],
   },
+  "short": "zlověstėn",
   "singular": {
     "acc": [
       "zlověstnogo / zlověstny",
@@ -75345,18 +76385,9 @@ exports[`adjective 14264 1`] = `
 exports[`adjective 14291 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "dobro informovanějši",
-      "dobro informovaněje",
-    ],
-    "positive": [
-      "dobro informovany",
-      "dobro informovano",
-    ],
-    "superlative": [
-      "najdobro informovanějši",
-      "najdobro informovaněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -75380,6 +76411,7 @@ exports[`adjective 14291 1`] = `
       "dobro informovane",
     ],
   },
+  "short": "dobro informovan",
   "singular": {
     "acc": [
       "dobro informovanogo / dobro informovany",
@@ -75449,6 +76481,7 @@ exports[`adjective 14302 1`] = `
       "dozrěne",
     ],
   },
+  "short": "dozrěn",
   "singular": {
     "acc": [
       "dozrěnogo / dozrěny",
@@ -75518,6 +76551,7 @@ exports[`adjective 14305 1`] = `
       "srųčne",
     ],
   },
+  "short": "srųčėn",
   "singular": {
     "acc": [
       "srųčnogo / srųčny",
@@ -75587,6 +76621,7 @@ exports[`adjective 14311 1`] = `
       "zvěŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "zvěŕskogo / zvěŕsky",
@@ -75656,6 +76691,7 @@ exports[`adjective 14349 1`] = `
       "žędne",
     ],
   },
+  "short": "žędėn",
   "singular": {
     "acc": [
       "žędnogo / žędny",
@@ -75725,6 +76761,7 @@ exports[`adjective 14366 1`] = `
       "želěznične",
     ],
   },
+  "short": "želězničėn",
   "singular": {
     "acc": [
       "želězničnogo / želězničny",
@@ -75794,6 +76831,7 @@ exports[`adjective 14384 1`] = `
       "židovske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "židovskogo / židovsky",
@@ -75863,6 +76901,7 @@ exports[`adjective 14408 1`] = `
       "žrtvene",
     ],
   },
+  "short": "žrtven",
   "singular": {
     "acc": [
       "žrtvenogo / žrtveny",
@@ -75932,6 +76971,7 @@ exports[`adjective 14451 1`] = `
       "avtomobiľne",
     ],
   },
+  "short": "avtomobiľėn",
   "singular": {
     "acc": [
       "avtomobiľnogo / avtomobiľny",
@@ -76001,6 +77041,7 @@ exports[`adjective 14455 1`] = `
       "bezdrěvne",
     ],
   },
+  "short": "bezdrěvėn",
   "singular": {
     "acc": [
       "bezdrěvnogo / bezdrěvny",
@@ -76070,6 +77111,7 @@ exports[`adjective 14457 1`] = `
       "bezkolorne",
     ],
   },
+  "short": "bezkolorėn",
   "singular": {
     "acc": [
       "bezkolornogo / bezkolorny",
@@ -76139,6 +77181,7 @@ exports[`adjective 14458 1`] = `
       "bezhybne",
     ],
   },
+  "short": "bezhybėn",
   "singular": {
     "acc": [
       "bezhybnogo / bezhybny",
@@ -76208,6 +77251,7 @@ exports[`adjective 14464 1`] = `
       "biznesne",
     ],
   },
+  "short": "biznesėn",
   "singular": {
     "acc": [
       "biznesnogo / biznesny",
@@ -76277,6 +77321,7 @@ exports[`adjective 14466 1`] = `
       "blågosklonne",
     ],
   },
+  "short": "blågosklonėn",
   "singular": {
     "acc": [
       "blågosklonnogo / blågosklonny",
@@ -76346,6 +77391,7 @@ exports[`adjective 14486 1`] = `
       "cibuljeve",
     ],
   },
+  "short": "cibuljev",
   "singular": {
     "acc": [
       "cibuljevogo / cibuljevy",
@@ -76415,6 +77461,7 @@ exports[`adjective 14520 1`] = `
       "dike",
     ],
   },
+  "short": "dik",
   "singular": {
     "acc": [
       "dikogo / diky",
@@ -76484,6 +77531,7 @@ exports[`adjective 14525 1`] = `
       "dive",
     ],
   },
+  "short": "div",
   "singular": {
     "acc": [
       "divogo / divy",
@@ -76553,6 +77601,7 @@ exports[`adjective 14533 1`] = `
       "lučše",
     ],
   },
+  "short": "lučš",
   "singular": {
     "acc": [
       "lučšego / lučši",
@@ -76622,6 +77671,7 @@ exports[`adjective 14549 1`] = `
       "dvuetapove",
     ],
   },
+  "short": "dvuetapov",
   "singular": {
     "acc": [
       "dvuetapovogo / dvuetapovy",
@@ -76691,6 +77741,7 @@ exports[`adjective 14567 1`] = `
       "garantovane",
     ],
   },
+  "short": "garantovan",
   "singular": {
     "acc": [
       "garantovanogo / garantovany",
@@ -76760,6 +77811,7 @@ exports[`adjective 14573 1`] = `
       "glųbinne",
     ],
   },
+  "short": "glųbinėn",
   "singular": {
     "acc": [
       "glųbinnogo / glųbinny",
@@ -76829,6 +77881,7 @@ exports[`adjective 14595 1`] = `
       "hųdožne",
     ],
   },
+  "short": "hųdožėn",
   "singular": {
     "acc": [
       "hųdožnogo / hųdožny",
@@ -76898,6 +77951,7 @@ exports[`adjective 14610 1`] = `
       "izvoljne",
     ],
   },
+  "short": "izvoljėn",
   "singular": {
     "acc": [
       "izvoljnogo / izvoljny",
@@ -76967,6 +78021,7 @@ exports[`adjective 14647 1`] = `
       "klientske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "klientskogo / klientsky",
@@ -77036,6 +78091,7 @@ exports[`adjective 14662 1`] = `
       "koprove",
     ],
   },
+  "short": "koprov",
   "singular": {
     "acc": [
       "koprovogo / koprovy",
@@ -77105,6 +78161,7 @@ exports[`adjective 14666 1`] = `
       "krmne",
     ],
   },
+  "short": "krmėn",
   "singular": {
     "acc": [
       "krmnogo / krmny",
@@ -77168,6 +78225,7 @@ exports[`adjective 14734 1`] = `
       "najvelike",
     ],
   },
+  "short": "najvelik",
   "singular": {
     "acc": [
       "najvelikogo / najveliky",
@@ -77237,6 +78295,7 @@ exports[`adjective 14745 1`] = `
       "nebystre",
     ],
   },
+  "short": "nebystr",
   "singular": {
     "acc": [
       "nebystrogo / nebystry",
@@ -77306,6 +78365,7 @@ exports[`adjective 14746 1`] = `
       "nedaleke",
     ],
   },
+  "short": "nedalek",
   "singular": {
     "acc": [
       "nedalekogo / nedaleky",
@@ -77375,6 +78435,7 @@ exports[`adjective 14752 1`] = `
       "neproste",
     ],
   },
+  "short": "neprost",
   "singular": {
     "acc": [
       "neprostogo / neprosty",
@@ -77444,6 +78505,7 @@ exports[`adjective 14756 1`] = `
       "nebrěžne",
     ],
   },
+  "short": "nebrěžėn",
   "singular": {
     "acc": [
       "nebrěžnogo / nebrěžny",
@@ -77513,6 +78575,7 @@ exports[`adjective 14762 1`] = `
       "niševe",
     ],
   },
+  "short": "nišev",
   "singular": {
     "acc": [
       "niševogo / niševy",
@@ -77582,6 +78645,7 @@ exports[`adjective 14823 1`] = `
       "oživjene",
     ],
   },
+  "short": "oživjen",
   "singular": {
     "acc": [
       "oživjenogo / oživjeny",
@@ -77651,6 +78715,7 @@ exports[`adjective 14830 1`] = `
       "Peruanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "Peruanskogo / Peruansky",
@@ -77720,6 +78785,7 @@ exports[`adjective 14832 1`] = `
       "råzvråtne",
     ],
   },
+  "short": "råzvråtėn",
   "singular": {
     "acc": [
       "råzvråtnogo / råzvråtny",
@@ -77789,6 +78855,7 @@ exports[`adjective 14834 1`] = `
       "pijane",
     ],
   },
+  "short": "pijan",
   "singular": {
     "acc": [
       "pijanogo / pijany",
@@ -77858,6 +78925,7 @@ exports[`adjective 14846 1`] = `
       "pokorjene",
     ],
   },
+  "short": "pokorjen",
   "singular": {
     "acc": [
       "pokorjenogo / pokorjeny",
@@ -77927,6 +78995,7 @@ exports[`adjective 14874 1`] = `
       "pomale",
     ],
   },
+  "short": "pomal",
   "singular": {
     "acc": [
       "pomalogo / pomaly",
@@ -77996,6 +79065,7 @@ exports[`adjective 14880 1`] = `
       "porotne",
     ],
   },
+  "short": "porotėn",
   "singular": {
     "acc": [
       "porotnogo / porotny",
@@ -78065,6 +79135,7 @@ exports[`adjective 14924 1`] = `
       "prědhodne",
     ],
   },
+  "short": "prědhodėn",
   "singular": {
     "acc": [
       "prědhodnogo / prědhodny",
@@ -78134,6 +79205,7 @@ exports[`adjective 14940 1`] = `
       "prisųtne",
     ],
   },
+  "short": "prisųtėn",
   "singular": {
     "acc": [
       "prisųtnogo / prisųtny",
@@ -78203,6 +79275,7 @@ exports[`adjective 14944 1`] = `
       "proganjane",
     ],
   },
+  "short": "proganjan",
   "singular": {
     "acc": [
       "proganjanogo / proganjany",
@@ -78272,6 +79345,7 @@ exports[`adjective 14952 1`] = `
       "ptačje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ptačjego / ptačji",
@@ -78341,6 +79415,7 @@ exports[`adjective 14999 1`] = `
       "syrove",
     ],
   },
+  "short": "syrov",
   "singular": {
     "acc": [
       "syrovogo / syrovy",
@@ -78410,6 +79485,7 @@ exports[`adjective 15052 1`] = `
       "sȯvŕšene",
     ],
   },
+  "short": "sȯvŕšen",
   "singular": {
     "acc": [
       "sȯvŕšenogo / sȯvŕšeny",
@@ -78479,6 +79555,7 @@ exports[`adjective 15100 1`] = `
       "udačlive",
     ],
   },
+  "short": "udačliv",
   "singular": {
     "acc": [
       "udačlivogo / udačlivy",
@@ -78513,18 +79590,9 @@ exports[`adjective 15100 1`] = `
 exports[`adjective 15131 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "dobro osvědomjenějši",
-      "dobro osvědomjeněje",
-    ],
-    "positive": [
-      "dobro osvědomjeny",
-      "dobro osvědomjeno",
-    ],
-    "superlative": [
-      "najdobro osvědomjenějši",
-      "najdobro osvědomjeněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -78548,6 +79616,7 @@ exports[`adjective 15131 1`] = `
       "dobro osvědomjene",
     ],
   },
+  "short": "dobro osvědomjen",
   "singular": {
     "acc": [
       "dobro osvědomjenogo / dobro osvědomjeny",
@@ -78617,6 +79686,7 @@ exports[`adjective 15153 1`] = `
       "vojevničje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vojevničjego / vojevničji",
@@ -78686,6 +79756,7 @@ exports[`adjective 15195 1`] = `
       "vzorne",
     ],
   },
+  "short": "vzorėn",
   "singular": {
     "acc": [
       "vzornogo / vzorny",
@@ -78755,6 +79826,7 @@ exports[`adjective 15203 1`] = `
       "zadnjeprohodne",
     ],
   },
+  "short": "zadnjeprohodėn",
   "singular": {
     "acc": [
       "zadnjeprohodnogo / zadnjeprohodny",
@@ -78824,6 +79896,7 @@ exports[`adjective 15207 1`] = `
       "dokončene",
     ],
   },
+  "short": "dokončen",
   "singular": {
     "acc": [
       "dokončenogo / dokončeny",
@@ -78893,6 +79966,7 @@ exports[`adjective 15222 1`] = `
       "udušene",
     ],
   },
+  "short": "udušen",
   "singular": {
     "acc": [
       "udušenogo / udušeny",
@@ -78962,6 +80036,7 @@ exports[`adjective 15248 1`] = `
       "bezumne",
     ],
   },
+  "short": "bezumėn",
   "singular": {
     "acc": [
       "bezumnogo / bezumny",
@@ -79031,6 +80106,7 @@ exports[`adjective 15251 1`] = `
       "blågomile",
     ],
   },
+  "short": "blågomil",
   "singular": {
     "acc": [
       "blågomilogo / blågomily",
@@ -79100,6 +80176,7 @@ exports[`adjective 15253 1`] = `
       "bobŕje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bobŕjego / bobŕji",
@@ -79169,6 +80246,7 @@ exports[`adjective 15282 1`] = `
       "defisovane",
     ],
   },
+  "short": "defisovan",
   "singular": {
     "acc": [
       "defisovanogo / defisovany",
@@ -79238,6 +80316,7 @@ exports[`adjective 15304 1`] = `
       "doråstle",
     ],
   },
+  "short": "doråstl",
   "singular": {
     "acc": [
       "doråstlogo / doråstly",
@@ -79307,6 +80386,7 @@ exports[`adjective 15309 1`] = `
       "dvojostre",
     ],
   },
+  "short": "dvojostr",
   "singular": {
     "acc": [
       "dvojostrogo / dvojostry",
@@ -79376,6 +80456,7 @@ exports[`adjective 15397 1`] = `
       "penthausne",
     ],
   },
+  "short": "penthausėn",
   "singular": {
     "acc": [
       "penthausnogo / penthausny",
@@ -79445,6 +80526,7 @@ exports[`adjective 15404 1`] = `
       "naslědne",
     ],
   },
+  "short": "naslědėn",
   "singular": {
     "acc": [
       "naslědnogo / naslědny",
@@ -79514,6 +80596,7 @@ exports[`adjective 15420 1`] = `
       "odzavisne",
     ],
   },
+  "short": "odzavisėn",
   "singular": {
     "acc": [
       "odzavisnogo / odzavisny",
@@ -79583,6 +80666,7 @@ exports[`adjective 15491 1`] = `
       "prědimenovane",
     ],
   },
+  "short": "prědimenovan",
   "singular": {
     "acc": [
       "prědimenovanogo / prědimenovany",
@@ -79652,6 +80736,7 @@ exports[`adjective 15492 1`] = `
       "prědprimetne",
     ],
   },
+  "short": "prědprimetėn",
   "singular": {
     "acc": [
       "prědprimetnogo / prědprimetny",
@@ -79721,6 +80806,7 @@ exports[`adjective 15509 1`] = `
       "råvěsničske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "råvěsničskogo / råvěsničsky",
@@ -79790,6 +80876,7 @@ exports[`adjective 15534 1`] = `
       "sěvernomorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sěvernomorskogo / sěvernomorsky",
@@ -79859,6 +80946,7 @@ exports[`adjective 15552 1`] = `
       "smŕteopasne",
     ],
   },
+  "short": "smŕteopasėn",
   "singular": {
     "acc": [
       "smŕteopasnogo / smŕteopasny",
@@ -79928,6 +81016,7 @@ exports[`adjective 15594 1`] = `
       "totožne",
     ],
   },
+  "short": "totožėn",
   "singular": {
     "acc": [
       "totožnogo / totožny",
@@ -79997,6 +81086,7 @@ exports[`adjective 15611 1`] = `
       "tutčasne",
     ],
   },
+  "short": "tutčasėn",
   "singular": {
     "acc": [
       "tutčasnogo / tutčasny",
@@ -80066,6 +81156,7 @@ exports[`adjective 15614 1`] = `
       "tutdenne",
     ],
   },
+  "short": "tutdenėn",
   "singular": {
     "acc": [
       "tutdennogo / tutdenny",
@@ -80135,6 +81226,7 @@ exports[`adjective 15655 1`] = `
       "vzadne",
     ],
   },
+  "short": "vzadėn",
   "singular": {
     "acc": [
       "vzadnogo / vzadny",
@@ -80204,6 +81296,7 @@ exports[`adjective 15674 1`] = `
       "zloumysľne",
     ],
   },
+  "short": "zloumysľėn",
   "singular": {
     "acc": [
       "zloumysľnogo / zloumysľny",
@@ -80273,6 +81366,7 @@ exports[`adjective 15684 1`] = `
       "žiťjeopasne",
     ],
   },
+  "short": "žiťjeopasėn",
   "singular": {
     "acc": [
       "žiťjeopasnogo / žiťjeopasny",
@@ -80342,6 +81436,7 @@ exports[`adjective 15690 1`] = `
       "apelacijne",
     ],
   },
+  "short": "apelacijėn",
   "singular": {
     "acc": [
       "apelacijnogo / apelacijny",
@@ -80411,6 +81506,7 @@ exports[`adjective 15744 1`] = `
       "žučje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "žučjego / žučji",
@@ -80480,6 +81576,7 @@ exports[`adjective 15759 1`] = `
       "alpijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "alpijskogo / alpijsky",
@@ -80549,6 +81646,7 @@ exports[`adjective 15768 1`] = `
       "artistične",
     ],
   },
+  "short": "artističėn",
   "singular": {
     "acc": [
       "artističnogo / artističny",
@@ -80618,6 +81716,7 @@ exports[`adjective 15776 1`] = `
       "avtoritetne",
     ],
   },
+  "short": "avtoritetėn",
   "singular": {
     "acc": [
       "avtoritetnogo / avtoritetny",
@@ -80687,6 +81786,7 @@ exports[`adjective 15818 1`] = `
       "diskusijne",
     ],
   },
+  "short": "diskusijėn",
   "singular": {
     "acc": [
       "diskusijnogo / diskusijny",
@@ -80756,6 +81856,7 @@ exports[`adjective 15952 1`] = `
       "komplikovane",
     ],
   },
+  "short": "komplikovan",
   "singular": {
     "acc": [
       "komplikovanogo / komplikovany",
@@ -80825,6 +81926,7 @@ exports[`adjective 15958 1`] = `
       "kompjuterizovane",
     ],
   },
+  "short": "kompjuterizovan",
   "singular": {
     "acc": [
       "kompjuterizovanogo / kompjuterizovany",
@@ -80894,6 +81996,7 @@ exports[`adjective 15960 1`] = `
       "kompjuterne",
     ],
   },
+  "short": "kompjuterėn",
   "singular": {
     "acc": [
       "kompjuternogo / kompjuterny",
@@ -80963,6 +82066,7 @@ exports[`adjective 15988 1`] = `
       "lunne",
     ],
   },
+  "short": "lunėn",
   "singular": {
     "acc": [
       "lunnogo / lunny",
@@ -81032,6 +82136,7 @@ exports[`adjective 16011 1`] = `
       "molekularne",
     ],
   },
+  "short": "molekularėn",
   "singular": {
     "acc": [
       "molekularnogo / molekularny",
@@ -81101,6 +82206,7 @@ exports[`adjective 16047 1`] = `
       "penisove",
     ],
   },
+  "short": "penisov",
   "singular": {
     "acc": [
       "penisovogo / penisovy",
@@ -81170,6 +82276,7 @@ exports[`adjective 16049 1`] = `
       "pensijne",
     ],
   },
+  "short": "pensijėn",
   "singular": {
     "acc": [
       "pensijnogo / pensijny",
@@ -81239,6 +82346,7 @@ exports[`adjective 16139 1`] = `
       "vikendove",
     ],
   },
+  "short": "vikendov",
   "singular": {
     "acc": [
       "vikendovogo / vikendovy",
@@ -81308,6 +82416,7 @@ exports[`adjective 16228 1`] = `
       "slovenske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "slovenskogo / slovensky",
@@ -81377,6 +82486,7 @@ exports[`adjective 16255 1`] = `
       "nedbale",
     ],
   },
+  "short": "nedbal",
   "singular": {
     "acc": [
       "nedbalogo / nedbaly",
@@ -81446,6 +82556,7 @@ exports[`adjective 16262 1`] = `
       "akademičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "akademičskogo / akademičsky",
@@ -81515,6 +82626,7 @@ exports[`adjective 16264 1`] = `
       "astrologične",
     ],
   },
+  "short": "astrologičėn",
   "singular": {
     "acc": [
       "astrologičnogo / astrologičny",
@@ -81584,6 +82696,7 @@ exports[`adjective 16265 1`] = `
       "astronomične",
     ],
   },
+  "short": "astronomičėn",
   "singular": {
     "acc": [
       "astronomičnogo / astronomičny",
@@ -81653,6 +82766,7 @@ exports[`adjective 16266 1`] = `
       "bezstydne",
     ],
   },
+  "short": "bezstydėn",
   "singular": {
     "acc": [
       "bezstydnogo / bezstydny",
@@ -81722,6 +82836,7 @@ exports[`adjective 16279 1`] = `
       "kubanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kubanskogo / kubansky",
@@ -81791,6 +82906,7 @@ exports[`adjective 16308 1`] = `
       "podzemne",
     ],
   },
+  "short": "podzemėn",
   "singular": {
     "acc": [
       "podzemnogo / podzemny",
@@ -81860,6 +82976,7 @@ exports[`adjective 16335 1`] = `
       "pråzdne",
     ],
   },
+  "short": "pråzdėn",
   "singular": {
     "acc": [
       "pråzdnogo / pråzdny",
@@ -81929,6 +83046,7 @@ exports[`adjective 16337 1`] = `
       "racionaľne",
     ],
   },
+  "short": "racionaľėn",
   "singular": {
     "acc": [
       "racionaľnogo / racionaľny",
@@ -81998,6 +83116,7 @@ exports[`adjective 16350 1`] = `
       "tehnologične",
     ],
   },
+  "short": "tehnologičėn",
   "singular": {
     "acc": [
       "tehnologičnogo / tehnologičny",
@@ -82067,6 +83186,7 @@ exports[`adjective 16365 1`] = `
       "starodavne",
     ],
   },
+  "short": "starodavėn",
   "singular": {
     "acc": [
       "starodavnogo / starodavny",
@@ -82136,6 +83256,7 @@ exports[`adjective 16369 1`] = `
       "antične",
     ],
   },
+  "short": "antičėn",
   "singular": {
     "acc": [
       "antičnogo / antičny",
@@ -82205,6 +83326,7 @@ exports[`adjective 16383 1`] = `
       "vesele",
     ],
   },
+  "short": "vesel",
   "singular": {
     "acc": [
       "veselogo / vesely",
@@ -82274,6 +83396,7 @@ exports[`adjective 16407 1`] = `
       "grbate",
     ],
   },
+  "short": "grbat",
   "singular": {
     "acc": [
       "grbatogo / grbaty",
@@ -82343,6 +83466,7 @@ exports[`adjective 16411 1`] = `
       "anaľne",
     ],
   },
+  "short": "anaľėn",
   "singular": {
     "acc": [
       "anaľnogo / anaľny",
@@ -82412,6 +83536,7 @@ exports[`adjective 16422 1`] = `
       "maksimaľne",
     ],
   },
+  "short": "maksimaľėn",
   "singular": {
     "acc": [
       "maksimaľnogo / maksimaľny",
@@ -82481,6 +83606,7 @@ exports[`adjective 16426 1`] = `
       "dvojčane",
     ],
   },
+  "short": "dvojčan",
   "singular": {
     "acc": [
       "dvojčanogo / dvojčany",
@@ -82550,6 +83676,7 @@ exports[`adjective 16466 1`] = `
       "historične",
     ],
   },
+  "short": "historičėn",
   "singular": {
     "acc": [
       "historičnogo / historičny",
@@ -82619,6 +83746,7 @@ exports[`adjective 16478 1`] = `
       "prostrånne",
     ],
   },
+  "short": "prostrånėn",
   "singular": {
     "acc": [
       "prostrånnogo / prostrånny",
@@ -82688,6 +83816,7 @@ exports[`adjective 16482 1`] = `
       "legkověrne",
     ],
   },
+  "short": "legkověrėn",
   "singular": {
     "acc": [
       "legkověrnogo / legkověrny",
@@ -82757,6 +83886,7 @@ exports[`adjective 16486 1`] = `
       "milosŕdne",
     ],
   },
+  "short": "milosŕdėn",
   "singular": {
     "acc": [
       "milosŕdnogo / milosŕdny",
@@ -82826,6 +83956,7 @@ exports[`adjective 16721 1`] = `
       "naivne",
     ],
   },
+  "short": "naivėn",
   "singular": {
     "acc": [
       "naivnogo / naivny",
@@ -82895,6 +84026,7 @@ exports[`adjective 16735 1`] = `
       "izprodane",
     ],
   },
+  "short": "izprodan",
   "singular": {
     "acc": [
       "izprodanogo / izprodany",
@@ -82964,6 +84096,7 @@ exports[`adjective 16752 1`] = `
       "doslovne",
     ],
   },
+  "short": "doslovėn",
   "singular": {
     "acc": [
       "doslovnogo / doslovny",
@@ -83033,6 +84166,7 @@ exports[`adjective 16754 1`] = `
       "bukvaľne",
     ],
   },
+  "short": "bukvaľėn",
   "singular": {
     "acc": [
       "bukvaľnogo / bukvaľny",
@@ -83102,6 +84236,7 @@ exports[`adjective 16763 1`] = `
       "dvucifrene",
     ],
   },
+  "short": "dvucifren",
   "singular": {
     "acc": [
       "dvucifrenogo / dvucifreny",
@@ -83171,6 +84306,7 @@ exports[`adjective 16798 1`] = `
       "jęčmenne",
     ],
   },
+  "short": "jęčmenėn",
   "singular": {
     "acc": [
       "jęčmennogo / jęčmenny",
@@ -83240,6 +84376,7 @@ exports[`adjective 16801 1`] = `
       "knęžne",
     ],
   },
+  "short": "knęžėn",
   "singular": {
     "acc": [
       "knęžnogo / knęžny",
@@ -83309,6 +84446,7 @@ exports[`adjective 16805 1`] = `
       "okrutne",
     ],
   },
+  "short": "okrutėn",
   "singular": {
     "acc": [
       "okrutnogo / okrutny",
@@ -83378,6 +84516,7 @@ exports[`adjective 16807 1`] = `
       "surove",
     ],
   },
+  "short": "surov",
   "singular": {
     "acc": [
       "surovogo / surovy",
@@ -83447,6 +84586,7 @@ exports[`adjective 16811 1`] = `
       "dvorjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dvorjanskogo / dvorjansky",
@@ -83516,6 +84656,7 @@ exports[`adjective 16820 1`] = `
       "psihologične",
     ],
   },
+  "short": "psihologičėn",
   "singular": {
     "acc": [
       "psihologičnogo / psihologičny",
@@ -83585,6 +84726,7 @@ exports[`adjective 16821 1`] = `
       "teoretične",
     ],
   },
+  "short": "teoretičėn",
   "singular": {
     "acc": [
       "teoretičnogo / teoretičny",
@@ -83654,6 +84796,7 @@ exports[`adjective 16861 1`] = `
       "neizvěstne",
     ],
   },
+  "short": "neizvěstėn",
   "singular": {
     "acc": [
       "neizvěstnogo / neizvěstny",
@@ -83723,6 +84866,7 @@ exports[`adjective 16873 1`] = `
       "učarovane",
     ],
   },
+  "short": "učarovan",
   "singular": {
     "acc": [
       "učarovanogo / učarovany",
@@ -83792,6 +84936,7 @@ exports[`adjective 16901 1`] = `
       "zaměšivajųće",
     ],
   },
+  "short": "zaměšivajųć",
   "singular": {
     "acc": [
       "zaměšivajųćego / zaměšivajųći",
@@ -83861,6 +85006,7 @@ exports[`adjective 16903 1`] = `
       "vněšnje",
     ],
   },
+  "short": "vněšėn",
   "singular": {
     "acc": [
       "vněšnjego / vněšnji",
@@ -83930,6 +85076,7 @@ exports[`adjective 16903-1 1`] = `
       "vněšne",
     ],
   },
+  "short": "vněšėn",
   "singular": {
     "acc": [
       "vněšnogo / vněšny",
@@ -83999,6 +85146,7 @@ exports[`adjective 16918 1`] = `
       "poljne",
     ],
   },
+  "short": "poljėn",
   "singular": {
     "acc": [
       "poljnogo / poljny",
@@ -84068,6 +85216,7 @@ exports[`adjective 16923 1`] = `
       "atematične",
     ],
   },
+  "short": "atematičėn",
   "singular": {
     "acc": [
       "atematičnogo / atematičny",
@@ -84137,6 +85286,7 @@ exports[`adjective 16931 1`] = `
       "digitaľne",
     ],
   },
+  "short": "digitaľėn",
   "singular": {
     "acc": [
       "digitaľnogo / digitaľny",
@@ -84206,6 +85356,7 @@ exports[`adjective 16933 1`] = `
       "edukacijne",
     ],
   },
+  "short": "edukacijėn",
   "singular": {
     "acc": [
       "edukacijnogo / edukacijny",
@@ -84275,6 +85426,7 @@ exports[`adjective 16935 1`] = `
       "grupove",
     ],
   },
+  "short": "grupov",
   "singular": {
     "acc": [
       "grupovogo / grupovy",
@@ -84344,6 +85496,7 @@ exports[`adjective 16936 1`] = `
       "harakteristične",
     ],
   },
+  "short": "harakterističėn",
   "singular": {
     "acc": [
       "harakterističnogo / harakterističny",
@@ -84413,6 +85566,7 @@ exports[`adjective 16947 1`] = `
       "jednosložne",
     ],
   },
+  "short": "jednosložėn",
   "singular": {
     "acc": [
       "jednosložnogo / jednosložny",
@@ -84482,6 +85636,7 @@ exports[`adjective 16952 1`] = `
       "kolikorake",
     ],
   },
+  "short": "kolikorak",
   "singular": {
     "acc": [
       "kolikorakogo / kolikoraky",
@@ -84551,6 +85706,7 @@ exports[`adjective 16957 1`] = `
       "kompromisne",
     ],
   },
+  "short": "kompromisėn",
   "singular": {
     "acc": [
       "kompromisnogo / kompromisny",
@@ -84620,6 +85776,7 @@ exports[`adjective 16963 1`] = `
       "leksikaľne",
     ],
   },
+  "short": "leksikaľėn",
   "singular": {
     "acc": [
       "leksikaľnogo / leksikaľny",
@@ -84689,6 +85846,7 @@ exports[`adjective 16971 1`] = `
       "mnogosložne",
     ],
   },
+  "short": "mnogosložėn",
   "singular": {
     "acc": [
       "mnogosložnogo / mnogosložny",
@@ -84758,6 +85916,7 @@ exports[`adjective 16977 1`] = `
       "nenaučne",
     ],
   },
+  "short": "nenaučėn",
   "singular": {
     "acc": [
       "nenaučnogo / nenaučny",
@@ -84827,6 +85986,7 @@ exports[`adjective 16978 1`] = `
       "neoznačene",
     ],
   },
+  "short": "neoznačen",
   "singular": {
     "acc": [
       "neoznačenogo / neoznačeny",
@@ -84896,6 +86056,7 @@ exports[`adjective 16980 1`] = `
       "neråzumlive",
     ],
   },
+  "short": "neråzumliv",
   "singular": {
     "acc": [
       "neråzumlivogo / neråzumlivy",
@@ -84965,6 +86126,7 @@ exports[`adjective 16981 1`] = `
       "neregularne",
     ],
   },
+  "short": "neregularėn",
   "singular": {
     "acc": [
       "neregularnogo / neregularny",
@@ -85034,6 +86196,7 @@ exports[`adjective 16982 1`] = `
       "nerędne",
     ],
   },
+  "short": "nerędėn",
   "singular": {
     "acc": [
       "nerędnogo / nerędny",
@@ -85103,6 +86266,7 @@ exports[`adjective 16983 1`] = `
       "nežive",
     ],
   },
+  "short": "neživ",
   "singular": {
     "acc": [
       "neživogo / neživy",
@@ -85172,6 +86336,7 @@ exports[`adjective 16987 1`] = `
       "notorične",
     ],
   },
+  "short": "notoričėn",
   "singular": {
     "acc": [
       "notoričnogo / notoričny",
@@ -85241,6 +86406,7 @@ exports[`adjective 16988 1`] = `
       "obćeslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "obćeslovjanskogo / obćeslovjansky",
@@ -85310,6 +86476,7 @@ exports[`adjective 16989 1`] = `
       "oddaljene",
     ],
   },
+  "short": "oddaljen",
   "singular": {
     "acc": [
       "oddaljenogo / oddaljeny",
@@ -85379,6 +86546,7 @@ exports[`adjective 16993 1`] = `
       "ostale",
     ],
   },
+  "short": "ostal",
   "singular": {
     "acc": [
       "ostalogo / ostaly",
@@ -85448,6 +86616,7 @@ exports[`adjective 16997 1`] = `
       "panslavistične",
     ],
   },
+  "short": "panslavističėn",
   "singular": {
     "acc": [
       "panslavističnogo / panslavističny",
@@ -85517,6 +86686,7 @@ exports[`adjective 17011 1`] = `
       "približene",
     ],
   },
+  "short": "približen",
   "singular": {
     "acc": [
       "približenogo / približeny",
@@ -85586,6 +86756,7 @@ exports[`adjective 17016 1`] = `
       "protetične",
     ],
   },
+  "short": "protetičėn",
   "singular": {
     "acc": [
       "protetičnogo / protetičny",
@@ -85655,6 +86826,7 @@ exports[`adjective 17022 1`] = `
       "radiove",
     ],
   },
+  "short": "radiov",
   "singular": {
     "acc": [
       "radiovogo / radiovy",
@@ -85724,6 +86896,7 @@ exports[`adjective 17027 1`] = `
       "rędne",
     ],
   },
+  "short": "rędėn",
   "singular": {
     "acc": [
       "rędnogo / rędny",
@@ -85793,6 +86966,7 @@ exports[`adjective 17035 1`] = `
       "sintetične",
     ],
   },
+  "short": "sintetičėn",
   "singular": {
     "acc": [
       "sintetičnogo / sintetičny",
@@ -85862,6 +87036,7 @@ exports[`adjective 17039 1`] = `
       "skråćene",
     ],
   },
+  "short": "skråćen",
   "singular": {
     "acc": [
       "skråćenogo / skråćeny",
@@ -85931,6 +87106,7 @@ exports[`adjective 17043 1`] = `
       "spokrȯvnjene",
     ],
   },
+  "short": "spokrȯvnjen",
   "singular": {
     "acc": [
       "spokrȯvnjenogo / spokrȯvnjeny",
@@ -86000,6 +87176,7 @@ exports[`adjective 17044 1`] = `
       "starocrkȯvnoslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "starocrkȯvnoslovjanskogo / starocrkȯvnoslovjansky",
@@ -86069,6 +87246,7 @@ exports[`adjective 17045 1`] = `
       "staroslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "staroslovjanskogo / staroslovjansky",
@@ -86138,6 +87316,7 @@ exports[`adjective 17047 1`] = `
       "sųčasne",
     ],
   },
+  "short": "sųčasėn",
   "singular": {
     "acc": [
       "sųčasnogo / sųčasny",
@@ -86207,6 +87386,7 @@ exports[`adjective 17048 1`] = `
       "sųće",
     ],
   },
+  "short": "sųć",
   "singular": {
     "acc": [
       "sųćego / sųći",
@@ -86276,6 +87456,7 @@ exports[`adjective 17049 1`] = `
       "tematične",
     ],
   },
+  "short": "tematičėn",
   "singular": {
     "acc": [
       "tematičnogo / tematičny",
@@ -86345,6 +87526,7 @@ exports[`adjective 17054 1`] = `
       "ukončene",
     ],
   },
+  "short": "ukončen",
   "singular": {
     "acc": [
       "ukončenogo / ukončeny",
@@ -86414,6 +87596,7 @@ exports[`adjective 17056 1`] = `
       "vseslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vseslovjanskogo / vseslovjansky",
@@ -86483,6 +87666,7 @@ exports[`adjective 17064 1`] = `
       "vtorne",
     ],
   },
+  "short": "vtorėn",
   "singular": {
     "acc": [
       "vtornogo / vtorny",
@@ -86552,6 +87736,7 @@ exports[`adjective 17067 1`] = `
       "zakoreněle",
     ],
   },
+  "short": "zakoreněl",
   "singular": {
     "acc": [
       "zakorenělogo / zakoreněly",
@@ -86621,6 +87806,7 @@ exports[`adjective 17069 1`] = `
       "zavisne",
     ],
   },
+  "short": "zavisėn",
   "singular": {
     "acc": [
       "zavisnogo / zavisny",
@@ -86690,6 +87876,7 @@ exports[`adjective 17070 1`] = `
       "znajeme",
     ],
   },
+  "short": "znajem",
   "singular": {
     "acc": [
       "znajemogo / znajemy",
@@ -86759,6 +87946,7 @@ exports[`adjective 17071 1`] = `
       "zonaľne",
     ],
   },
+  "short": "zonaľėn",
   "singular": {
     "acc": [
       "zonaľnogo / zonaľny",
@@ -86828,6 +88016,7 @@ exports[`adjective 17077 1`] = `
       "mnoge",
     ],
   },
+  "short": "mnog",
   "singular": {
     "acc": [
       "mnogogo / mnogy",
@@ -86897,6 +88086,7 @@ exports[`adjective 17108 1`] = `
       "administrativne",
     ],
   },
+  "short": "administrativėn",
   "singular": {
     "acc": [
       "administrativnogo / administrativny",
@@ -86966,6 +88156,7 @@ exports[`adjective 17119 1`] = `
       "alternativne",
     ],
   },
+  "short": "alternativėn",
   "singular": {
     "acc": [
       "alternativnogo / alternativny",
@@ -87035,6 +88226,7 @@ exports[`adjective 17130 1`] = `
       "avtonomne",
     ],
   },
+  "short": "avtonomėn",
   "singular": {
     "acc": [
       "avtonomnogo / avtonomny",
@@ -87104,6 +88296,7 @@ exports[`adjective 17138 1`] = `
       "bezizhodne",
     ],
   },
+  "short": "bezizhodėn",
   "singular": {
     "acc": [
       "bezizhodnogo / bezizhodny",
@@ -87173,6 +88366,7 @@ exports[`adjective 17141 1`] = `
       "bezolovne",
     ],
   },
+  "short": "bezolovėn",
   "singular": {
     "acc": [
       "bezolovnogo / bezolovny",
@@ -87242,6 +88436,7 @@ exports[`adjective 17143 1`] = `
       "bezvyhodne",
     ],
   },
+  "short": "bezvyhodėn",
   "singular": {
     "acc": [
       "bezvyhodnogo / bezvyhodny",
@@ -87311,6 +88506,7 @@ exports[`adjective 17151 1`] = `
       "bogatyrske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bogatyrskogo / bogatyrsky",
@@ -87380,6 +88576,7 @@ exports[`adjective 17171 1`] = `
       "brěmenne",
     ],
   },
+  "short": "brěmenėn",
   "singular": {
     "acc": [
       "brěmennogo / brěmenny",
@@ -87449,6 +88646,7 @@ exports[`adjective 17193 1`] = `
       "čehoslovačske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "čehoslovačskogo / čehoslovačsky",
@@ -87518,6 +88716,7 @@ exports[`adjective 17197 1`] = `
       "čelične",
     ],
   },
+  "short": "čeličėn",
   "singular": {
     "acc": [
       "čeličnogo / čeličny",
@@ -87587,6 +88786,7 @@ exports[`adjective 17202 1`] = `
       "čestigodne",
     ],
   },
+  "short": "čestigodėn",
   "singular": {
     "acc": [
       "čestigodnogo / čestigodny",
@@ -87656,6 +88856,7 @@ exports[`adjective 17232 1`] = `
       "čudne",
     ],
   },
+  "short": "čudėn",
   "singular": {
     "acc": [
       "čudnogo / čudny",
@@ -87725,6 +88926,7 @@ exports[`adjective 17243 1`] = `
       "darovite",
     ],
   },
+  "short": "darovit",
   "singular": {
     "acc": [
       "darovitogo / darovity",
@@ -87794,6 +88996,7 @@ exports[`adjective 17254 1`] = `
       "dnešnje",
     ],
   },
+  "short": "dnešėn",
   "singular": {
     "acc": [
       "dnešnjego / dnešnji",
@@ -87863,6 +89066,7 @@ exports[`adjective 17254-1 1`] = `
       "dnešne",
     ],
   },
+  "short": "dnešėn",
   "singular": {
     "acc": [
       "dnešnogo / dnešny",
@@ -87932,6 +89136,7 @@ exports[`adjective 17277 1`] = `
       "dobrovoljne",
     ],
   },
+  "short": "dobrovoljėn",
   "singular": {
     "acc": [
       "dobrovoljnogo / dobrovoljny",
@@ -88001,6 +89206,7 @@ exports[`adjective 17301 1`] = `
       "dȯlgoživene",
     ],
   },
+  "short": "dȯlgoživen",
   "singular": {
     "acc": [
       "dȯlgoživenogo / dȯlgoživeny",
@@ -88070,6 +89276,7 @@ exports[`adjective 17304 1`] = `
       "dȯlgoživostne",
     ],
   },
+  "short": "dȯlgoživostėn",
   "singular": {
     "acc": [
       "dȯlgoživostnogo / dȯlgoživostny",
@@ -88139,6 +89346,7 @@ exports[`adjective 17305 1`] = `
       "domašnje",
     ],
   },
+  "short": "domašėn",
   "singular": {
     "acc": [
       "domašnjego / domašnji",
@@ -88208,6 +89416,7 @@ exports[`adjective 17305-1 1`] = `
       "domašne",
     ],
   },
+  "short": "domašėn",
   "singular": {
     "acc": [
       "domašnogo / domašny",
@@ -88277,6 +89486,7 @@ exports[`adjective 17310 1`] = `
       "domorodne",
     ],
   },
+  "short": "domorodėn",
   "singular": {
     "acc": [
       "domorodnogo / domorodny",
@@ -88346,6 +89556,7 @@ exports[`adjective 17317 1`] = `
       "dopȯlnjene",
     ],
   },
+  "short": "dopȯlnjen",
   "singular": {
     "acc": [
       "dopȯlnjenogo / dopȯlnjeny",
@@ -88415,6 +89626,7 @@ exports[`adjective 17327 1`] = `
       "dosadne",
     ],
   },
+  "short": "dosadėn",
   "singular": {
     "acc": [
       "dosadnogo / dosadny",
@@ -88484,6 +89696,7 @@ exports[`adjective 17331 1`] = `
       "doslědne",
     ],
   },
+  "short": "doslědėn",
   "singular": {
     "acc": [
       "doslědnogo / doslědny",
@@ -88553,6 +89766,7 @@ exports[`adjective 17342 1`] = `
       "drugorędne",
     ],
   },
+  "short": "drugorędėn",
   "singular": {
     "acc": [
       "drugorędnogo / drugorędny",
@@ -88622,6 +89836,7 @@ exports[`adjective 17349 1`] = `
       "duševne",
     ],
   },
+  "short": "duševėn",
   "singular": {
     "acc": [
       "duševnogo / duševny",
@@ -88691,6 +89906,7 @@ exports[`adjective 17359 1`] = `
       "dvulične",
     ],
   },
+  "short": "dvuličėn",
   "singular": {
     "acc": [
       "dvuličnogo / dvuličny",
@@ -88760,6 +89976,7 @@ exports[`adjective 17363 1`] = `
       "dvusmysľne",
     ],
   },
+  "short": "dvusmysľėn",
   "singular": {
     "acc": [
       "dvusmysľnogo / dvusmysľny",
@@ -88829,6 +90046,7 @@ exports[`adjective 17367 1`] = `
       "dvuznačne",
     ],
   },
+  "short": "dvuznačėn",
   "singular": {
     "acc": [
       "dvuznačnogo / dvuznačny",
@@ -88898,6 +90116,7 @@ exports[`adjective 17379 1`] = `
       "fiktivne",
     ],
   },
+  "short": "fiktivėn",
   "singular": {
     "acc": [
       "fiktivnogo / fiktivny",
@@ -88967,6 +90186,7 @@ exports[`adjective 17392 1`] = `
       "geniaľne",
     ],
   },
+  "short": "geniaľėn",
   "singular": {
     "acc": [
       "geniaľnogo / geniaľny",
@@ -89036,6 +90256,7 @@ exports[`adjective 17397 1`] = `
       "gybke",
     ],
   },
+  "short": "gybȯk",
   "singular": {
     "acc": [
       "gybkogo / gybky",
@@ -89105,6 +90326,7 @@ exports[`adjective 17428 1`] = `
       "gorlive",
     ],
   },
+  "short": "gorliv",
   "singular": {
     "acc": [
       "gorlivogo / gorlivy",
@@ -89174,6 +90396,7 @@ exports[`adjective 17435 1`] = `
       "grådske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "grådskogo / grådsky",
@@ -89243,6 +90466,7 @@ exports[`adjective 17449 1`] = `
       "hirugične",
     ],
   },
+  "short": "hirugičėn",
   "singular": {
     "acc": [
       "hirugičnogo / hirugičny",
@@ -89312,6 +90536,7 @@ exports[`adjective 17452 1`] = `
       "hytre",
     ],
   },
+  "short": "hytr",
   "singular": {
     "acc": [
       "hytrogo / hytry",
@@ -89381,6 +90606,7 @@ exports[`adjective 17487 1`] = `
       "imųće",
     ],
   },
+  "short": "imųć",
   "singular": {
     "acc": [
       "imųćego / imųći",
@@ -89450,6 +90676,7 @@ exports[`adjective 17509 1`] = `
       "izbrane",
     ],
   },
+  "short": "izbran",
   "singular": {
     "acc": [
       "izbranogo / izbrany",
@@ -89519,6 +90746,7 @@ exports[`adjective 17531 1`] = `
       "izgodne",
     ],
   },
+  "short": "izgodėn",
   "singular": {
     "acc": [
       "izgodnogo / izgodny",
@@ -89588,6 +90816,7 @@ exports[`adjective 17586 1`] = `
       "izrazne",
     ],
   },
+  "short": "izrazėn",
   "singular": {
     "acc": [
       "izraznogo / izrazny",
@@ -89657,6 +90886,7 @@ exports[`adjective 17594 1`] = `
       "iztočnoslovjanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "iztočnoslovjanskogo / iztočnoslovjansky",
@@ -89726,6 +90956,7 @@ exports[`adjective 17615 1`] = `
       "jedinove",
     ],
   },
+  "short": "jedinov",
   "singular": {
     "acc": [
       "jedinovogo / jedinovy",
@@ -89795,6 +91026,7 @@ exports[`adjective 17619 1`] = `
       "jednoglåsne",
     ],
   },
+  "short": "jednoglåsėn",
   "singular": {
     "acc": [
       "jednoglåsnogo / jednoglåsny",
@@ -89864,6 +91096,7 @@ exports[`adjective 17625 1`] = `
       "jednoznačne",
     ],
   },
+  "short": "jednoznačėn",
   "singular": {
     "acc": [
       "jednoznačnogo / jednoznačny",
@@ -89933,6 +91166,7 @@ exports[`adjective 17631 1`] = `
       "języčne",
     ],
   },
+  "short": "języčėn",
   "singular": {
     "acc": [
       "języčnogo / języčny",
@@ -90002,6 +91236,7 @@ exports[`adjective 17641 1`] = `
       "kaštanove",
     ],
   },
+  "short": "kaštanov",
   "singular": {
     "acc": [
       "kaštanovogo / kaštanovy",
@@ -90071,6 +91306,7 @@ exports[`adjective 17670 1`] = `
       "kompetitivne",
     ],
   },
+  "short": "kompetitivėn",
   "singular": {
     "acc": [
       "kompetitivnogo / kompetitivny",
@@ -90140,6 +91376,7 @@ exports[`adjective 17679 1`] = `
       "konkurencijne",
     ],
   },
+  "short": "konkurencijėn",
   "singular": {
     "acc": [
       "konkurencijnogo / konkurencijny",
@@ -90209,6 +91446,7 @@ exports[`adjective 17691 1`] = `
       "kosmične",
     ],
   },
+  "short": "kosmičėn",
   "singular": {
     "acc": [
       "kosmičnogo / kosmičny",
@@ -90278,6 +91516,7 @@ exports[`adjective 17709 1`] = `
       "krȯvne",
     ],
   },
+  "short": "krȯvėn",
   "singular": {
     "acc": [
       "krȯvnogo / krȯvny",
@@ -90347,6 +91586,7 @@ exports[`adjective 17726 1`] = `
       "legše",
     ],
   },
+  "short": "legš",
   "singular": {
     "acc": [
       "legšego / legši",
@@ -90416,6 +91656,7 @@ exports[`adjective 17731 1`] = `
       "lěsiste",
     ],
   },
+  "short": "lěsist",
   "singular": {
     "acc": [
       "lěsistogo / lěsisty",
@@ -90485,6 +91726,7 @@ exports[`adjective 17746 1`] = `
       "lȯžne",
     ],
   },
+  "short": "lȯžėn",
   "singular": {
     "acc": [
       "lȯžnogo / lȯžny",
@@ -90554,6 +91796,7 @@ exports[`adjective 17752 1`] = `
       "lukove",
     ],
   },
+  "short": "lukov",
   "singular": {
     "acc": [
       "lukovogo / lukovy",
@@ -90623,6 +91866,7 @@ exports[`adjective 17753 1`] = `
       "lžive",
     ],
   },
+  "short": "lživ",
   "singular": {
     "acc": [
       "lživogo / lživy",
@@ -90692,6 +91936,7 @@ exports[`adjective 17755 1`] = `
       "malodušne",
     ],
   },
+  "short": "malodušėn",
   "singular": {
     "acc": [
       "malodušnogo / malodušny",
@@ -90761,6 +92006,7 @@ exports[`adjective 17764 1`] = `
       "marlive",
     ],
   },
+  "short": "marliv",
   "singular": {
     "acc": [
       "marlivogo / marlivy",
@@ -90830,6 +92076,7 @@ exports[`adjective 17772 1`] = `
       "međusobne",
     ],
   },
+  "short": "međusobėn",
   "singular": {
     "acc": [
       "međusobnogo / međusobny",
@@ -90899,6 +92146,7 @@ exports[`adjective 17786 1`] = `
       "mimohodne",
     ],
   },
+  "short": "mimohodėn",
   "singular": {
     "acc": [
       "mimohodnogo / mimohodny",
@@ -90968,6 +92216,7 @@ exports[`adjective 17811 1`] = `
       "mråžene",
     ],
   },
+  "short": "mråžen",
   "singular": {
     "acc": [
       "mråženogo / mråženy",
@@ -91037,6 +92286,7 @@ exports[`adjective 17829 1`] = `
       "nabožne",
     ],
   },
+  "short": "nabožėn",
   "singular": {
     "acc": [
       "nabožnogo / nabožny",
@@ -91106,6 +92356,7 @@ exports[`adjective 17834 1`] = `
       "nacionalistične",
     ],
   },
+  "short": "nacionalističėn",
   "singular": {
     "acc": [
       "nacionalističnogo / nacionalističny",
@@ -91169,6 +92420,7 @@ exports[`adjective 17862 1`] = `
       "najlegše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najlegšego / najlegši",
@@ -91232,6 +92484,7 @@ exports[`adjective 17866 1`] = `
       "najprostějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najprostějšego / najprostějši",
@@ -91301,6 +92554,7 @@ exports[`adjective 17892 1`] = `
       "navětrne",
     ],
   },
+  "short": "navětrėn",
   "singular": {
     "acc": [
       "navětrnogo / navětrny",
@@ -91370,6 +92624,7 @@ exports[`adjective 17896 1`] = `
       "neboge",
     ],
   },
+  "short": "nebog",
   "singular": {
     "acc": [
       "nebogogo / nebogy",
@@ -91439,6 +92694,7 @@ exports[`adjective 17898 1`] = `
       "nebyvale",
     ],
   },
+  "short": "nebyval",
   "singular": {
     "acc": [
       "nebyvalogo / nebyvaly",
@@ -91508,6 +92764,7 @@ exports[`adjective 17900 1`] = `
       "nedostųpne",
     ],
   },
+  "short": "nedostųpėn",
   "singular": {
     "acc": [
       "nedostųpnogo / nedostųpny",
@@ -91577,6 +92834,7 @@ exports[`adjective 17913 1`] = `
       "nekrasne",
     ],
   },
+  "short": "nekrasėn",
   "singular": {
     "acc": [
       "nekrasnogo / nekrasny",
@@ -91646,6 +92904,7 @@ exports[`adjective 17914 1`] = `
       "neobrazovane",
     ],
   },
+  "short": "neobrazovan",
   "singular": {
     "acc": [
       "neobrazovanogo / neobrazovany",
@@ -91715,6 +92974,7 @@ exports[`adjective 17924 1`] = `
       "nepȯlnomožne",
     ],
   },
+  "short": "nepȯlnomožėn",
   "singular": {
     "acc": [
       "nepȯlnomožnogo / nepȯlnomožny",
@@ -91784,6 +93044,7 @@ exports[`adjective 17932 1`] = `
       "nepȯlnosposobne",
     ],
   },
+  "short": "nepȯlnosposobėn",
   "singular": {
     "acc": [
       "nepȯlnosposobnogo / nepȯlnosposobny",
@@ -91853,6 +93114,7 @@ exports[`adjective 17937 1`] = `
       "neprěhodne",
     ],
   },
+  "short": "neprěhodėn",
   "singular": {
     "acc": [
       "neprěhodnogo / neprěhodny",
@@ -91922,6 +93184,7 @@ exports[`adjective 17938 1`] = `
       "neprodyšne",
     ],
   },
+  "short": "neprodyšėn",
   "singular": {
     "acc": [
       "neprodyšnogo / neprodyšny",
@@ -91991,6 +93254,7 @@ exports[`adjective 17942 1`] = `
       "neudobne",
     ],
   },
+  "short": "neudobėn",
   "singular": {
     "acc": [
       "neudobnogo / neudobny",
@@ -92060,6 +93324,7 @@ exports[`adjective 17943 1`] = `
       "neustųplive",
     ],
   },
+  "short": "neustųpliv",
   "singular": {
     "acc": [
       "neustųplivogo / neustųplivy",
@@ -92129,6 +93394,7 @@ exports[`adjective 17943-1 1`] = `
       "neustųpne",
     ],
   },
+  "short": "neustųpėn",
   "singular": {
     "acc": [
       "neustųpnogo / neustųpny",
@@ -92198,6 +93464,7 @@ exports[`adjective 17950 1`] = `
       "nezadovoljene",
     ],
   },
+  "short": "nezadovoljen",
   "singular": {
     "acc": [
       "nezadovoljenogo / nezadovoljeny",
@@ -92267,6 +93534,7 @@ exports[`adjective 17958 1`] = `
       "nezavisne",
     ],
   },
+  "short": "nezavisėn",
   "singular": {
     "acc": [
       "nezavisnogo / nezavisny",
@@ -92336,6 +93604,7 @@ exports[`adjective 17960 1`] = `
       "neznajeme",
     ],
   },
+  "short": "neznajem",
   "singular": {
     "acc": [
       "neznajemogo / neznajemy",
@@ -92405,6 +93674,7 @@ exports[`adjective 17975 1`] = `
       "nudne",
     ],
   },
+  "short": "nudėn",
   "singular": {
     "acc": [
       "nudnogo / nudny",
@@ -92474,6 +93744,7 @@ exports[`adjective 18030 1`] = `
       "obråtne",
     ],
   },
+  "short": "obråtėn",
   "singular": {
     "acc": [
       "obråtnogo / obråtny",
@@ -92543,6 +93814,7 @@ exports[`adjective 18040 1`] = `
       "obyčajne",
     ],
   },
+  "short": "obyčajėn",
   "singular": {
     "acc": [
       "obyčajnogo / obyčajny",
@@ -92612,6 +93884,7 @@ exports[`adjective 18050 1`] = `
       "oceljeve",
     ],
   },
+  "short": "oceljev",
   "singular": {
     "acc": [
       "oceljevogo / oceljevy",
@@ -92681,6 +93954,7 @@ exports[`adjective 18062 1`] = `
       "oddane",
     ],
   },
+  "short": "oddan",
   "singular": {
     "acc": [
       "oddanogo / oddany",
@@ -92750,6 +94024,7 @@ exports[`adjective 18083 1`] = `
       "odomašnjene",
     ],
   },
+  "short": "odomašnjen",
   "singular": {
     "acc": [
       "odomašnjenogo / odomašnjeny",
@@ -92819,6 +94094,7 @@ exports[`adjective 18143 1`] = `
       "oplođene",
     ],
   },
+  "short": "oplođen",
   "singular": {
     "acc": [
       "oplođenogo / oplođeny",
@@ -92853,67 +94129,59 @@ exports[`adjective 18143 1`] = `
 exports[`adjective 18156 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "ši",
-      "je",
-    ],
-    "positive": [
-      "y",
-      "o",
-    ],
-    "superlative": [
-      "najši",
-      "najje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
-      "yh / e",
-      "e",
+      "osnovanyh na / osnovane na",
+      "osnovane na",
     ],
     "dat": [
-      "ym",
+      "osnovanym na",
     ],
     "gen": [
-      "yh",
+      "osnovanyh na",
     ],
     "ins": [
-      "ymi",
+      "osnovanymi na",
     ],
     "loc": [
-      "yh",
+      "osnovanyh na",
     ],
     "nom": [
-      "i / e",
-      "e",
+      "osnovani na / osnovane na",
+      "osnovane na",
     ],
   },
+  "short": "osnovan",
   "singular": {
     "acc": [
-      "ogo / osnovany na",
-      "o",
-      "ų",
+      "osnovanogo na / osnovany na",
+      "osnovano na",
+      "osnovanų na",
     ],
     "dat": [
-      "omu",
-      "oj",
+      "osnovanomu na",
+      "osnovanoj na",
     ],
     "gen": [
-      "ogo",
-      "oj",
+      "osnovanogo na",
+      "osnovanoj na",
     ],
     "ins": [
-      "ym",
-      "ojų",
+      "osnovanym na",
+      "osnovanojų na",
     ],
     "loc": [
-      "om",
-      "oj",
+      "osnovanom na",
+      "osnovanoj na",
     ],
     "nom": [
-      "y",
-      "o",
-      "a",
+      "osnovany na",
+      "osnovano na",
+      "osnovana na",
     ],
   },
 }
@@ -92957,6 +94225,7 @@ exports[`adjective 18192 1`] = `
       "označene",
     ],
   },
+  "short": "označen",
   "singular": {
     "acc": [
       "označenogo / označeny",
@@ -93026,6 +94295,7 @@ exports[`adjective 18211 1`] = `
       "plastične",
     ],
   },
+  "short": "plastičėn",
   "singular": {
     "acc": [
       "plastičnogo / plastičny",
@@ -93095,6 +94365,7 @@ exports[`adjective 18213 1`] = `
       "plastikove",
     ],
   },
+  "short": "plastikov",
   "singular": {
     "acc": [
       "plastikovogo / plastikovy",
@@ -93164,6 +94435,7 @@ exports[`adjective 18262 1`] = `
       "podle",
     ],
   },
+  "short": "podl",
   "singular": {
     "acc": [
       "podlogo / podly",
@@ -93233,6 +94505,7 @@ exports[`adjective 18266 1`] = `
       "podnebne",
     ],
   },
+  "short": "podnebėn",
   "singular": {
     "acc": [
       "podnebnogo / podnebny",
@@ -93302,6 +94575,7 @@ exports[`adjective 18330 1`] = `
       "poslěporodne",
     ],
   },
+  "short": "poslěporodėn",
   "singular": {
     "acc": [
       "poslěporodnogo / poslěporodny",
@@ -93371,6 +94645,7 @@ exports[`adjective 18333 1`] = `
       "posvęćene",
     ],
   },
+  "short": "posvęćen",
   "singular": {
     "acc": [
       "posvęćenogo / posvęćeny",
@@ -93440,6 +94715,7 @@ exports[`adjective 18346 1`] = `
       "potvŕđene",
     ],
   },
+  "short": "potvŕđen",
   "singular": {
     "acc": [
       "potvŕđenogo / potvŕđeny",
@@ -93509,6 +94785,7 @@ exports[`adjective 18383 1`] = `
       "pravedne",
     ],
   },
+  "short": "pravedėn",
   "singular": {
     "acc": [
       "pravednogo / pravedny",
@@ -93578,6 +94855,7 @@ exports[`adjective 18398 1`] = `
       "prědminųle",
     ],
   },
+  "short": "prědminųl",
   "singular": {
     "acc": [
       "prědminųlogo / prědminųly",
@@ -93647,6 +94925,7 @@ exports[`adjective 18422 1`] = `
       "prěinačene",
     ],
   },
+  "short": "prěinačen",
   "singular": {
     "acc": [
       "prěinačenogo / prěinačeny",
@@ -93681,67 +94960,59 @@ exports[`adjective 18422 1`] = `
 exports[`adjective 18452 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "ši",
-      "je",
-    ],
-    "positive": [
-      "y",
-      "o",
-    ],
-    "superlative": [
-      "najši",
-      "najje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
-      "yh / e",
-      "e",
+      "prěznačenyh za / prěznačene za",
+      "prěznačene za",
     ],
     "dat": [
-      "ym",
+      "prěznačenym za",
     ],
     "gen": [
-      "yh",
+      "prěznačenyh za",
     ],
     "ins": [
-      "ymi",
+      "prěznačenymi za",
     ],
     "loc": [
-      "yh",
+      "prěznačenyh za",
     ],
     "nom": [
-      "i / e",
-      "e",
+      "prěznačeni za / prěznačene za",
+      "prěznačene za",
     ],
   },
+  "short": "prěznačen",
   "singular": {
     "acc": [
-      "ogo / prěznačeny za",
-      "o",
-      "ų",
+      "prěznačenogo za / prěznačeny za",
+      "prěznačeno za",
+      "prěznačenų za",
     ],
     "dat": [
-      "omu",
-      "oj",
+      "prěznačenomu za",
+      "prěznačenoj za",
     ],
     "gen": [
-      "ogo",
-      "oj",
+      "prěznačenogo za",
+      "prěznačenoj za",
     ],
     "ins": [
-      "ym",
-      "ojų",
+      "prěznačenym za",
+      "prěznačenojų za",
     ],
     "loc": [
-      "om",
-      "oj",
+      "prěznačenom za",
+      "prěznačenoj za",
     ],
     "nom": [
-      "y",
-      "o",
-      "a",
+      "prěznačeny za",
+      "prěznačeno za",
+      "prěznačena za",
     ],
   },
 }
@@ -93785,6 +95056,7 @@ exports[`adjective 18500 1`] = `
       "pritvorne",
     ],
   },
+  "short": "pritvorėn",
   "singular": {
     "acc": [
       "pritvornogo / pritvorny",
@@ -93854,6 +95126,7 @@ exports[`adjective 18504 1`] = `
       "probne",
     ],
   },
+  "short": "probėn",
   "singular": {
     "acc": [
       "probnogo / probny",
@@ -93923,6 +95196,7 @@ exports[`adjective 18522 1`] = `
       "prohlådne",
     ],
   },
+  "short": "prohlådėn",
   "singular": {
     "acc": [
       "prohlådnogo / prohlådny",
@@ -93989,6 +95263,7 @@ exports[`adjective 18540 1`] = `
       "prostějše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "prostějšego / prostějši",
@@ -94058,6 +95333,7 @@ exports[`adjective 18555 1`] = `
       "pŕvobytne",
     ],
   },
+  "short": "pŕvobytėn",
   "singular": {
     "acc": [
       "pŕvobytnogo / pŕvobytny",
@@ -94127,6 +95403,7 @@ exports[`adjective 18559 1`] = `
       "pŕvotne",
     ],
   },
+  "short": "pŕvotėn",
   "singular": {
     "acc": [
       "pŕvotnogo / pŕvotny",
@@ -94196,6 +95473,7 @@ exports[`adjective 18588 1`] = `
       "råvnopravne",
     ],
   },
+  "short": "råvnopravėn",
   "singular": {
     "acc": [
       "råvnopravnogo / råvnopravny",
@@ -94265,6 +95543,7 @@ exports[`adjective 18633 1`] = `
       "redakcijne",
     ],
   },
+  "short": "redakcijėn",
   "singular": {
     "acc": [
       "redakcijnogo / redakcijny",
@@ -94334,6 +95613,7 @@ exports[`adjective 18635 1`] = `
       "rěšene",
     ],
   },
+  "short": "rěšen",
   "singular": {
     "acc": [
       "rěšenogo / rěšeny",
@@ -94403,6 +95683,7 @@ exports[`adjective 18640 1`] = `
       "rimskokatoličske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "rimskokatoličskogo / rimskokatoličsky",
@@ -94472,6 +95753,7 @@ exports[`adjective 18662 1`] = `
       "rųčne",
     ],
   },
+  "short": "rųčėn",
   "singular": {
     "acc": [
       "rųčnogo / rųčny",
@@ -94541,6 +95823,7 @@ exports[`adjective 18686 1`] = `
       "sdanlive",
     ],
   },
+  "short": "sdanliv",
   "singular": {
     "acc": [
       "sdanlivogo / sdanlivy",
@@ -94610,6 +95893,7 @@ exports[`adjective 18691 1`] = `
       "shodne",
     ],
   },
+  "short": "shodėn",
   "singular": {
     "acc": [
       "shodnogo / shodny",
@@ -94679,6 +95963,7 @@ exports[`adjective 18723 1`] = `
       "snuđene",
     ],
   },
+  "short": "snuđen",
   "singular": {
     "acc": [
       "snuđenogo / snuđeny",
@@ -94748,6 +96033,7 @@ exports[`adjective 18760 1`] = `
       "svråtne",
     ],
   },
+  "short": "svråtėn",
   "singular": {
     "acc": [
       "svråtnogo / svråtny",
@@ -94817,6 +96103,7 @@ exports[`adjective 18769 1`] = `
       "samobytne",
     ],
   },
+  "short": "samobytėn",
   "singular": {
     "acc": [
       "samobytnogo / samobytny",
@@ -94886,6 +96173,7 @@ exports[`adjective 18777 1`] = `
       "samostojne",
     ],
   },
+  "short": "samostojėn",
   "singular": {
     "acc": [
       "samostojnogo / samostojny",
@@ -94955,6 +96243,7 @@ exports[`adjective 18784 1`] = `
       "ščedre",
     ],
   },
+  "short": "ščedr",
   "singular": {
     "acc": [
       "ščedrogo / ščedry",
@@ -95024,6 +96313,7 @@ exports[`adjective 18792 1`] = `
       "seběčne",
     ],
   },
+  "short": "seběčėn",
   "singular": {
     "acc": [
       "seběčnogo / seběčny",
@@ -95093,6 +96383,7 @@ exports[`adjective 18795 1`] = `
       "sedmične",
     ],
   },
+  "short": "sedmičėn",
   "singular": {
     "acc": [
       "sedmičnogo / sedmičny",
@@ -95162,6 +96453,7 @@ exports[`adjective 18815 1`] = `
       "shematične",
     ],
   },
+  "short": "shematičėn",
   "singular": {
     "acc": [
       "shematičnogo / shematičny",
@@ -95231,6 +96523,7 @@ exports[`adjective 18831 1`] = `
       "šljahetne",
     ],
   },
+  "short": "šljahetėn",
   "singular": {
     "acc": [
       "šljahetnogo / šljahetny",
@@ -95300,6 +96593,7 @@ exports[`adjective 18840 1`] = `
       "slovesne",
     ],
   },
+  "short": "slovesėn",
   "singular": {
     "acc": [
       "slovesnogo / slovesny",
@@ -95369,6 +96663,7 @@ exports[`adjective 18882 1`] = `
       "sportivne",
     ],
   },
+  "short": "sportivėn",
   "singular": {
     "acc": [
       "sportivnogo / sportivny",
@@ -95438,6 +96733,7 @@ exports[`adjective 18884 1`] = `
       "sŕdečnosȯsųdne",
     ],
   },
+  "short": "sŕdečnosȯsųdėn",
   "singular": {
     "acc": [
       "sŕdečnosȯsųdnogo / sŕdečnosȯsųdny",
@@ -95507,6 +96803,7 @@ exports[`adjective 18890 1`] = `
       "srědnjevěčne",
     ],
   },
+  "short": "srědnjevěčėn",
   "singular": {
     "acc": [
       "srědnjevěčnogo / srědnjevěčny",
@@ -95576,6 +96873,7 @@ exports[`adjective 18892 1`] = `
       "stalove",
     ],
   },
+  "short": "stalov",
   "singular": {
     "acc": [
       "stalovogo / stalovy",
@@ -95645,6 +96943,7 @@ exports[`adjective 18896 1`] = `
       "statične",
     ],
   },
+  "short": "statičėn",
   "singular": {
     "acc": [
       "statičnogo / statičny",
@@ -95714,6 +97013,7 @@ exports[`adjective 18897 1`] = `
       "statistične",
     ],
   },
+  "short": "statističėn",
   "singular": {
     "acc": [
       "statističnogo / statističny",
@@ -95783,6 +97083,7 @@ exports[`adjective 18908 1`] = `
       "stolične",
     ],
   },
+  "short": "stoličėn",
   "singular": {
     "acc": [
       "stoličnogo / stoličny",
@@ -95852,6 +97153,7 @@ exports[`adjective 18921 1`] = `
       "sųmniteljne",
     ],
   },
+  "short": "sųmniteljėn",
   "singular": {
     "acc": [
       "sųmniteljnogo / sųmniteljny",
@@ -95921,6 +97223,7 @@ exports[`adjective 18929 1`] = `
       "svęćene",
     ],
   },
+  "short": "svęćen",
   "singular": {
     "acc": [
       "svęćenogo / svęćeny",
@@ -95990,6 +97293,7 @@ exports[`adjective 18934 1`] = `
       "svinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "svinskogo / svinsky",
@@ -96059,6 +97363,7 @@ exports[`adjective 18935 1`] = `
       "svojske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "svojskogo / svojsky",
@@ -96093,18 +97398,9 @@ exports[`adjective 18935 1`] = `
 exports[`adjective 18942 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "tako rěčenějši",
-      "tako rěčeněje",
-    ],
-    "positive": [
-      "tako rěčeny",
-      "tako rěčeno",
-    ],
-    "superlative": [
-      "najtako rěčenějši",
-      "najtako rěčeněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -96128,6 +97424,7 @@ exports[`adjective 18942 1`] = `
       "tako rěčene",
     ],
   },
+  "short": "tako rěčen",
   "singular": {
     "acc": [
       "tako rěčenogo / tako rěčeny",
@@ -96197,6 +97494,7 @@ exports[`adjective 18958 1`] = `
       "temnolavandove",
     ],
   },
+  "short": "temnolavandov",
   "singular": {
     "acc": [
       "temnolavandovogo / temnolavandovy",
@@ -96266,6 +97564,7 @@ exports[`adjective 18991 1`] = `
       "trězve",
     ],
   },
+  "short": "trězv",
   "singular": {
     "acc": [
       "trězvogo / trězvy",
@@ -96335,6 +97634,7 @@ exports[`adjective 18998 1`] = `
       "tŕpime",
     ],
   },
+  "short": "tŕpim",
   "singular": {
     "acc": [
       "tŕpimogo / tŕpimy",
@@ -96404,6 +97704,7 @@ exports[`adjective 19004 1`] = `
       "trudoljubive",
     ],
   },
+  "short": "trudoljubiv",
   "singular": {
     "acc": [
       "trudoljubivogo / trudoljubivy",
@@ -96473,6 +97774,7 @@ exports[`adjective 19015 1`] = `
       "tvŕdoglåve",
     ],
   },
+  "short": "tvŕdoglåv",
   "singular": {
     "acc": [
       "tvŕdoglåvogo / tvŕdoglåvy",
@@ -96542,6 +97844,7 @@ exports[`adjective 19019 1`] = `
       "uboge",
     ],
   },
+  "short": "ubog",
   "singular": {
     "acc": [
       "ubogogo / ubogy",
@@ -96611,6 +97914,7 @@ exports[`adjective 19026 1`] = `
       "učtive",
     ],
   },
+  "short": "učtiv",
   "singular": {
     "acc": [
       "učtivogo / učtivy",
@@ -96680,6 +97984,7 @@ exports[`adjective 19035 1`] = `
       "udobne",
     ],
   },
+  "short": "udobėn",
   "singular": {
     "acc": [
       "udobnogo / udobny",
@@ -96749,6 +98054,7 @@ exports[`adjective 19045 1`] = `
       "ugodne",
     ],
   },
+  "short": "ugodėn",
   "singular": {
     "acc": [
       "ugodnogo / ugodny",
@@ -96818,6 +98124,7 @@ exports[`adjective 19070 1`] = `
       "uporne",
     ],
   },
+  "short": "uporėn",
   "singular": {
     "acc": [
       "upornogo / uporny",
@@ -96887,6 +98194,7 @@ exports[`adjective 19104 1`] = `
       "uvažne",
     ],
   },
+  "short": "uvažėn",
   "singular": {
     "acc": [
       "uvažnogo / uvažny",
@@ -96956,6 +98264,7 @@ exports[`adjective 19129 1`] = `
       "vȯzbrånjene",
     ],
   },
+  "short": "vȯzbrånjen",
   "singular": {
     "acc": [
       "vȯzbrånjenogo / vȯzbrånjeny",
@@ -97025,6 +98334,7 @@ exports[`adjective 19165 1`] = `
       "velebne",
     ],
   },
+  "short": "velebėn",
   "singular": {
     "acc": [
       "velebnogo / velebny",
@@ -97094,6 +98404,7 @@ exports[`adjective 19172 1`] = `
       "velikodušne",
     ],
   },
+  "short": "velikodušėn",
   "singular": {
     "acc": [
       "velikodušnogo / velikodušny",
@@ -97163,6 +98474,7 @@ exports[`adjective 19184 1`] = `
       "věrodostojne",
     ],
   },
+  "short": "věrodostojėn",
   "singular": {
     "acc": [
       "věrodostojnogo / věrodostojny",
@@ -97232,6 +98544,7 @@ exports[`adjective 19190 1`] = `
       "věrogodne",
     ],
   },
+  "short": "věrogodėn",
   "singular": {
     "acc": [
       "věrogodnogo / věrogodny",
@@ -97301,6 +98614,7 @@ exports[`adjective 19219 1`] = `
       "vidime",
     ],
   },
+  "short": "vidim",
   "singular": {
     "acc": [
       "vidimogo / vidimy",
@@ -97370,6 +98684,7 @@ exports[`adjective 19225 1`] = `
       "vlåsate",
     ],
   },
+  "short": "vlåsat",
   "singular": {
     "acc": [
       "vlåsatogo / vlåsaty",
@@ -97439,6 +98754,7 @@ exports[`adjective 19231 1`] = `
       "vlåžne",
     ],
   },
+  "short": "vlåžėn",
   "singular": {
     "acc": [
       "vlåžnogo / vlåžny",
@@ -97508,6 +98824,7 @@ exports[`adjective 19242 1`] = `
       "vȯlgke",
     ],
   },
+  "short": "vȯlgȯk",
   "singular": {
     "acc": [
       "vȯlgkogo / vȯlgky",
@@ -97577,6 +98894,7 @@ exports[`adjective 19251 1`] = `
       "vozne",
     ],
   },
+  "short": "vozėn",
   "singular": {
     "acc": [
       "voznogo / vozny",
@@ -97646,6 +98964,7 @@ exports[`adjective 19258 1`] = `
       "vsesvětove",
     ],
   },
+  "short": "vsesvětov",
   "singular": {
     "acc": [
       "vsesvětovogo / vsesvětovy",
@@ -97715,6 +99034,7 @@ exports[`adjective 19344 1`] = `
       "zabobonne",
     ],
   },
+  "short": "zabobonėn",
   "singular": {
     "acc": [
       "zabobonnogo / zabobonny",
@@ -97784,6 +99104,7 @@ exports[`adjective 19373 1`] = `
       "zajęte",
     ],
   },
+  "short": "zajęt",
   "singular": {
     "acc": [
       "zajętogo / zajęty",
@@ -97853,6 +99174,7 @@ exports[`adjective 19395 1`] = `
       "zaměnlive",
     ],
   },
+  "short": "zaměnliv",
   "singular": {
     "acc": [
       "zaměnlivogo / zaměnlivy",
@@ -97922,6 +99244,7 @@ exports[`adjective 19398 1`] = `
       "zamotane",
     ],
   },
+  "short": "zamotan",
   "singular": {
     "acc": [
       "zamotanogo / zamotany",
@@ -97991,6 +99314,7 @@ exports[`adjective 19403 1`] = `
       "žarke",
     ],
   },
+  "short": "žarȯk",
   "singular": {
     "acc": [
       "žarkogo / žarky",
@@ -98060,6 +99384,7 @@ exports[`adjective 19415 1`] = `
       "zaspane",
     ],
   },
+  "short": "zaspan",
   "singular": {
     "acc": [
       "zaspanogo / zaspany",
@@ -98129,6 +99454,7 @@ exports[`adjective 19423 1`] = `
       "zavětrne",
     ],
   },
+  "short": "zavětrėn",
   "singular": {
     "acc": [
       "zavětrnogo / zavětrny",
@@ -98198,6 +99524,7 @@ exports[`adjective 19448 1`] = `
       "žędajųće",
     ],
   },
+  "short": "žędajųć",
   "singular": {
     "acc": [
       "žędajųćego / žędajųći",
@@ -98267,6 +99594,7 @@ exports[`adjective 19462 1`] = `
       "zlostlive",
     ],
   },
+  "short": "zlostliv",
   "singular": {
     "acc": [
       "zlostlivogo / zlostlivy",
@@ -98336,6 +99664,7 @@ exports[`adjective 19489 1`] = `
       "dȯlgočašene",
     ],
   },
+  "short": "dȯlgočašen",
   "singular": {
     "acc": [
       "dȯlgočašenogo / dȯlgočašeny",
@@ -98405,6 +99734,7 @@ exports[`adjective 19490 1`] = `
       "dȯlgočasne",
     ],
   },
+  "short": "dȯlgočasėn",
   "singular": {
     "acc": [
       "dȯlgočasnogo / dȯlgočasny",
@@ -98474,6 +99804,7 @@ exports[`adjective 19494 1`] = `
       "bezpartijne",
     ],
   },
+  "short": "bezpartijėn",
   "singular": {
     "acc": [
       "bezpartijnogo / bezpartijny",
@@ -98543,6 +99874,7 @@ exports[`adjective 19499 1`] = `
       "legaľne",
     ],
   },
+  "short": "legaľėn",
   "singular": {
     "acc": [
       "legaľnogo / legaľny",
@@ -98612,6 +99944,7 @@ exports[`adjective 19507 1`] = `
       "råbotničske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "råbotničskogo / råbotničsky",
@@ -98681,6 +100014,7 @@ exports[`adjective 19511 1`] = `
       "solidarne",
     ],
   },
+  "short": "solidarėn",
   "singular": {
     "acc": [
       "solidarnogo / solidarny",
@@ -98750,6 +100084,7 @@ exports[`adjective 19518 1`] = `
       "hipotetične",
     ],
   },
+  "short": "hipotetičėn",
   "singular": {
     "acc": [
       "hipotetičnogo / hipotetičny",
@@ -98819,6 +100154,7 @@ exports[`adjective 19579 1`] = `
       "ovake",
     ],
   },
+  "short": "ovak",
   "singular": {
     "acc": [
       "ovakogo / ovaky",
@@ -98888,6 +100224,7 @@ exports[`adjective 19580 1`] = `
       "onake",
     ],
   },
+  "short": "onak",
   "singular": {
     "acc": [
       "onakogo / onaky",
@@ -98957,6 +100294,7 @@ exports[`adjective 19587 1`] = `
       "kolike",
     ],
   },
+  "short": "kolik",
   "singular": {
     "acc": [
       "kolikogo / koliky",
@@ -99026,6 +100364,7 @@ exports[`adjective 19588 1`] = `
       "selike",
     ],
   },
+  "short": "selik",
   "singular": {
     "acc": [
       "selikogo / seliky",
@@ -99095,6 +100434,7 @@ exports[`adjective 19589 1`] = `
       "tolike",
     ],
   },
+  "short": "tolik",
   "singular": {
     "acc": [
       "tolikogo / toliky",
@@ -99164,6 +100504,7 @@ exports[`adjective 19590 1`] = `
       "ovolike",
     ],
   },
+  "short": "ovolik",
   "singular": {
     "acc": [
       "ovolikogo / ovoliky",
@@ -99233,6 +100574,7 @@ exports[`adjective 19591 1`] = `
       "onolike",
     ],
   },
+  "short": "onolik",
   "singular": {
     "acc": [
       "onolikogo / onoliky",
@@ -99302,6 +100644,7 @@ exports[`adjective 19593 1`] = `
       "vselike",
     ],
   },
+  "short": "vselik",
   "singular": {
     "acc": [
       "vselikogo / vseliky",
@@ -99371,6 +100714,7 @@ exports[`adjective 19594 1`] = `
       "inolike",
     ],
   },
+  "short": "inolik",
   "singular": {
     "acc": [
       "inolikogo / inoliky",
@@ -99440,6 +100784,7 @@ exports[`adjective 19627 1`] = `
       "abstraktne",
     ],
   },
+  "short": "abstraktėn",
   "singular": {
     "acc": [
       "abstraktnogo / abstraktny",
@@ -99509,6 +100854,7 @@ exports[`adjective 19630 1`] = `
       "afektivne",
     ],
   },
+  "short": "afektivėn",
   "singular": {
     "acc": [
       "afektivnogo / afektivny",
@@ -99578,6 +100924,7 @@ exports[`adjective 19634 1`] = `
       "anglijskojęzyčne",
     ],
   },
+  "short": "anglijskojęzyčėn",
   "singular": {
     "acc": [
       "anglijskojęzyčnogo / anglijskojęzyčny",
@@ -99647,6 +100994,7 @@ exports[`adjective 19635 1`] = `
       "anglosaksonske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "anglosaksonskogo / anglosaksonsky",
@@ -99716,6 +101064,7 @@ exports[`adjective 19642 1`] = `
       "basnjeve",
     ],
   },
+  "short": "basnjev",
   "singular": {
     "acc": [
       "basnjevogo / basnjevy",
@@ -99785,6 +101134,7 @@ exports[`adjective 19645 1`] = `
       "bezbolěsne",
     ],
   },
+  "short": "bezbolěsėn",
   "singular": {
     "acc": [
       "bezbolěsnogo / bezbolěsny",
@@ -99854,6 +101204,7 @@ exports[`adjective 19646 1`] = `
       "bezdyšne",
     ],
   },
+  "short": "bezdyšėn",
   "singular": {
     "acc": [
       "bezdyšnogo / bezdyšny",
@@ -99923,6 +101274,7 @@ exports[`adjective 19649 1`] = `
       "bezpokojęće",
     ],
   },
+  "short": "bezpokojęć",
   "singular": {
     "acc": [
       "bezpokojęćego / bezpokojęći",
@@ -99992,6 +101344,7 @@ exports[`adjective 19659 1`] = `
       "bezpokojne",
     ],
   },
+  "short": "bezpokojėn",
   "singular": {
     "acc": [
       "bezpokojnogo / bezpokojny",
@@ -100061,6 +101414,7 @@ exports[`adjective 19671 1`] = `
       "čudovistne",
     ],
   },
+  "short": "čudovistėn",
   "singular": {
     "acc": [
       "čudovistnogo / čudovistny",
@@ -100130,6 +101484,7 @@ exports[`adjective 19672 1`] = `
       "delikatne",
     ],
   },
+  "short": "delikatėn",
   "singular": {
     "acc": [
       "delikatnogo / delikatny",
@@ -100199,6 +101554,7 @@ exports[`adjective 19673 1`] = `
       "delirične",
     ],
   },
+  "short": "deliričėn",
   "singular": {
     "acc": [
       "deliričnogo / deliričny",
@@ -100268,6 +101624,7 @@ exports[`adjective 19674 1`] = `
       "detaljevane",
     ],
   },
+  "short": "detaljevan",
   "singular": {
     "acc": [
       "detaljevanogo / detaljevany",
@@ -100337,6 +101694,7 @@ exports[`adjective 19677 1`] = `
       "doľnosŕbske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "doľnosŕbskogo / doľnosŕbsky",
@@ -100406,6 +101764,7 @@ exports[`adjective 19678 1`] = `
       "doľne",
     ],
   },
+  "short": "doľėn",
   "singular": {
     "acc": [
       "doľnogo / doľny",
@@ -100475,6 +101834,7 @@ exports[`adjective 19685 1`] = `
       "egalitarne",
     ],
   },
+  "short": "egalitarėn",
   "singular": {
     "acc": [
       "egalitarnogo / egalitarny",
@@ -100544,6 +101904,7 @@ exports[`adjective 19686 1`] = `
       "elastične",
     ],
   },
+  "short": "elastičėn",
   "singular": {
     "acc": [
       "elastičnogo / elastičny",
@@ -100613,6 +101974,7 @@ exports[`adjective 19688 1`] = `
       "enciklopedične",
     ],
   },
+  "short": "enciklopedičėn",
   "singular": {
     "acc": [
       "enciklopedičnogo / enciklopedičny",
@@ -100682,6 +102044,7 @@ exports[`adjective 19696 1`] = `
       "fleksibiľne",
     ],
   },
+  "short": "fleksibiľėn",
   "singular": {
     "acc": [
       "fleksibiľnogo / fleksibiľny",
@@ -100751,6 +102114,7 @@ exports[`adjective 19702 1`] = `
       "francuzskojęzyčne",
     ],
   },
+  "short": "francuzskojęzyčėn",
   "singular": {
     "acc": [
       "francuzskojęzyčnogo / francuzskojęzyčny",
@@ -100820,6 +102184,7 @@ exports[`adjective 19703 1`] = `
       "freudovske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "freudovskogo / freudovsky",
@@ -100889,6 +102254,7 @@ exports[`adjective 19709 1`] = `
       "gornosŕbske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gornosŕbskogo / gornosŕbsky",
@@ -100958,6 +102324,7 @@ exports[`adjective 19710 1`] = `
       "groteskove",
     ],
   },
+  "short": "groteskov",
   "singular": {
     "acc": [
       "groteskovogo / groteskovy",
@@ -101027,6 +102394,7 @@ exports[`adjective 19711 1`] = `
       "hebrejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "hebrejskogo / hebrejsky",
@@ -101096,6 +102464,7 @@ exports[`adjective 19718 1`] = `
       "homogenne",
     ],
   },
+  "short": "homogenėn",
   "singular": {
     "acc": [
       "homogennogo / homogenny",
@@ -101165,6 +102534,7 @@ exports[`adjective 19720 1`] = `
       "horizontaľne",
     ],
   },
+  "short": "horizontaľėn",
   "singular": {
     "acc": [
       "horizontaľnogo / horizontaľny",
@@ -101234,6 +102604,7 @@ exports[`adjective 19722 1`] = `
       "humoristične",
     ],
   },
+  "short": "humorističėn",
   "singular": {
     "acc": [
       "humorističnogo / humorističny",
@@ -101303,6 +102674,7 @@ exports[`adjective 19727 1`] = `
       "inavguraľne",
     ],
   },
+  "short": "inavguraľėn",
   "singular": {
     "acc": [
       "inavguraľnogo / inavguraľny",
@@ -101372,6 +102744,7 @@ exports[`adjective 19728 1`] = `
       "indonezske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "indonezskogo / indonezsky",
@@ -101441,6 +102814,7 @@ exports[`adjective 19729 1`] = `
       "informativne",
     ],
   },
+  "short": "informativėn",
   "singular": {
     "acc": [
       "informativnogo / informativny",
@@ -101510,6 +102884,7 @@ exports[`adjective 19731 1`] = `
       "intelektuaľne",
     ],
   },
+  "short": "intelektuaľėn",
   "singular": {
     "acc": [
       "intelektuaľnogo / intelektuaľny",
@@ -101579,6 +102954,7 @@ exports[`adjective 19733 1`] = `
       "ironične",
     ],
   },
+  "short": "ironičėn",
   "singular": {
     "acc": [
       "ironičnogo / ironičny",
@@ -101648,6 +103024,7 @@ exports[`adjective 19743 1`] = `
       "izkusne",
     ],
   },
+  "short": "izkusėn",
   "singular": {
     "acc": [
       "izkusnogo / izkusny",
@@ -101717,6 +103094,7 @@ exports[`adjective 19749 1`] = `
       "niščiteljske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "niščiteljskogo / niščiteljsky",
@@ -101786,6 +103164,7 @@ exports[`adjective 19761 1`] = `
       "jednojęzyčne",
     ],
   },
+  "short": "jednojęzyčėn",
   "singular": {
     "acc": [
       "jednojęzyčnogo / jednojęzyčny",
@@ -101855,6 +103234,7 @@ exports[`adjective 19773 1`] = `
       "karaibske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "karaibskogo / karaibsky",
@@ -101924,6 +103304,7 @@ exports[`adjective 19774 1`] = `
       "karne",
     ],
   },
+  "short": "karėn",
   "singular": {
     "acc": [
       "karnogo / karny",
@@ -101993,6 +103374,7 @@ exports[`adjective 19775 1`] = `
       "katalanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "katalanskogo / katalansky",
@@ -102062,6 +103444,7 @@ exports[`adjective 19779 1`] = `
       "klinične",
     ],
   },
+  "short": "kliničėn",
   "singular": {
     "acc": [
       "kliničnogo / kliničny",
@@ -102131,6 +103514,7 @@ exports[`adjective 19786 1`] = `
       "ključne",
     ],
   },
+  "short": "ključėn",
   "singular": {
     "acc": [
       "ključnogo / ključny",
@@ -102200,6 +103584,7 @@ exports[`adjective 19804 1`] = `
       "kreoľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kreoľskogo / kreoľsky",
@@ -102269,6 +103654,7 @@ exports[`adjective 19827 1`] = `
       "ledovite",
     ],
   },
+  "short": "ledovit",
   "singular": {
     "acc": [
       "ledovitogo / ledovity",
@@ -102338,6 +103724,7 @@ exports[`adjective 19829 1`] = `
       "legkomysljne",
     ],
   },
+  "short": "legkomysljėn",
   "singular": {
     "acc": [
       "legkomysljnogo / legkomysljny",
@@ -102407,6 +103794,7 @@ exports[`adjective 19835 1`] = `
       "lingvistične",
     ],
   },
+  "short": "lingvističėn",
   "singular": {
     "acc": [
       "lingvističnogo / lingvističny",
@@ -102476,6 +103864,7 @@ exports[`adjective 19837 1`] = `
       "lomlive",
     ],
   },
+  "short": "lomliv",
   "singular": {
     "acc": [
       "lomlivogo / lomlivy",
@@ -102545,6 +103934,7 @@ exports[`adjective 19839 1`] = `
       "magične",
     ],
   },
+  "short": "magičėn",
   "singular": {
     "acc": [
       "magičnogo / magičny",
@@ -102614,6 +104004,7 @@ exports[`adjective 19843 1`] = `
       "međuljudske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "međuljudskogo / međuljudsky",
@@ -102683,6 +104074,7 @@ exports[`adjective 19845 1`] = `
       "mentaľne",
     ],
   },
+  "short": "mentaľėn",
   "singular": {
     "acc": [
       "mentaľnogo / mentaľny",
@@ -102752,6 +104144,7 @@ exports[`adjective 19853 1`] = `
       "mnogobarvne",
     ],
   },
+  "short": "mnogobarvėn",
   "singular": {
     "acc": [
       "mnogobarvnogo / mnogobarvny",
@@ -102821,6 +104214,7 @@ exports[`adjective 19854 1`] = `
       "mnogojęzyčne",
     ],
   },
+  "short": "mnogojęzyčėn",
   "singular": {
     "acc": [
       "mnogojęzyčnogo / mnogojęzyčny",
@@ -102890,6 +104284,7 @@ exports[`adjective 19855 1`] = `
       "mnogokulturne",
     ],
   },
+  "short": "mnogokulturėn",
   "singular": {
     "acc": [
       "mnogokulturnogo / mnogokulturny",
@@ -102959,6 +104354,7 @@ exports[`adjective 19856 1`] = `
       "mnogoljudne",
     ],
   },
+  "short": "mnogoljudėn",
   "singular": {
     "acc": [
       "mnogoljudnogo / mnogoljudny",
@@ -103028,6 +104424,7 @@ exports[`adjective 19861 1`] = `
       "morne",
     ],
   },
+  "short": "morėn",
   "singular": {
     "acc": [
       "mornogo / morny",
@@ -103097,6 +104494,7 @@ exports[`adjective 19865 1`] = `
       "nadljudske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "nadljudskogo / nadljudsky",
@@ -103166,6 +104564,7 @@ exports[`adjective 19866 1`] = `
       "nadoprošćene",
     ],
   },
+  "short": "nadoprošćen",
   "singular": {
     "acc": [
       "nadoprošćenogo / nadoprošćeny",
@@ -103235,6 +104634,7 @@ exports[`adjective 19879 1`] = `
       "nasųćne",
     ],
   },
+  "short": "nasųćėn",
   "singular": {
     "acc": [
       "nasųćnogo / nasųćny",
@@ -103304,6 +104704,7 @@ exports[`adjective 19880 1`] = `
       "neadekvatne",
     ],
   },
+  "short": "neadekvatėn",
   "singular": {
     "acc": [
       "neadekvatnogo / neadekvatny",
@@ -103373,6 +104774,7 @@ exports[`adjective 19881 1`] = `
       "nebske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "nebskogo / nebsky",
@@ -103442,6 +104844,7 @@ exports[`adjective 19885 1`] = `
       "nedostojne",
     ],
   },
+  "short": "nedostojėn",
   "singular": {
     "acc": [
       "nedostojnogo / nedostojny",
@@ -103511,6 +104914,7 @@ exports[`adjective 19886 1`] = `
       "neizměnne",
     ],
   },
+  "short": "neizměnėn",
   "singular": {
     "acc": [
       "neizměnnogo / neizměnny",
@@ -103580,6 +104984,7 @@ exports[`adjective 19889 1`] = `
       "nekompletne",
     ],
   },
+  "short": "nekompletėn",
   "singular": {
     "acc": [
       "nekompletnogo / nekompletny",
@@ -103649,6 +105054,7 @@ exports[`adjective 19891 1`] = `
       "nelogične",
     ],
   },
+  "short": "nelogičėn",
   "singular": {
     "acc": [
       "nelogičnogo / nelogičny",
@@ -103718,6 +105124,7 @@ exports[`adjective 19893 1`] = `
       "nenarušime",
     ],
   },
+  "short": "nenarušim",
   "singular": {
     "acc": [
       "nenarušimogo / nenarušimy",
@@ -103787,6 +105194,7 @@ exports[`adjective 19894 1`] = `
       "neobjasnime",
     ],
   },
+  "short": "neobjasnim",
   "singular": {
     "acc": [
       "neobjasnimogo / neobjasnimy",
@@ -103856,6 +105264,7 @@ exports[`adjective 19895 1`] = `
       "neograničene",
     ],
   },
+  "short": "neograničen",
   "singular": {
     "acc": [
       "neograničenogo / neograničeny",
@@ -103925,6 +105334,7 @@ exports[`adjective 19896 1`] = `
       "neopisujeme",
     ],
   },
+  "short": "neopisujem",
   "singular": {
     "acc": [
       "neopisujemogo / neopisujemy",
@@ -103994,6 +105404,7 @@ exports[`adjective 19897 1`] = `
       "nepisane",
     ],
   },
+  "short": "nepisan",
   "singular": {
     "acc": [
       "nepisanogo / nepisany",
@@ -104063,6 +105474,7 @@ exports[`adjective 19898 1`] = `
       "nepomoćne",
     ],
   },
+  "short": "nepomoćėn",
   "singular": {
     "acc": [
       "nepomoćnogo / nepomoćny",
@@ -104132,6 +105544,7 @@ exports[`adjective 19902 1`] = `
       "neracionaľne",
     ],
   },
+  "short": "neracionaľėn",
   "singular": {
     "acc": [
       "neracionaľnogo / neracionaľny",
@@ -104201,6 +105614,7 @@ exports[`adjective 19904 1`] = `
       "nesvęzane",
     ],
   },
+  "short": "nesvęzan",
   "singular": {
     "acc": [
       "nesvęzanogo / nesvęzany",
@@ -104270,6 +105684,7 @@ exports[`adjective 19905 1`] = `
       "nesamovoljne",
     ],
   },
+  "short": "nesamovoljėn",
   "singular": {
     "acc": [
       "nesamovoljnogo / nesamovoljny",
@@ -104339,6 +105754,7 @@ exports[`adjective 19908 1`] = `
       "nespravědlive",
     ],
   },
+  "short": "nespravědliv",
   "singular": {
     "acc": [
       "nespravědlivogo / nespravědlivy",
@@ -104408,6 +105824,7 @@ exports[`adjective 19909 1`] = `
       "netŕpime",
     ],
   },
+  "short": "netŕpim",
   "singular": {
     "acc": [
       "netŕpimogo / netŕpimy",
@@ -104477,6 +105894,7 @@ exports[`adjective 19912 1`] = `
       "nevědome",
     ],
   },
+  "short": "nevědom",
   "singular": {
     "acc": [
       "nevědomogo / nevědomy",
@@ -104546,6 +105964,7 @@ exports[`adjective 19915 1`] = `
       "nižne",
     ],
   },
+  "short": "nižėn",
   "singular": {
     "acc": [
       "nižnogo / nižny",
@@ -104615,6 +106034,7 @@ exports[`adjective 19916 1`] = `
       "novonarođene",
     ],
   },
+  "short": "novonarođen",
   "singular": {
     "acc": [
       "novonarođenogo / novonarođeny",
@@ -104684,6 +106104,7 @@ exports[`adjective 19918 1`] = `
       "nyněšnje",
     ],
   },
+  "short": "nyněšėn",
   "singular": {
     "acc": [
       "nyněšnjego / nyněšnji",
@@ -104753,6 +106174,7 @@ exports[`adjective 19918-1 1`] = `
       "nyněšne",
     ],
   },
+  "short": "nyněšėn",
   "singular": {
     "acc": [
       "nyněšnogo / nyněšny",
@@ -104822,6 +106244,7 @@ exports[`adjective 19921 1`] = `
       "objektivne",
     ],
   },
+  "short": "objektivėn",
   "singular": {
     "acc": [
       "objektivnogo / objektivny",
@@ -104891,6 +106314,7 @@ exports[`adjective 19934 1`] = `
       "obrazovite",
     ],
   },
+  "short": "obrazovit",
   "singular": {
     "acc": [
       "obrazovitogo / obrazovity",
@@ -104960,6 +106384,7 @@ exports[`adjective 19936 1`] = `
       "obustrånne",
     ],
   },
+  "short": "obustrånėn",
   "singular": {
     "acc": [
       "obustrånnogo / obustrånny",
@@ -105029,6 +106454,7 @@ exports[`adjective 19988 1`] = `
       "ograničene",
     ],
   },
+  "short": "ograničen",
   "singular": {
     "acc": [
       "ograničenogo / ograničeny",
@@ -105098,6 +106524,7 @@ exports[`adjective 19998 1`] = `
       "omŕžajųće",
     ],
   },
+  "short": "omŕžajųć",
   "singular": {
     "acc": [
       "omŕžajųćego / omŕžajųći",
@@ -105167,6 +106594,7 @@ exports[`adjective 20002 1`] = `
       "oporędčene",
     ],
   },
+  "short": "oporędčen",
   "singular": {
     "acc": [
       "oporędčenogo / oporędčeny",
@@ -105236,6 +106664,7 @@ exports[`adjective 20006 1`] = `
       "ornitologične",
     ],
   },
+  "short": "ornitologičėn",
   "singular": {
     "acc": [
       "ornitologičnogo / ornitologičny",
@@ -105305,6 +106734,7 @@ exports[`adjective 20019 1`] = `
       "poblåžlive",
     ],
   },
+  "short": "poblåžliv",
   "singular": {
     "acc": [
       "poblåžlivogo / poblåžlivy",
@@ -105374,6 +106804,7 @@ exports[`adjective 20021 1`] = `
       "počętkujųće",
     ],
   },
+  "short": "počętkujųć",
   "singular": {
     "acc": [
       "počętkujųćego / počętkujųći",
@@ -105443,6 +106874,7 @@ exports[`adjective 20037 1`] = `
       "pokazne",
     ],
   },
+  "short": "pokazėn",
   "singular": {
     "acc": [
       "pokaznogo / pokazny",
@@ -105512,6 +106944,7 @@ exports[`adjective 20046 1`] = `
       "poprědnje",
     ],
   },
+  "short": "poprědėn",
   "singular": {
     "acc": [
       "poprědnjego / poprědnji",
@@ -105581,6 +107014,7 @@ exports[`adjective 20046-1 1`] = `
       "poprědne",
     ],
   },
+  "short": "poprědėn",
   "singular": {
     "acc": [
       "poprědnogo / poprědny",
@@ -105650,6 +107084,7 @@ exports[`adjective 20047 1`] = `
       "postojanne",
     ],
   },
+  "short": "postojanėn",
   "singular": {
     "acc": [
       "postojannogo / postojanny",
@@ -105719,6 +107154,7 @@ exports[`adjective 20051 1`] = `
       "postųpne",
     ],
   },
+  "short": "postųpėn",
   "singular": {
     "acc": [
       "postųpnogo / postųpny",
@@ -105788,6 +107224,7 @@ exports[`adjective 20060 1`] = `
       "praviľne",
     ],
   },
+  "short": "praviľėn",
   "singular": {
     "acc": [
       "praviľnogo / praviľny",
@@ -105857,6 +107294,7 @@ exports[`adjective 20068 1`] = `
       "prěletne",
     ],
   },
+  "short": "prěletėn",
   "singular": {
     "acc": [
       "prěletnogo / prěletny",
@@ -105926,6 +107364,7 @@ exports[`adjective 20070 1`] = `
       "prěpȯlnjene",
     ],
   },
+  "short": "prěpȯlnjen",
   "singular": {
     "acc": [
       "prěpȯlnjenogo / prěpȯlnjeny",
@@ -105995,6 +107434,7 @@ exports[`adjective 20072 1`] = `
       "prestižne",
     ],
   },
+  "short": "prestižėn",
   "singular": {
     "acc": [
       "prestižnogo / prestižny",
@@ -106064,6 +107504,7 @@ exports[`adjective 20099 1`] = `
       "psihiatrične",
     ],
   },
+  "short": "psihiatričėn",
   "singular": {
     "acc": [
       "psihiatričnogo / psihiatričny",
@@ -106133,6 +107574,7 @@ exports[`adjective 20100 1`] = `
       "psihične",
     ],
   },
+  "short": "psihičėn",
   "singular": {
     "acc": [
       "psihičnogo / psihičny",
@@ -106202,6 +107644,7 @@ exports[`adjective 20101 1`] = `
       "råboče",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "råbočego / råboči",
@@ -106271,6 +107714,7 @@ exports[`adjective 20103 1`] = `
       "rafinovane",
     ],
   },
+  "short": "rafinovan",
   "singular": {
     "acc": [
       "rafinovanogo / rafinovany",
@@ -106340,6 +107784,7 @@ exports[`adjective 20106 1`] = `
       "råzdŕte",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "råzdŕtogo / råzdŕty",
@@ -106409,6 +107854,7 @@ exports[`adjective 20106-1 1`] = `
       "råzdrěne",
     ],
   },
+  "short": "råzdrěn",
   "singular": {
     "acc": [
       "råzdrěnogo / råzdrěny",
@@ -106478,6 +107924,7 @@ exports[`adjective 20122 1`] = `
       "råzprostrånjene",
     ],
   },
+  "short": "råzprostrånjen",
   "singular": {
     "acc": [
       "råzprostrånjenogo / råzprostrånjeny",
@@ -106547,6 +107994,7 @@ exports[`adjective 20134 1`] = `
       "rodime",
     ],
   },
+  "short": "rodim",
   "singular": {
     "acc": [
       "rodimogo / rodimy",
@@ -106616,6 +108064,7 @@ exports[`adjective 20137 1`] = `
       "rutenske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "rutenskogo / rutensky",
@@ -106685,6 +108134,7 @@ exports[`adjective 20168 1`] = `
       "sråvnime",
     ],
   },
+  "short": "sråvnim",
   "singular": {
     "acc": [
       "sråvnimogo / sråvnimy",
@@ -106754,6 +108204,7 @@ exports[`adjective 20173 1`] = `
       "seľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "seľskogo / seľsky",
@@ -106823,6 +108274,7 @@ exports[`adjective 20174 1`] = `
       "semantične",
     ],
   },
+  "short": "semantičėn",
   "singular": {
     "acc": [
       "semantičnogo / semantičny",
@@ -106892,6 +108344,7 @@ exports[`adjective 20175 1`] = `
       "širše",
     ],
   },
+  "short": "širš",
   "singular": {
     "acc": [
       "širšego / širši",
@@ -106961,6 +108414,7 @@ exports[`adjective 20178 1`] = `
       "sociaľne",
     ],
   },
+  "short": "sociaľėn",
   "singular": {
     "acc": [
       "sociaľnogo / sociaľny",
@@ -107030,6 +108484,7 @@ exports[`adjective 20179 1`] = `
       "solidne",
     ],
   },
+  "short": "solidėn",
   "singular": {
     "acc": [
       "solidnogo / solidny",
@@ -107099,6 +108554,7 @@ exports[`adjective 20186 1`] = `
       "sŕbohrvatske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sŕbohrvatskogo / sŕbohrvatsky",
@@ -107168,6 +108624,7 @@ exports[`adjective 20188 1`] = `
       "sŕbolužičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sŕbolužičskogo / sŕbolužičsky",
@@ -107237,6 +108694,7 @@ exports[`adjective 20193 1`] = `
       "sųćstvene",
     ],
   },
+  "short": "sųćstven",
   "singular": {
     "acc": [
       "sųćstvenogo / sųćstveny",
@@ -107306,6 +108764,7 @@ exports[`adjective 20198 1`] = `
       "sȯglåsne",
     ],
   },
+  "short": "sȯglåsėn",
   "singular": {
     "acc": [
       "sȯglåsnogo / sȯglåsny",
@@ -107375,6 +108834,7 @@ exports[`adjective 20198-1 1`] = `
       "sųglåsne",
     ],
   },
+  "short": "sųglåsėn",
   "singular": {
     "acc": [
       "sųglåsnogo / sųglåsny",
@@ -107444,6 +108904,7 @@ exports[`adjective 20222 1`] = `
       "trilětne",
     ],
   },
+  "short": "trilětėn",
   "singular": {
     "acc": [
       "trilětnogo / trilětny",
@@ -107513,6 +108974,7 @@ exports[`adjective 20223 1`] = `
       "triumfaľne",
     ],
   },
+  "short": "triumfaľėn",
   "singular": {
     "acc": [
       "triumfaľnogo / triumfaľny",
@@ -107582,6 +109044,7 @@ exports[`adjective 20226 1`] = `
       "tysęćlětne",
     ],
   },
+  "short": "tysęćlětėn",
   "singular": {
     "acc": [
       "tysęćlětnogo / tysęćlětny",
@@ -107651,6 +109114,7 @@ exports[`adjective 20227 1`] = `
       "uběđajųće",
     ],
   },
+  "short": "uběđajųć",
   "singular": {
     "acc": [
       "uběđajųćego / uběđajųći",
@@ -107720,6 +109184,7 @@ exports[`adjective 20246 1`] = `
       "umysľne",
     ],
   },
+  "short": "umysľėn",
   "singular": {
     "acc": [
       "umysľnogo / umysľny",
@@ -107789,6 +109254,7 @@ exports[`adjective 20284 1`] = `
       "vědome",
     ],
   },
+  "short": "vědom",
   "singular": {
     "acc": [
       "vědomogo / vědomy",
@@ -107858,6 +109324,7 @@ exports[`adjective 20285 1`] = `
       "verifikovajeme",
     ],
   },
+  "short": "verifikovajem",
   "singular": {
     "acc": [
       "verifikovajemogo / verifikovajemy",
@@ -107927,6 +109394,7 @@ exports[`adjective 20287 1`] = `
       "vertikaľne",
     ],
   },
+  "short": "vertikaľėn",
   "singular": {
     "acc": [
       "vertikaľnogo / vertikaľny",
@@ -107996,6 +109464,7 @@ exports[`adjective 20294 1`] = `
       "vsesvětne",
     ],
   },
+  "short": "vsesvětėn",
   "singular": {
     "acc": [
       "vsesvětnogo / vsesvětny",
@@ -108065,6 +109534,7 @@ exports[`adjective 20301 1`] = `
       "vyšne",
     ],
   },
+  "short": "vyšėn",
   "singular": {
     "acc": [
       "vyšnogo / vyšny",
@@ -108134,6 +109604,7 @@ exports[`adjective 20302 1`] = `
       "vysše",
     ],
   },
+  "short": "vysš",
   "singular": {
     "acc": [
       "vysšego / vysši",
@@ -108203,6 +109674,7 @@ exports[`adjective 20331 1`] = `
       "anemične",
     ],
   },
+  "short": "anemičėn",
   "singular": {
     "acc": [
       "anemičnogo / anemičny",
@@ -108272,6 +109744,7 @@ exports[`adjective 20340 1`] = `
       "bditeljne",
     ],
   },
+  "short": "bditeljėn",
   "singular": {
     "acc": [
       "bditeljnogo / bditeljny",
@@ -108341,6 +109814,7 @@ exports[`adjective 20345 1`] = `
       "běgle",
     ],
   },
+  "short": "běgl",
   "singular": {
     "acc": [
       "běglogo / běgly",
@@ -108410,6 +109884,7 @@ exports[`adjective 20351 1`] = `
       "bezmȯlvne",
     ],
   },
+  "short": "bezmȯlvėn",
   "singular": {
     "acc": [
       "bezmȯlvnogo / bezmȯlvny",
@@ -108479,6 +109954,7 @@ exports[`adjective 20355 1`] = `
       "bodre",
     ],
   },
+  "short": "bodr",
   "singular": {
     "acc": [
       "bodrogo / bodry",
@@ -108548,6 +110024,7 @@ exports[`adjective 20359 1`] = `
       "bosnjačske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bosnjačskogo / bosnjačsky",
@@ -108617,6 +110094,7 @@ exports[`adjective 20370 1`] = `
       "domysľne",
     ],
   },
+  "short": "domysľėn",
   "singular": {
     "acc": [
       "domysľnogo / domysľny",
@@ -108686,6 +110164,7 @@ exports[`adjective 20374 1`] = `
       "eksperimentaľne",
     ],
   },
+  "short": "eksperimentaľėn",
   "singular": {
     "acc": [
       "eksperimentaľnogo / eksperimentaľny",
@@ -108755,6 +110234,7 @@ exports[`adjective 20376 1`] = `
       "formaľne",
     ],
   },
+  "short": "formaľėn",
   "singular": {
     "acc": [
       "formaľnogo / formaľny",
@@ -108824,6 +110304,7 @@ exports[`adjective 20380 1`] = `
       "heterogenne",
     ],
   },
+  "short": "heterogenėn",
   "singular": {
     "acc": [
       "heterogennogo / heterogenny",
@@ -108893,6 +110374,7 @@ exports[`adjective 20402 1`] = `
       "izumŕle",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "izumŕlogo / izumŕly",
@@ -108962,6 +110444,7 @@ exports[`adjective 20402-1 1`] = `
       "izumrěle",
     ],
   },
+  "short": "izumrěl",
   "singular": {
     "acc": [
       "izumrělogo / izumrěly",
@@ -109031,6 +110514,7 @@ exports[`adjective 20412 1`] = `
       "koloniaľne",
     ],
   },
+  "short": "koloniaľėn",
   "singular": {
     "acc": [
       "koloniaľnogo / koloniaľny",
@@ -109100,6 +110584,7 @@ exports[`adjective 20413 1`] = `
       "konceptuaľne",
     ],
   },
+  "short": "konceptuaľėn",
   "singular": {
     "acc": [
       "konceptuaľnogo / konceptuaľny",
@@ -109169,6 +110654,7 @@ exports[`adjective 20434 1`] = `
       "ljubopytne",
     ],
   },
+  "short": "ljubopytėn",
   "singular": {
     "acc": [
       "ljubopytnogo / ljubopytny",
@@ -109238,6 +110724,7 @@ exports[`adjective 20448 1`] = `
       "malolětne",
     ],
   },
+  "short": "malolětėn",
   "singular": {
     "acc": [
       "malolětnogo / malolětny",
@@ -109307,6 +110794,7 @@ exports[`adjective 20450 1`] = `
       "malomȯlvne",
     ],
   },
+  "short": "malomȯlvėn",
   "singular": {
     "acc": [
       "malomȯlvnogo / malomȯlvny",
@@ -109376,6 +110864,7 @@ exports[`adjective 20451 1`] = `
       "malovažne",
     ],
   },
+  "short": "malovažėn",
   "singular": {
     "acc": [
       "malovažnogo / malovažny",
@@ -109445,6 +110934,7 @@ exports[`adjective 20452 1`] = `
       "materinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "materinskogo / materinsky",
@@ -109514,6 +111004,7 @@ exports[`adjective 20468 1`] = `
       "měrodajne",
     ],
   },
+  "short": "měrodajėn",
   "singular": {
     "acc": [
       "měrodajnogo / měrodajny",
@@ -109583,6 +111074,7 @@ exports[`adjective 20490 1`] = `
       "mnogocentrične",
     ],
   },
+  "short": "mnogocentričėn",
   "singular": {
     "acc": [
       "mnogocentričnogo / mnogocentričny",
@@ -109652,6 +111144,7 @@ exports[`adjective 20491 1`] = `
       "mnogorake",
     ],
   },
+  "short": "mnogorak",
   "singular": {
     "acc": [
       "mnogorakogo / mnogoraky",
@@ -109721,6 +111214,7 @@ exports[`adjective 20495 1`] = `
       "mogųće",
     ],
   },
+  "short": "mogųć",
   "singular": {
     "acc": [
       "mogųćego / mogųći",
@@ -109790,6 +111284,7 @@ exports[`adjective 20506 1`] = `
       "mųtne",
     ],
   },
+  "short": "mųtėn",
   "singular": {
     "acc": [
       "mųtnogo / mųtny",
@@ -109859,6 +111354,7 @@ exports[`adjective 20517 1`] = `
       "nadměrne",
     ],
   },
+  "short": "nadměrėn",
   "singular": {
     "acc": [
       "nadměrnogo / nadměrny",
@@ -109928,6 +111424,7 @@ exports[`adjective 20523 1`] = `
       "naležite",
     ],
   },
+  "short": "naležit",
   "singular": {
     "acc": [
       "naležitogo / naležity",
@@ -109997,6 +111494,7 @@ exports[`adjective 20537 1`] = `
       "neformaľne",
     ],
   },
+  "short": "neformaľėn",
   "singular": {
     "acc": [
       "neformaľnogo / neformaľny",
@@ -110066,6 +111564,7 @@ exports[`adjective 20540 1`] = `
       "nemoćne",
     ],
   },
+  "short": "nemoćėn",
   "singular": {
     "acc": [
       "nemoćnogo / nemoćny",
@@ -110135,6 +111634,7 @@ exports[`adjective 20542 1`] = `
       "nepamętne",
     ],
   },
+  "short": "nepamętėn",
   "singular": {
     "acc": [
       "nepamętnogo / nepamętny",
@@ -110204,6 +111704,7 @@ exports[`adjective 20544 1`] = `
       "nesnosne",
     ],
   },
+  "short": "nesnosėn",
   "singular": {
     "acc": [
       "nesnosnogo / nesnosny",
@@ -110273,6 +111774,7 @@ exports[`adjective 20556 1`] = `
       "novohebrejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "novohebrejskogo / novohebrejsky",
@@ -110342,6 +111844,7 @@ exports[`adjective 20565 1`] = `
       "obmŕle",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "obmŕlogo / obmŕly",
@@ -110411,6 +111914,7 @@ exports[`adjective 20583 1`] = `
       "organične",
     ],
   },
+  "short": "organičėn",
   "singular": {
     "acc": [
       "organičnogo / organičny",
@@ -110480,6 +111984,7 @@ exports[`adjective 20616 1`] = `
       "praindoevropejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "praindoevropejskogo / praindoevropejsky",
@@ -110549,6 +112054,7 @@ exports[`adjective 20621 1`] = `
       "prědběžne",
     ],
   },
+  "short": "prědběžėn",
   "singular": {
     "acc": [
       "prědběžnogo / prědběžny",
@@ -110618,6 +112124,7 @@ exports[`adjective 20635 1`] = `
       "prěnosne",
     ],
   },
+  "short": "prěnosėn",
   "singular": {
     "acc": [
       "prěnosnogo / prěnosny",
@@ -110687,6 +112194,7 @@ exports[`adjective 20639 1`] = `
       "prilegle",
     ],
   },
+  "short": "prilegl",
   "singular": {
     "acc": [
       "prileglogo / prilegly",
@@ -110756,6 +112264,7 @@ exports[`adjective 20651 1`] = `
       "priměrne",
     ],
   },
+  "short": "priměrėn",
   "singular": {
     "acc": [
       "priměrnogo / priměrny",
@@ -110825,6 +112334,7 @@ exports[`adjective 20660 1`] = `
       "problematične",
     ],
   },
+  "short": "problematičėn",
   "singular": {
     "acc": [
       "problematičnogo / problematičny",
@@ -110894,6 +112404,7 @@ exports[`adjective 20661 1`] = `
       "prohodne",
     ],
   },
+  "short": "prohodėn",
   "singular": {
     "acc": [
       "prohodnogo / prohodny",
@@ -110963,6 +112474,7 @@ exports[`adjective 20666 1`] = `
       "protivlegle",
     ],
   },
+  "short": "protivlegl",
   "singular": {
     "acc": [
       "protivleglogo / protivlegly",
@@ -111032,6 +112544,7 @@ exports[`adjective 20667 1`] = `
       "protivpoložene",
     ],
   },
+  "short": "protivpoložen",
   "singular": {
     "acc": [
       "protivpoloženogo / protivpoloženy",
@@ -111101,6 +112614,7 @@ exports[`adjective 20670 1`] = `
       "råvnoměrne",
     ],
   },
+  "short": "råvnoměrėn",
   "singular": {
     "acc": [
       "råvnoměrnogo / råvnoměrny",
@@ -111170,6 +112684,7 @@ exports[`adjective 20692 1`] = `
       "retoromanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "retoromanskogo / retoromansky",
@@ -111239,6 +112754,7 @@ exports[`adjective 20693 1`] = `
       "rodne",
     ],
   },
+  "short": "rodėn",
   "singular": {
     "acc": [
       "rodnogo / rodny",
@@ -111308,6 +112824,7 @@ exports[`adjective 20716 1`] = `
       "smysľne",
     ],
   },
+  "short": "smysľėn",
   "singular": {
     "acc": [
       "smysľnogo / smysľny",
@@ -111377,6 +112894,7 @@ exports[`adjective 20718 1`] = `
       "snosne",
     ],
   },
+  "short": "snosėn",
   "singular": {
     "acc": [
       "snosnogo / snosny",
@@ -111446,6 +112964,7 @@ exports[`adjective 20731 1`] = `
       "simetrične",
     ],
   },
+  "short": "simetričėn",
   "singular": {
     "acc": [
       "simetričnogo / simetričny",
@@ -111515,6 +113034,7 @@ exports[`adjective 20749 1`] = `
       "stale",
     ],
   },
+  "short": "stal",
   "singular": {
     "acc": [
       "stalogo / staly",
@@ -111584,6 +113104,7 @@ exports[`adjective 20754 1`] = `
       "standardne",
     ],
   },
+  "short": "standardėn",
   "singular": {
     "acc": [
       "standardnogo / standardny",
@@ -111653,6 +113174,7 @@ exports[`adjective 20755 1`] = `
       "starohebrejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "starohebrejskogo / starohebrejsky",
@@ -111722,6 +113244,7 @@ exports[`adjective 20760 1`] = `
       "sųråzměrne",
     ],
   },
+  "short": "sųråzměrėn",
   "singular": {
     "acc": [
       "sųråzměrnogo / sųråzměrny",
@@ -111791,6 +113314,7 @@ exports[`adjective 20775 1`] = `
       "uměrjene",
     ],
   },
+  "short": "uměrjen",
   "singular": {
     "acc": [
       "uměrjenogo / uměrjeny",
@@ -111860,6 +113384,7 @@ exports[`adjective 20814 1`] = `
       "věrolomne",
     ],
   },
+  "short": "věrolomėn",
   "singular": {
     "acc": [
       "věrolomnogo / věrolomny",
@@ -111929,6 +113454,7 @@ exports[`adjective 20820 1`] = `
       "vsemogųće",
     ],
   },
+  "short": "vsemogųć",
   "singular": {
     "acc": [
       "vsemogųćego / vsemogųći",
@@ -111998,6 +113524,7 @@ exports[`adjective 20844 1`] = `
       "bezopasne",
     ],
   },
+  "short": "bezopasėn",
   "singular": {
     "acc": [
       "bezopasnogo / bezopasny",
@@ -112067,6 +113594,7 @@ exports[`adjective 20847 1`] = `
       "bezpečne",
     ],
   },
+  "short": "bezpečėn",
   "singular": {
     "acc": [
       "bezpečnogo / bezpečny",
@@ -112136,6 +113664,7 @@ exports[`adjective 20848 1`] = `
       "bezplatne",
     ],
   },
+  "short": "bezplatėn",
   "singular": {
     "acc": [
       "bezplatnogo / bezplatny",
@@ -112205,6 +113734,7 @@ exports[`adjective 20898 1`] = `
       "napadne",
     ],
   },
+  "short": "napadėn",
   "singular": {
     "acc": [
       "napadnogo / napadny",
@@ -112274,6 +113804,7 @@ exports[`adjective 20901 1`] = `
       "napęte",
     ],
   },
+  "short": "napęt",
   "singular": {
     "acc": [
       "napętogo / napęty",
@@ -112343,6 +113874,7 @@ exports[`adjective 20999 1`] = `
       "plavne",
     ],
   },
+  "short": "plavėn",
   "singular": {
     "acc": [
       "plavnogo / plavny",
@@ -112412,6 +113944,7 @@ exports[`adjective 21001 1`] = `
       "plåve",
     ],
   },
+  "short": "plåv",
   "singular": {
     "acc": [
       "plåvogo / plåvy",
@@ -112481,6 +114014,7 @@ exports[`adjective 21003 1`] = `
       "pȯlnolětne",
     ],
   },
+  "short": "pȯlnolětėn",
   "singular": {
     "acc": [
       "pȯlnolětnogo / pȯlnolětny",
@@ -112550,6 +114084,7 @@ exports[`adjective 21019 1`] = `
       "poprěčne",
     ],
   },
+  "short": "poprěčėn",
   "singular": {
     "acc": [
       "poprěčnogo / poprěčny",
@@ -112619,6 +114154,7 @@ exports[`adjective 21035 1`] = `
       "pravověrne",
     ],
   },
+  "short": "pravověrėn",
   "singular": {
     "acc": [
       "pravověrnogo / pravověrny",
@@ -112688,6 +114224,7 @@ exports[`adjective 21107 1`] = `
       "prųžne",
     ],
   },
+  "short": "prųžėn",
   "singular": {
     "acc": [
       "prųžnogo / prųžny",
@@ -112757,6 +114294,7 @@ exports[`adjective 21182 1`] = `
       "travime",
     ],
   },
+  "short": "travim",
   "singular": {
     "acc": [
       "travimogo / travimy",
@@ -112826,6 +114364,7 @@ exports[`adjective 21212 1`] = `
       "varlive",
     ],
   },
+  "short": "varliv",
   "singular": {
     "acc": [
       "varlivogo / varlivy",
@@ -112895,6 +114434,7 @@ exports[`adjective 21240 1`] = `
       "zapušćene",
     ],
   },
+  "short": "zapušćen",
   "singular": {
     "acc": [
       "zapušćenogo / zapušćeny",
@@ -112964,6 +114504,7 @@ exports[`adjective 21261 1`] = `
       "bezsmysľne",
     ],
   },
+  "short": "bezsmysľėn",
   "singular": {
     "acc": [
       "bezsmysľnogo / bezsmysľny",
@@ -113033,6 +114574,7 @@ exports[`adjective 21263 1`] = `
       "bezuslovne",
     ],
   },
+  "short": "bezuslovėn",
   "singular": {
     "acc": [
       "bezuslovnogo / bezuslovny",
@@ -113102,6 +114644,7 @@ exports[`adjective 21264 1`] = `
       "blågorodne",
     ],
   },
+  "short": "blågorodėn",
   "singular": {
     "acc": [
       "blågorodnogo / blågorodny",
@@ -113171,6 +114714,7 @@ exports[`adjective 21287 1`] = `
       "elegantne",
     ],
   },
+  "short": "elegantėn",
   "singular": {
     "acc": [
       "elegantnogo / elegantny",
@@ -113240,6 +114784,7 @@ exports[`adjective 21293 1`] = `
       "goloslovne",
     ],
   },
+  "short": "goloslovėn",
   "singular": {
     "acc": [
       "goloslovnogo / goloslovny",
@@ -113309,6 +114854,7 @@ exports[`adjective 21298 1`] = `
       "izolovane",
     ],
   },
+  "short": "izolovan",
   "singular": {
     "acc": [
       "izolovanogo / izolovany",
@@ -113378,6 +114924,7 @@ exports[`adjective 21310 1`] = `
       "jednoobrazne",
     ],
   },
+  "short": "jednoobrazėn",
   "singular": {
     "acc": [
       "jednoobraznogo / jednoobrazny",
@@ -113447,6 +114994,7 @@ exports[`adjective 21312 1`] = `
       "jednorodne",
     ],
   },
+  "short": "jednorodėn",
   "singular": {
     "acc": [
       "jednorodnogo / jednorodny",
@@ -113516,6 +115064,7 @@ exports[`adjective 21320 1`] = `
       "krasnorěčive",
     ],
   },
+  "short": "krasnorěčiv",
   "singular": {
     "acc": [
       "krasnorěčivogo / krasnorěčivy",
@@ -113585,6 +115134,7 @@ exports[`adjective 21331 1`] = `
       "lagodne",
     ],
   },
+  "short": "lagodėn",
   "singular": {
     "acc": [
       "lagodnogo / lagodny",
@@ -113654,6 +115204,7 @@ exports[`adjective 21343 1`] = `
       "mnogorěčive",
     ],
   },
+  "short": "mnogorěčiv",
   "singular": {
     "acc": [
       "mnogorěčivogo / mnogorěčivy",
@@ -113723,6 +115274,7 @@ exports[`adjective 21344 1`] = `
       "mnogoslovne",
     ],
   },
+  "short": "mnogoslovėn",
   "singular": {
     "acc": [
       "mnogoslovnogo / mnogoslovny",
@@ -113792,6 +115344,7 @@ exports[`adjective 21356 1`] = `
       "naročite",
     ],
   },
+  "short": "naročit",
   "singular": {
     "acc": [
       "naročitogo / naročity",
@@ -113861,6 +115414,7 @@ exports[`adjective 21365 1`] = `
       "neposědlive",
     ],
   },
+  "short": "neposědliv",
   "singular": {
     "acc": [
       "neposědlivogo / neposědlivy",
@@ -113930,6 +115484,7 @@ exports[`adjective 21380 1`] = `
       "obrazne",
     ],
   },
+  "short": "obrazėn",
   "singular": {
     "acc": [
       "obraznogo / obrazny",
@@ -113999,6 +115554,7 @@ exports[`adjective 21395 1`] = `
       "očarovateljne",
     ],
   },
+  "short": "očarovateljėn",
   "singular": {
     "acc": [
       "očarovateljnogo / očarovateljny",
@@ -114068,6 +115624,7 @@ exports[`adjective 21402 1`] = `
       "odrěčne",
     ],
   },
+  "short": "odrěčėn",
   "singular": {
     "acc": [
       "odrěčnogo / odrěčny",
@@ -114137,6 +115694,7 @@ exports[`adjective 21462 1`] = `
       "prěkrasne",
     ],
   },
+  "short": "prěkrasėn",
   "singular": {
     "acc": [
       "prěkrasnogo / prěkrasny",
@@ -114206,6 +115764,7 @@ exports[`adjective 21493 1`] = `
       "råstle",
     ],
   },
+  "short": "råstl",
   "singular": {
     "acc": [
       "råstlogo / råstly",
@@ -114275,6 +115834,7 @@ exports[`adjective 21496 1`] = `
       "råvnodušne",
     ],
   },
+  "short": "råvnodušėn",
   "singular": {
     "acc": [
       "råvnodušnogo / råvnodušny",
@@ -114344,6 +115904,7 @@ exports[`adjective 21503 1`] = `
       "raziteljne",
     ],
   },
+  "short": "raziteljėn",
   "singular": {
     "acc": [
       "raziteljnogo / raziteljny",
@@ -114413,6 +115974,7 @@ exports[`adjective 21509 1`] = `
       "råznorodne",
     ],
   },
+  "short": "råznorodėn",
   "singular": {
     "acc": [
       "råznorodnogo / råznorodny",
@@ -114482,6 +116044,7 @@ exports[`adjective 21557 1`] = `
       "samovoljne",
     ],
   },
+  "short": "samovoljėn",
   "singular": {
     "acc": [
       "samovoljnogo / samovoljny",
@@ -114551,6 +116114,7 @@ exports[`adjective 21585 1`] = `
       "sobstvene",
     ],
   },
+  "short": "sobstven",
   "singular": {
     "acc": [
       "sobstvenogo / sobstveny",
@@ -114620,6 +116184,7 @@ exports[`adjective 21588 1`] = `
       "srědoběžne",
     ],
   },
+  "short": "srědoběžėn",
   "singular": {
     "acc": [
       "srědoběžnogo / srědoběžny",
@@ -114689,6 +116254,7 @@ exports[`adjective 21589 1`] = `
       "srědotěčne",
     ],
   },
+  "short": "srědotěčėn",
   "singular": {
     "acc": [
       "srědotěčnogo / srědotěčny",
@@ -114758,6 +116324,7 @@ exports[`adjective 21593 1`] = `
       "strånne",
     ],
   },
+  "short": "strånėn",
   "singular": {
     "acc": [
       "strånnogo / strånny",
@@ -114827,6 +116394,7 @@ exports[`adjective 21599 1`] = `
       "umarjajųće",
     ],
   },
+  "short": "umarjajųć",
   "singular": {
     "acc": [
       "umarjajųćego / umarjajųći",
@@ -114896,6 +116464,7 @@ exports[`adjective 21618 1`] = `
       "usŕdne",
     ],
   },
+  "short": "usŕdėn",
   "singular": {
     "acc": [
       "usŕdnogo / usŕdny",
@@ -114965,6 +116534,7 @@ exports[`adjective 21628 1`] = `
       "vrođene",
     ],
   },
+  "short": "vrođen",
   "singular": {
     "acc": [
       "vrođenogo / vrođeny",
@@ -115034,6 +116604,7 @@ exports[`adjective 21650 1`] = `
       "zabavne",
     ],
   },
+  "short": "zabavėn",
   "singular": {
     "acc": [
       "zabavnogo / zabavny",
@@ -115103,6 +116674,7 @@ exports[`adjective 21698 1`] = `
       "statne",
     ],
   },
+  "short": "statėn",
   "singular": {
     "acc": [
       "statnogo / statny",
@@ -115172,6 +116744,7 @@ exports[`adjective 21763 1`] = `
       "prědstojęće",
     ],
   },
+  "short": "prědstojęć",
   "singular": {
     "acc": [
       "prědstojęćego / prědstojęći",
@@ -115241,6 +116814,7 @@ exports[`adjective 21772 1`] = `
       "pristojne",
     ],
   },
+  "short": "pristojėn",
   "singular": {
     "acc": [
       "pristojnogo / pristojny",
@@ -115310,6 +116884,7 @@ exports[`adjective 21883 1`] = `
       "postrånne",
     ],
   },
+  "short": "postrånėn",
   "singular": {
     "acc": [
       "postrånnogo / postrånny",
@@ -115379,6 +116954,7 @@ exports[`adjective 21896 1`] = `
       "pristrastne",
     ],
   },
+  "short": "pristrastėn",
   "singular": {
     "acc": [
       "pristrastnogo / pristrastny",
@@ -115448,6 +117024,7 @@ exports[`adjective 21963 1`] = `
       "prěstųpne",
     ],
   },
+  "short": "prěstųpėn",
   "singular": {
     "acc": [
       "prěstųpnogo / prěstųpny",
@@ -115517,6 +117094,7 @@ exports[`adjective 22020 1`] = `
       "svojevlastne",
     ],
   },
+  "short": "svojevlastėn",
   "singular": {
     "acc": [
       "svojevlastnogo / svojevlastny",
@@ -115586,6 +117164,7 @@ exports[`adjective 22027 1`] = `
       "tęglive",
     ],
   },
+  "short": "tęgliv",
   "singular": {
     "acc": [
       "tęglivogo / tęglivy",
@@ -115655,6 +117234,7 @@ exports[`adjective 22041 1`] = `
       "tųge",
     ],
   },
+  "short": "tųg",
   "singular": {
     "acc": [
       "tųgogo / tųgy",
@@ -115724,6 +117304,7 @@ exports[`adjective 22046 1`] = `
       "pritęglive",
     ],
   },
+  "short": "pritęgliv",
   "singular": {
     "acc": [
       "pritęglivogo / pritęglivy",
@@ -115793,6 +117374,7 @@ exports[`adjective 22048 1`] = `
       "protęžne",
     ],
   },
+  "short": "protęžėn",
   "singular": {
     "acc": [
       "protęžnogo / protęžny",
@@ -115862,6 +117444,7 @@ exports[`adjective 22146 1`] = `
       "blågotvorne",
     ],
   },
+  "short": "blågotvorėn",
   "singular": {
     "acc": [
       "blågotvornogo / blågotvorny",
@@ -115931,6 +117514,7 @@ exports[`adjective 22162 1`] = `
       "nadobyčajne",
     ],
   },
+  "short": "nadobyčajėn",
   "singular": {
     "acc": [
       "nadobyčajnogo / nadobyčajny",
@@ -116000,6 +117584,7 @@ exports[`adjective 22269 1`] = `
       "vvodne",
     ],
   },
+  "short": "vvodėn",
   "singular": {
     "acc": [
       "vvodnogo / vvodny",
@@ -116069,6 +117654,7 @@ exports[`adjective 22284 1`] = `
       "veličstvene",
     ],
   },
+  "short": "veličstven",
   "singular": {
     "acc": [
       "veličstvenogo / veličstveny",
@@ -116138,6 +117724,7 @@ exports[`adjective 22286 1`] = `
       "velikolěpne",
     ],
   },
+  "short": "velikolěpėn",
   "singular": {
     "acc": [
       "velikolěpnogo / velikolěpny",
@@ -116207,6 +117794,7 @@ exports[`adjective 22299 1`] = `
       "blågovoljne",
     ],
   },
+  "short": "blågovoljėn",
   "singular": {
     "acc": [
       "blågovoljnogo / blågovoljny",
@@ -116276,6 +117864,7 @@ exports[`adjective 22300 1`] = `
       "libovoljne",
     ],
   },
+  "short": "libovoljėn",
   "singular": {
     "acc": [
       "libovoljnogo / libovoljny",
@@ -116345,6 +117934,7 @@ exports[`adjective 22302 1`] = `
       "mimovoljne",
     ],
   },
+  "short": "mimovoljėn",
   "singular": {
     "acc": [
       "mimovoljnogo / mimovoljny",
@@ -116414,6 +118004,7 @@ exports[`adjective 22304 1`] = `
       "svojevoljne",
     ],
   },
+  "short": "svojevoljėn",
   "singular": {
     "acc": [
       "svojevoljnogo / svojevoljny",
@@ -116483,6 +118074,7 @@ exports[`adjective 22318 1`] = `
       "proizvoljne",
     ],
   },
+  "short": "proizvoljėn",
   "singular": {
     "acc": [
       "proizvoljnogo / proizvoljny",
@@ -116552,6 +118144,7 @@ exports[`adjective 22323 1`] = `
       "malověrne",
     ],
   },
+  "short": "malověrėn",
   "singular": {
     "acc": [
       "malověrnogo / malověrny",
@@ -116621,6 +118214,7 @@ exports[`adjective 22325 1`] = `
       "dověrne",
     ],
   },
+  "short": "dověrėn",
   "singular": {
     "acc": [
       "dověrnogo / dověrny",
@@ -116690,6 +118284,7 @@ exports[`adjective 22344 1`] = `
       "povsednje",
     ],
   },
+  "short": "povsedėn",
   "singular": {
     "acc": [
       "povsednjego / povsednji",
@@ -116759,6 +118354,7 @@ exports[`adjective 22347 1`] = `
       "vsežerne",
     ],
   },
+  "short": "vsežerėn",
   "singular": {
     "acc": [
       "vsežernogo / vsežerny",
@@ -116828,6 +118424,7 @@ exports[`adjective 22353 1`] = `
       "pŕvorędne",
     ],
   },
+  "short": "pŕvorędėn",
   "singular": {
     "acc": [
       "pŕvorędnogo / pŕvorędny",
@@ -116897,6 +118494,7 @@ exports[`adjective 22360 1`] = `
       "podrędne",
     ],
   },
+  "short": "podrędėn",
   "singular": {
     "acc": [
       "podrędnogo / podrędny",
@@ -116966,6 +118564,7 @@ exports[`adjective 22378 1`] = `
       "vnųtrišnje",
     ],
   },
+  "short": "vnųtrišėn",
   "singular": {
     "acc": [
       "vnųtrišnjego / vnųtrišnji",
@@ -117035,6 +118634,7 @@ exports[`adjective 22378-1 1`] = `
       "vnųtrišne",
     ],
   },
+  "short": "vnųtrišėn",
   "singular": {
     "acc": [
       "vnųtrišnogo / vnųtrišny",
@@ -117104,6 +118704,7 @@ exports[`adjective 22385 1`] = `
       "gvatemaľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gvatemaľskogo / gvatemaľsky",
@@ -117173,6 +118774,7 @@ exports[`adjective 22387 1`] = `
       "hondurasske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "hondurasskogo / hondurassky",
@@ -117242,6 +118844,7 @@ exports[`adjective 22389 1`] = `
       "argentinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "argentinskogo / argentinsky",
@@ -117311,6 +118914,7 @@ exports[`adjective 22394 1`] = `
       "egoistične",
     ],
   },
+  "short": "egoističėn",
   "singular": {
     "acc": [
       "egoističnogo / egoističny",
@@ -117380,6 +118984,7 @@ exports[`adjective 22405 1`] = `
       "privětlive",
     ],
   },
+  "short": "privětliv",
   "singular": {
     "acc": [
       "privětlivogo / privětlivy",
@@ -117449,6 +119054,7 @@ exports[`adjective 22430 1`] = `
       "zavistne",
     ],
   },
+  "short": "zavistėn",
   "singular": {
     "acc": [
       "zavistnogo / zavistny",
@@ -117518,6 +119124,7 @@ exports[`adjective 22432 1`] = `
       "sųvisle",
     ],
   },
+  "short": "sųvisl",
   "singular": {
     "acc": [
       "sųvislogo / sųvisly",
@@ -117587,6 +119194,7 @@ exports[`adjective 22435 1`] = `
       "bolivijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bolivijskogo / bolivijsky",
@@ -117656,6 +119264,7 @@ exports[`adjective 22437 1`] = `
       "ekvadorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ekvadorskogo / ekvadorsky",
@@ -117725,6 +119334,7 @@ exports[`adjective 22439 1`] = `
       "gajanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gajanskogo / gajansky",
@@ -117794,6 +119404,7 @@ exports[`adjective 22441 1`] = `
       "kolumbijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kolumbijskogo / kolumbijsky",
@@ -117863,6 +119474,7 @@ exports[`adjective 22443 1`] = `
       "paragvajske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "paragvajskogo / paragvajsky",
@@ -117932,6 +119544,7 @@ exports[`adjective 22447 1`] = `
       "surinamske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "surinamskogo / surinamsky",
@@ -118001,6 +119614,7 @@ exports[`adjective 22449 1`] = `
       "urugvajske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "urugvajskogo / urugvajsky",
@@ -118070,6 +119684,7 @@ exports[`adjective 22451 1`] = `
       "venezueľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "venezueľskogo / venezueľsky",
@@ -118139,6 +119754,7 @@ exports[`adjective 22453 1`] = `
       "bahamske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bahamskogo / bahamsky",
@@ -118208,6 +119824,7 @@ exports[`adjective 22457 1`] = `
       "haitianske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "haitianskogo / haitiansky",
@@ -118277,6 +119894,7 @@ exports[`adjective 22458 1`] = `
       "jamajske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "jamajskogo / jamajsky",
@@ -118346,6 +119964,7 @@ exports[`adjective 22460 1`] = `
       "kostarikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kostarikanskogo / kostarikansky",
@@ -118415,6 +120034,7 @@ exports[`adjective 22463 1`] = `
       "nikaraguanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "nikaraguanskogo / nikaraguansky",
@@ -118484,6 +120104,7 @@ exports[`adjective 22465 1`] = `
       "panamske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "panamskogo / panamsky",
@@ -118553,6 +120174,7 @@ exports[`adjective 22467 1`] = `
       "salvadorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "salvadorskogo / salvadorsky",
@@ -118622,6 +120244,7 @@ exports[`adjective 22485 1`] = `
       "bezvladne",
     ],
   },
+  "short": "bezvladėn",
   "singular": {
     "acc": [
       "bezvladnogo / bezvladny",
@@ -118691,6 +120314,7 @@ exports[`adjective 22543 1`] = `
       "privlěkateljne",
     ],
   },
+  "short": "privlěkateljėn",
   "singular": {
     "acc": [
       "privlěkateljnogo / privlěkateljny",
@@ -118760,6 +120384,7 @@ exports[`adjective 22548 1`] = `
       "vodoråvne",
     ],
   },
+  "short": "vodoråvėn",
   "singular": {
     "acc": [
       "vodoråvnogo / vodoråvny",
@@ -118829,6 +120454,7 @@ exports[`adjective 22549 1`] = `
       "vodozemne",
     ],
   },
+  "short": "vodozemėn",
   "singular": {
     "acc": [
       "vodozemnogo / vodozemny",
@@ -118898,6 +120524,7 @@ exports[`adjective 22565 1`] = `
       "vŕhovne",
     ],
   },
+  "short": "vŕhovėn",
   "singular": {
     "acc": [
       "vŕhovnogo / vŕhovny",
@@ -118967,6 +120594,7 @@ exports[`adjective 22568 1`] = `
       "povŕhne",
     ],
   },
+  "short": "povŕhėn",
   "singular": {
     "acc": [
       "povŕhnogo / povŕhny",
@@ -119036,6 +120664,7 @@ exports[`adjective 22573 1`] = `
       "vrěmenne",
     ],
   },
+  "short": "vrěmenėn",
   "singular": {
     "acc": [
       "vrěmennogo / vrěmenny",
@@ -119105,6 +120734,7 @@ exports[`adjective 22574 1`] = `
       "jednovrěmenne",
     ],
   },
+  "short": "jednovrěmenėn",
   "singular": {
     "acc": [
       "jednovrěmennogo / jednovrěmenny",
@@ -119174,6 +120804,7 @@ exports[`adjective 22695 1`] = `
       "povråtne",
     ],
   },
+  "short": "povråtėn",
   "singular": {
     "acc": [
       "povråtnogo / povråtny",
@@ -119243,6 +120874,7 @@ exports[`adjective 22700 1`] = `
       "prěvråtne",
     ],
   },
+  "short": "prěvråtėn",
   "singular": {
     "acc": [
       "prěvråtnogo / prěvråtny",
@@ -119312,6 +120944,7 @@ exports[`adjective 22718 1`] = `
       "vȯzvråtne",
     ],
   },
+  "short": "vȯzvråtėn",
   "singular": {
     "acc": [
       "vȯzvråtnogo / vȯzvråtny",
@@ -119381,6 +121014,7 @@ exports[`adjective 22720 1`] = `
       "zavråtne",
     ],
   },
+  "short": "zavråtėn",
   "singular": {
     "acc": [
       "zavråtnogo / zavråtny",
@@ -119450,6 +121084,7 @@ exports[`adjective 22724 1`] = `
       "vysokoparne",
     ],
   },
+  "short": "vysokoparėn",
   "singular": {
     "acc": [
       "vysokoparnogo / vysokoparny",
@@ -119519,6 +121154,7 @@ exports[`adjective 22765 1`] = `
       "mongoľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "mongoľskogo / mongoľsky",
@@ -119588,6 +121224,7 @@ exports[`adjective 22766 1`] = `
       "pakistanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pakistanskogo / pakistansky",
@@ -119657,6 +121294,7 @@ exports[`adjective 22768 1`] = `
       "korejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "korejskogo / korejsky",
@@ -119726,6 +121364,7 @@ exports[`adjective 22770 1`] = `
       "malajske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "malajskogo / malajsky",
@@ -119795,6 +121434,7 @@ exports[`adjective 22773 1`] = `
       "sěvernokorejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sěvernokorejskogo / sěvernokorejsky",
@@ -119864,6 +121504,7 @@ exports[`adjective 22774 1`] = `
       "južnokorejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "južnokorejskogo / južnokorejsky",
@@ -119933,6 +121574,7 @@ exports[`adjective 22777 1`] = `
       "etiopske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "etiopskogo / etiopsky",
@@ -120002,6 +121644,7 @@ exports[`adjective 22801 1`] = `
       "osiroćene",
     ],
   },
+  "short": "osiroćen",
   "singular": {
     "acc": [
       "osiroćenogo / osiroćeny",
@@ -120071,6 +121714,7 @@ exports[`adjective 22810 1`] = `
       "avtentične",
     ],
   },
+  "short": "avtentičėn",
   "singular": {
     "acc": [
       "avtentičnogo / avtentičny",
@@ -120140,6 +121784,7 @@ exports[`adjective 22832 1`] = `
       "znatne",
     ],
   },
+  "short": "znatėn",
   "singular": {
     "acc": [
       "znatnogo / znatny",
@@ -120209,6 +121854,7 @@ exports[`adjective 22884 1`] = `
       "sųznačne",
     ],
   },
+  "short": "sųznačėn",
   "singular": {
     "acc": [
       "sųznačnogo / sųznačny",
@@ -120278,6 +121924,7 @@ exports[`adjective 22893 1`] = `
       "neobzrime",
     ],
   },
+  "short": "neobzrim",
   "singular": {
     "acc": [
       "neobzrimogo / neobzrimy",
@@ -120347,6 +121994,7 @@ exports[`adjective 22943 1`] = `
       "jedome",
     ],
   },
+  "short": "jedom",
   "singular": {
     "acc": [
       "jedomogo / jedomy",
@@ -120416,6 +122064,7 @@ exports[`adjective 22944 1`] = `
       "męsojedne",
     ],
   },
+  "short": "męsojedėn",
   "singular": {
     "acc": [
       "męsojednogo / męsojedny",
@@ -120485,6 +122134,7 @@ exports[`adjective 22946 1`] = `
       "męsožerne",
     ],
   },
+  "short": "męsožerėn",
   "singular": {
     "acc": [
       "męsožernogo / męsožerny",
@@ -120554,6 +122204,7 @@ exports[`adjective 22948 1`] = `
       "råstlinožerne",
     ],
   },
+  "short": "råstlinožerėn",
   "singular": {
     "acc": [
       "råstlinožernogo / råstlinožerny",
@@ -120623,6 +122274,7 @@ exports[`adjective 22949 1`] = `
       "travojedne",
     ],
   },
+  "short": "travojedėn",
   "singular": {
     "acc": [
       "travojednogo / travojedny",
@@ -120692,6 +122344,7 @@ exports[`adjective 22950 1`] = `
       "vsejedne",
     ],
   },
+  "short": "vsejedėn",
   "singular": {
     "acc": [
       "vsejednogo / vsejedny",
@@ -120761,6 +122414,7 @@ exports[`adjective 22953 1`] = `
       "ljudojedske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ljudojedskogo / ljudojedsky",
@@ -120830,6 +122484,7 @@ exports[`adjective 22958 1`] = `
       "ljudožerske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "ljudožerskogo / ljudožersky",
@@ -120899,6 +122554,7 @@ exports[`adjective 22961 1`] = `
       "kanibaľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kanibaľskogo / kanibaľsky",
@@ -120968,6 +122624,7 @@ exports[`adjective 22962 1`] = `
       "žrave",
     ],
   },
+  "short": "žrav",
   "singular": {
     "acc": [
       "žravogo / žravy",
@@ -121037,6 +122694,7 @@ exports[`adjective 22984 1`] = `
       "črězměrne",
     ],
   },
+  "short": "črězměrėn",
   "singular": {
     "acc": [
       "črězměrnogo / črězměrny",
@@ -121106,6 +122764,7 @@ exports[`adjective 22993 1`] = `
       "dvujęzyčne",
     ],
   },
+  "short": "dvujęzyčėn",
   "singular": {
     "acc": [
       "dvujęzyčnogo / dvujęzyčny",
@@ -121175,6 +122834,7 @@ exports[`adjective 22995 1`] = `
       "dinamične",
     ],
   },
+  "short": "dinamičėn",
   "singular": {
     "acc": [
       "dinamičnogo / dinamičny",
@@ -121244,6 +122904,7 @@ exports[`adjective 23013 1`] = `
       "mikroskopične",
     ],
   },
+  "short": "mikroskopičėn",
   "singular": {
     "acc": [
       "mikroskopičnogo / mikroskopičny",
@@ -121307,6 +122968,7 @@ exports[`adjective 23043 1`] = `
       "najdaljše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najdaljšego / najdaljši",
@@ -121376,6 +123038,7 @@ exports[`adjective 23049 1`] = `
       "staromodne",
     ],
   },
+  "short": "staromodėn",
   "singular": {
     "acc": [
       "staromodnogo / staromodny",
@@ -121445,6 +123108,7 @@ exports[`adjective 23056 1`] = `
       "posrane",
     ],
   },
+  "short": "posran",
   "singular": {
     "acc": [
       "posranogo / posrany",
@@ -121514,6 +123178,7 @@ exports[`adjective 23163 1`] = `
       "kristaľne",
     ],
   },
+  "short": "kristaľėn",
   "singular": {
     "acc": [
       "kristaľnogo / kristaľny",
@@ -121583,6 +123248,7 @@ exports[`adjective 23204 1`] = `
       "slaboumne",
     ],
   },
+  "short": "slaboumėn",
   "singular": {
     "acc": [
       "slaboumnogo / slaboumny",
@@ -121652,6 +123318,7 @@ exports[`adjective 23205 1`] = `
       "råvnoběžne",
     ],
   },
+  "short": "råvnoběžėn",
   "singular": {
     "acc": [
       "råvnoběžnogo / råvnoběžny",
@@ -121721,6 +123388,7 @@ exports[`adjective 23207 1`] = `
       "paraleľne",
     ],
   },
+  "short": "paraleľėn",
   "singular": {
     "acc": [
       "paraleľnogo / paraleľny",
@@ -121790,6 +123458,7 @@ exports[`adjective 23209 1`] = `
       "analogične",
     ],
   },
+  "short": "analogičėn",
   "singular": {
     "acc": [
       "analogičnogo / analogičny",
@@ -121859,6 +123528,7 @@ exports[`adjective 23212 1`] = `
       "kožene",
     ],
   },
+  "short": "kožen",
   "singular": {
     "acc": [
       "koženogo / koženy",
@@ -121928,6 +123598,7 @@ exports[`adjective 23220 1`] = `
       "dražlive",
     ],
   },
+  "short": "dražliv",
   "singular": {
     "acc": [
       "dražlivogo / dražlivy",
@@ -121997,6 +123668,7 @@ exports[`adjective 23222 1`] = `
       "nervozne",
     ],
   },
+  "short": "nervozėn",
   "singular": {
     "acc": [
       "nervoznogo / nervozny",
@@ -122066,6 +123738,7 @@ exports[`adjective 23224 1`] = `
       "nervne",
     ],
   },
+  "short": "nervėn",
   "singular": {
     "acc": [
       "nervnogo / nervny",
@@ -122135,6 +123808,7 @@ exports[`adjective 23230 1`] = `
       "idiotske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "idiotskogo / idiotsky",
@@ -122204,6 +123878,7 @@ exports[`adjective 23233 1`] = `
       "kretenske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kretenskogo / kretensky",
@@ -122273,6 +123948,7 @@ exports[`adjective 23249 1`] = `
       "poměšane",
     ],
   },
+  "short": "poměšan",
   "singular": {
     "acc": [
       "poměšanogo / poměšany",
@@ -122342,6 +124018,7 @@ exports[`adjective 23263 1`] = `
       "nejlonove",
     ],
   },
+  "short": "nejlonov",
   "singular": {
     "acc": [
       "nejlonovogo / nejlonovy",
@@ -122411,6 +124088,7 @@ exports[`adjective 23272 1`] = `
       "podvodne",
     ],
   },
+  "short": "podvodėn",
   "singular": {
     "acc": [
       "podvodnogo / podvodny",
@@ -122480,6 +124158,7 @@ exports[`adjective 23282 1`] = `
       "mitične",
     ],
   },
+  "short": "mitičėn",
   "singular": {
     "acc": [
       "mitičnogo / mitičny",
@@ -122549,6 +124228,7 @@ exports[`adjective 23284 1`] = `
       "mitologične",
     ],
   },
+  "short": "mitologičėn",
   "singular": {
     "acc": [
       "mitologičnogo / mitologičny",
@@ -122618,6 +124298,7 @@ exports[`adjective 23290 1`] = `
       "sněžnoběle",
     ],
   },
+  "short": "sněžnoběl",
   "singular": {
     "acc": [
       "sněžnobělogo / sněžnoběly",
@@ -122687,6 +124368,7 @@ exports[`adjective 23292 1`] = `
       "naznačene",
     ],
   },
+  "short": "naznačen",
   "singular": {
     "acc": [
       "naznačenogo / naznačeny",
@@ -122756,6 +124438,7 @@ exports[`adjective 23293 1`] = `
       "ustaljene",
     ],
   },
+  "short": "ustaljen",
   "singular": {
     "acc": [
       "ustaljenogo / ustaljeny",
@@ -122825,6 +124508,7 @@ exports[`adjective 23294 1`] = `
       "lěpke",
     ],
   },
+  "short": "lěpȯk",
   "singular": {
     "acc": [
       "lěpkogo / lěpky",
@@ -122894,6 +124578,7 @@ exports[`adjective 23297 1`] = `
       "klejke",
     ],
   },
+  "short": "klejėk",
   "singular": {
     "acc": [
       "klejkogo / klejky",
@@ -122963,6 +124648,7 @@ exports[`adjective 23300 1`] = `
       "mistične",
     ],
   },
+  "short": "mističėn",
   "singular": {
     "acc": [
       "mističnogo / mističny",
@@ -123032,6 +124718,7 @@ exports[`adjective 23302 1`] = `
       "tajenstvene",
     ],
   },
+  "short": "tajenstven",
   "singular": {
     "acc": [
       "tajenstvenogo / tajenstveny",
@@ -123101,6 +124788,7 @@ exports[`adjective 23312 1`] = `
       "probuđene",
     ],
   },
+  "short": "probuđen",
   "singular": {
     "acc": [
       "probuđenogo / probuđeny",
@@ -123170,6 +124858,7 @@ exports[`adjective 23324 1`] = `
       "botanične",
     ],
   },
+  "short": "botaničėn",
   "singular": {
     "acc": [
       "botaničnogo / botaničny",
@@ -123239,6 +124928,7 @@ exports[`adjective 23341 1`] = `
       "nevažne",
     ],
   },
+  "short": "nevažėn",
   "singular": {
     "acc": [
       "nevažnogo / nevažny",
@@ -123308,6 +124998,7 @@ exports[`adjective 23369 1`] = `
       "skryte",
     ],
   },
+  "short": "skryt",
   "singular": {
     "acc": [
       "skrytogo / skryty",
@@ -123377,6 +125068,7 @@ exports[`adjective 23396 1`] = `
       "vplyvne",
     ],
   },
+  "short": "vplyvėn",
   "singular": {
     "acc": [
       "vplyvnogo / vplyvny",
@@ -123446,6 +125138,7 @@ exports[`adjective 23397 1`] = `
       "vlivne",
     ],
   },
+  "short": "vlivėn",
   "singular": {
     "acc": [
       "vlivnogo / vlivny",
@@ -123515,6 +125208,7 @@ exports[`adjective 23494 1`] = `
       "anatomične",
     ],
   },
+  "short": "anatomičėn",
   "singular": {
     "acc": [
       "anatomičnogo / anatomičny",
@@ -123584,6 +125278,7 @@ exports[`adjective 23514 1`] = `
       "kapitalistične",
     ],
   },
+  "short": "kapitalističėn",
   "singular": {
     "acc": [
       "kapitalističnogo / kapitalističny",
@@ -123653,6 +125348,7 @@ exports[`adjective 23545 1`] = `
       "etične",
     ],
   },
+  "short": "etičėn",
   "singular": {
     "acc": [
       "etičnogo / etičny",
@@ -123722,6 +125418,7 @@ exports[`adjective 23559 1`] = `
       "fundamentalistične",
     ],
   },
+  "short": "fundamentalističėn",
   "singular": {
     "acc": [
       "fundamentalističnogo / fundamentalističny",
@@ -123791,6 +125488,7 @@ exports[`adjective 23570 1`] = `
       "geologične",
     ],
   },
+  "short": "geologičėn",
   "singular": {
     "acc": [
       "geologičnogo / geologičny",
@@ -123860,6 +125558,7 @@ exports[`adjective 23576 1`] = `
       "ideologične",
     ],
   },
+  "short": "ideologičėn",
   "singular": {
     "acc": [
       "ideologičnogo / ideologičny",
@@ -123929,6 +125628,7 @@ exports[`adjective 23590 1`] = `
       "magnetične",
     ],
   },
+  "short": "magnetičėn",
   "singular": {
     "acc": [
       "magnetičnogo / magnetičny",
@@ -123998,6 +125698,7 @@ exports[`adjective 23605 1`] = `
       "pedagogične",
     ],
   },
+  "short": "pedagogičėn",
   "singular": {
     "acc": [
       "pedagogičnogo / pedagogičny",
@@ -124067,6 +125768,7 @@ exports[`adjective 23608 1`] = `
       "prědhistorične",
     ],
   },
+  "short": "prědhistoričėn",
   "singular": {
     "acc": [
       "prědhistoričnogo / prědhistoričny",
@@ -124136,6 +125838,7 @@ exports[`adjective 23624 1`] = `
       "rasistične",
     ],
   },
+  "short": "rasističėn",
   "singular": {
     "acc": [
       "rasističnogo / rasističny",
@@ -124205,6 +125908,7 @@ exports[`adjective 23632 1`] = `
       "sociologične",
     ],
   },
+  "short": "sociologičėn",
   "singular": {
     "acc": [
       "sociologičnogo / sociologičny",
@@ -124274,6 +125978,7 @@ exports[`adjective 23642 1`] = `
       "turkmenske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "turkmenskogo / turkmensky",
@@ -124343,6 +126048,7 @@ exports[`adjective 23643 1`] = `
       "uzbečske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "uzbečskogo / uzbečsky",
@@ -124412,6 +126118,7 @@ exports[`adjective 23643-1 1`] = `
       "uzbekske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "uzbekskogo / uzbeksky",
@@ -124481,6 +126188,7 @@ exports[`adjective 23644 1`] = `
       "kyrgyzske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kyrgyzskogo / kyrgyzsky",
@@ -124550,6 +126258,7 @@ exports[`adjective 23645 1`] = `
       "kazahske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kazahskogo / kazahsky",
@@ -124619,6 +126328,7 @@ exports[`adjective 23645-1 1`] = `
       "kazašske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kazašskogo / kazašsky",
@@ -124688,6 +126398,7 @@ exports[`adjective 23646 1`] = `
       "tadžičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "tadžičskogo / tadžičsky",
@@ -124757,6 +126468,7 @@ exports[`adjective 23646-1 1`] = `
       "tadžikske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "tadžikskogo / tadžiksky",
@@ -124826,6 +126538,7 @@ exports[`adjective 23677 1`] = `
       "čudesne",
     ],
   },
+  "short": "čudesėn",
   "singular": {
     "acc": [
       "čudesnogo / čudesny",
@@ -124895,6 +126608,7 @@ exports[`adjective 23692 1`] = `
       "definitivne",
     ],
   },
+  "short": "definitivėn",
   "singular": {
     "acc": [
       "definitivnogo / definitivny",
@@ -124964,6 +126678,7 @@ exports[`adjective 23708 1`] = `
       "neposlušne",
     ],
   },
+  "short": "neposlušėn",
   "singular": {
     "acc": [
       "neposlušnogo / neposlušny",
@@ -125033,6 +126748,7 @@ exports[`adjective 23709 1`] = `
       "nevidime",
     ],
   },
+  "short": "nevidim",
   "singular": {
     "acc": [
       "nevidimogo / nevidimy",
@@ -125102,6 +126818,7 @@ exports[`adjective 23712 1`] = `
       "něžne",
     ],
   },
+  "short": "něžėn",
   "singular": {
     "acc": [
       "něžnogo / něžny",
@@ -125171,6 +126888,7 @@ exports[`adjective 23714 1`] = `
       "poetične",
     ],
   },
+  "short": "poetičėn",
   "singular": {
     "acc": [
       "poetičnogo / poetičny",
@@ -125240,6 +126958,7 @@ exports[`adjective 23719 1`] = `
       "steklěne",
     ],
   },
+  "short": "steklěn",
   "singular": {
     "acc": [
       "steklěnogo / steklěny",
@@ -125309,6 +127028,7 @@ exports[`adjective 23723 1`] = `
       "vulkanične",
     ],
   },
+  "short": "vulkaničėn",
   "singular": {
     "acc": [
       "vulkaničnogo / vulkaničny",
@@ -125378,6 +127098,7 @@ exports[`adjective 23733 1`] = `
       "vinovate",
     ],
   },
+  "short": "vinovat",
   "singular": {
     "acc": [
       "vinovatogo / vinovaty",
@@ -125447,6 +127168,7 @@ exports[`adjective 23740 1`] = `
       "oblěčene",
     ],
   },
+  "short": "oblěčen",
   "singular": {
     "acc": [
       "oblěčenogo / oblěčeny",
@@ -125516,6 +127238,7 @@ exports[`adjective 23742 1`] = `
       "oděte",
     ],
   },
+  "short": "odět",
   "singular": {
     "acc": [
       "odětogo / oděty",
@@ -125585,6 +127308,7 @@ exports[`adjective 23752 1`] = `
       "sŕdite",
     ],
   },
+  "short": "sŕdit",
   "singular": {
     "acc": [
       "sŕditogo / sŕdity",
@@ -125654,6 +127378,7 @@ exports[`adjective 23753 1`] = `
       "uběđene",
     ],
   },
+  "short": "uběđen",
   "singular": {
     "acc": [
       "uběđenogo / uběđeny",
@@ -125723,6 +127448,7 @@ exports[`adjective 23756 1`] = `
       "blågoprijatne",
     ],
   },
+  "short": "blågoprijatėn",
   "singular": {
     "acc": [
       "blågoprijatnogo / blågoprijatny",
@@ -125792,6 +127518,7 @@ exports[`adjective 23763 1`] = `
       "nemilosŕdne",
     ],
   },
+  "short": "nemilosŕdėn",
   "singular": {
     "acc": [
       "nemilosŕdnogo / nemilosŕdny",
@@ -125861,6 +127588,7 @@ exports[`adjective 23768 1`] = `
       "revmatične",
     ],
   },
+  "short": "revmatičėn",
   "singular": {
     "acc": [
       "revmatičnogo / revmatičny",
@@ -125930,6 +127658,7 @@ exports[`adjective 23782 1`] = `
       "proporcionaľne",
     ],
   },
+  "short": "proporcionaľėn",
   "singular": {
     "acc": [
       "proporcionaľnogo / proporcionaľny",
@@ -125999,6 +127728,7 @@ exports[`adjective 23796 1`] = `
       "večerne",
     ],
   },
+  "short": "večerėn",
   "singular": {
     "acc": [
       "večernogo / večerny",
@@ -126068,6 +127798,7 @@ exports[`adjective 23797 1`] = `
       "råzdražnjene",
     ],
   },
+  "short": "råzdražnjen",
   "singular": {
     "acc": [
       "råzdražnjenogo / råzdražnjeny",
@@ -126137,6 +127868,7 @@ exports[`adjective 23804 1`] = `
       "protivrěčne",
     ],
   },
+  "short": "protivrěčėn",
   "singular": {
     "acc": [
       "protivrěčnogo / protivrěčny",
@@ -126206,6 +127938,7 @@ exports[`adjective 23808 1`] = `
       "samoljubne",
     ],
   },
+  "short": "samoljubėn",
   "singular": {
     "acc": [
       "samoljubnogo / samoljubny",
@@ -126275,6 +128008,7 @@ exports[`adjective 23819 1`] = `
       "sråmotne",
     ],
   },
+  "short": "sråmotėn",
   "singular": {
     "acc": [
       "sråmotnogo / sråmotny",
@@ -126344,6 +128078,7 @@ exports[`adjective 23821 1`] = `
       "sråmne",
     ],
   },
+  "short": "sråmėn",
   "singular": {
     "acc": [
       "sråmnogo / sråmny",
@@ -126413,6 +128148,7 @@ exports[`adjective 23825 1`] = `
       "sråmęžlive",
     ],
   },
+  "short": "sråmęžliv",
   "singular": {
     "acc": [
       "sråmęžlivogo / sråmęžlivy",
@@ -126482,6 +128218,7 @@ exports[`adjective 23844 1`] = `
       "zasråmjene",
     ],
   },
+  "short": "zasråmjen",
   "singular": {
     "acc": [
       "zasråmjenogo / zasråmjeny",
@@ -126551,6 +128288,7 @@ exports[`adjective 23845 1`] = `
       "vpečatlive",
     ],
   },
+  "short": "vpečatliv",
   "singular": {
     "acc": [
       "vpečatlivogo / vpečatlivy",
@@ -126620,6 +128358,7 @@ exports[`adjective 23847 1`] = `
       "imponujųće",
     ],
   },
+  "short": "imponujųć",
   "singular": {
     "acc": [
       "imponujųćego / imponujųći",
@@ -126689,6 +128428,7 @@ exports[`adjective 23850 1`] = `
       "impulsivne",
     ],
   },
+  "short": "impulsivėn",
   "singular": {
     "acc": [
       "impulsivnogo / impulsivny",
@@ -126758,6 +128498,7 @@ exports[`adjective 23879 1`] = `
       "nesrųčne",
     ],
   },
+  "short": "nesrųčėn",
   "singular": {
     "acc": [
       "nesrųčnogo / nesrųčny",
@@ -126827,6 +128568,7 @@ exports[`adjective 23881 1`] = `
       "neodložne",
     ],
   },
+  "short": "neodložėn",
   "singular": {
     "acc": [
       "neodložnogo / neodložny",
@@ -126896,6 +128638,7 @@ exports[`adjective 23885 1`] = `
       "odvlěčene",
     ],
   },
+  "short": "odvlěčen",
   "singular": {
     "acc": [
       "odvlěčenogo / odvlěčeny",
@@ -126965,6 +128708,7 @@ exports[`adjective 23908 1`] = `
       "prělěpe",
     ],
   },
+  "short": "prělěp",
   "singular": {
     "acc": [
       "prělěpogo / prělěpy",
@@ -127034,6 +128778,7 @@ exports[`adjective 23924 1`] = `
       "råzgněvane",
     ],
   },
+  "short": "råzgněvan",
   "singular": {
     "acc": [
       "råzgněvanogo / råzgněvany",
@@ -127103,6 +128848,7 @@ exports[`adjective 23953 1`] = `
       "vrědne",
     ],
   },
+  "short": "vrědėn",
   "singular": {
     "acc": [
       "vrědnogo / vrědny",
@@ -127172,6 +128918,7 @@ exports[`adjective 23961 1`] = `
       "zahvaćajųće",
     ],
   },
+  "short": "zahvaćajųć",
   "singular": {
     "acc": [
       "zahvaćajųćego / zahvaćajųći",
@@ -127241,6 +128988,7 @@ exports[`adjective 23990 1`] = `
       "tŕpělive",
     ],
   },
+  "short": "tŕpěliv",
   "singular": {
     "acc": [
       "tŕpělivogo / tŕpělivy",
@@ -127310,6 +129058,7 @@ exports[`adjective 23993 1`] = `
       "generične",
     ],
   },
+  "short": "generičėn",
   "singular": {
     "acc": [
       "generičnogo / generičny",
@@ -127379,6 +129128,7 @@ exports[`adjective 23995 1`] = `
       "drågocěnne",
     ],
   },
+  "short": "drågocěnėn",
   "singular": {
     "acc": [
       "drågocěnnogo / drågocěnny",
@@ -127448,6 +129198,7 @@ exports[`adjective 23997 1`] = `
       "geografične",
     ],
   },
+  "short": "geografičėn",
   "singular": {
     "acc": [
       "geografičnogo / geografičny",
@@ -127517,6 +129268,7 @@ exports[`adjective 24009 1`] = `
       "jednakove",
     ],
   },
+  "short": "jednakov",
   "singular": {
     "acc": [
       "jednakovogo / jednakovy",
@@ -127586,6 +129338,7 @@ exports[`adjective 24071 1`] = `
       "adekvatne",
     ],
   },
+  "short": "adekvatėn",
   "singular": {
     "acc": [
       "adekvatnogo / adekvatny",
@@ -127655,6 +129408,7 @@ exports[`adjective 24116 1`] = `
       "aglutinativne",
     ],
   },
+  "short": "aglutinativėn",
   "singular": {
     "acc": [
       "aglutinativnogo / aglutinativny",
@@ -127724,6 +129478,7 @@ exports[`adjective 24124 1`] = `
       "agrarne",
     ],
   },
+  "short": "agrarėn",
   "singular": {
     "acc": [
       "agrarnogo / agrarny",
@@ -127793,6 +129548,7 @@ exports[`adjective 24128 1`] = `
       "agresivne",
     ],
   },
+  "short": "agresivėn",
   "singular": {
     "acc": [
       "agresivnogo / agresivny",
@@ -127862,6 +129618,7 @@ exports[`adjective 24132 1`] = `
       "agronomične",
     ],
   },
+  "short": "agronomičėn",
   "singular": {
     "acc": [
       "agronomičnogo / agronomičny",
@@ -127931,6 +129688,7 @@ exports[`adjective 24175 1`] = `
       "akrobatske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "akrobatskogo / akrobatsky",
@@ -128000,6 +129758,7 @@ exports[`adjective 24206 1`] = `
       "akuratne",
     ],
   },
+  "short": "akuratėn",
   "singular": {
     "acc": [
       "akuratnogo / akuratny",
@@ -128069,6 +129828,7 @@ exports[`adjective 24207 1`] = `
       "akustične",
     ],
   },
+  "short": "akustičėn",
   "singular": {
     "acc": [
       "akustičnogo / akustičny",
@@ -128138,6 +129898,7 @@ exports[`adjective 24211 1`] = `
       "akušerske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "akušerskogo / akušersky",
@@ -128207,6 +129968,7 @@ exports[`adjective 24229 1`] = `
       "alegorične",
     ],
   },
+  "short": "alegoričėn",
   "singular": {
     "acc": [
       "alegoričnogo / alegoričny",
@@ -128276,6 +130038,7 @@ exports[`adjective 24262 1`] = `
       "altruistične",
     ],
   },
+  "short": "altruističėn",
   "singular": {
     "acc": [
       "altruističnogo / altruističny",
@@ -128345,6 +130108,7 @@ exports[`adjective 24265 1`] = `
       "aluminijeve",
     ],
   },
+  "short": "aluminijev",
   "singular": {
     "acc": [
       "aluminijevogo / aluminijevy",
@@ -128414,6 +130178,7 @@ exports[`adjective 24269 1`] = `
       "alveolarne",
     ],
   },
+  "short": "alveolarėn",
   "singular": {
     "acc": [
       "alveolarnogo / alveolarny",
@@ -128483,6 +130248,7 @@ exports[`adjective 24304 1`] = `
       "amoraľne",
     ],
   },
+  "short": "amoraľėn",
   "singular": {
     "acc": [
       "amoraľnogo / amoraľny",
@@ -128552,6 +130318,7 @@ exports[`adjective 24339 1`] = `
       "avansove",
     ],
   },
+  "short": "avansov",
   "singular": {
     "acc": [
       "avansovogo / avansovy",
@@ -128621,6 +130388,7 @@ exports[`adjective 24348 1`] = `
       "avarijne",
     ],
   },
+  "short": "avarijėn",
   "singular": {
     "acc": [
       "avarijnogo / avarijny",
@@ -128690,6 +130458,7 @@ exports[`adjective 24363 1`] = `
       "avtobiografične",
     ],
   },
+  "short": "avtobiografičėn",
   "singular": {
     "acc": [
       "avtobiografičnogo / avtobiografičny",
@@ -128759,6 +130528,7 @@ exports[`adjective 24393 1`] = `
       "avtoritarne",
     ],
   },
+  "short": "avtoritarėn",
   "singular": {
     "acc": [
       "avtoritarnogo / avtoritarny",
@@ -128828,6 +130598,7 @@ exports[`adjective 24398 1`] = `
       "avtorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "avtorskogo / avtorsky",
@@ -128897,6 +130668,7 @@ exports[`adjective 24409 1`] = `
       "azotiste",
     ],
   },
+  "short": "azotist",
   "singular": {
     "acc": [
       "azotistogo / azotisty",
@@ -128966,6 +130738,7 @@ exports[`adjective 24410 1`] = `
       "azotne",
     ],
   },
+  "short": "azotėn",
   "singular": {
     "acc": [
       "azotnogo / azotny",
@@ -129035,6 +130808,7 @@ exports[`adjective 24411 1`] = `
       "azurne",
     ],
   },
+  "short": "azurėn",
   "singular": {
     "acc": [
       "azurnogo / azurny",
@@ -129104,6 +130878,7 @@ exports[`adjective 24425 1`] = `
       "babine",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "babinogo / babin",
@@ -129173,6 +130948,7 @@ exports[`adjective 24430 1`] = `
       "babske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "babskogo / babsky",
@@ -129242,6 +131018,7 @@ exports[`adjective 24474 1`] = `
       "balistične",
     ],
   },
+  "short": "balističėn",
   "singular": {
     "acc": [
       "balističnogo / balističny",
@@ -129311,6 +131088,7 @@ exports[`adjective 24576 1`] = `
       "bedrene",
     ],
   },
+  "short": "bedren",
   "singular": {
     "acc": [
       "bedrenogo / bedreny",
@@ -129380,6 +131158,7 @@ exports[`adjective 24583 1`] = `
       "bělave",
     ],
   },
+  "short": "bělav",
   "singular": {
     "acc": [
       "bělavogo / bělavy",
@@ -129449,6 +131228,7 @@ exports[`adjective 24591 1`] = `
       "bělobråde",
     ],
   },
+  "short": "bělobråd",
   "singular": {
     "acc": [
       "bělobrådogo / bělobrådy",
@@ -129518,6 +131298,7 @@ exports[`adjective 24600 1`] = `
       "bělopere",
     ],
   },
+  "short": "běloper",
   "singular": {
     "acc": [
       "běloperogo / bělopery",
@@ -129587,6 +131368,7 @@ exports[`adjective 24605 1`] = `
       "bělovlåse",
     ],
   },
+  "short": "bělovlås",
   "singular": {
     "acc": [
       "bělovlåsogo / bělovlåsy",
@@ -129656,6 +131438,7 @@ exports[`adjective 24606 1`] = `
       "bělozųbe",
     ],
   },
+  "short": "bělozųb",
   "singular": {
     "acc": [
       "bělozųbogo / bělozųby",
@@ -129725,6 +131508,7 @@ exports[`adjective 24613 1`] = `
       "běsne",
     ],
   },
+  "short": "běsėn",
   "singular": {
     "acc": [
       "běsnogo / běsny",
@@ -129794,6 +131578,7 @@ exports[`adjective 24618 1`] = `
       "bezbråde",
     ],
   },
+  "short": "bezbråd",
   "singular": {
     "acc": [
       "bezbrådogo / bezbrådy",
@@ -129863,6 +131648,7 @@ exports[`adjective 24620 1`] = `
       "bezčestne",
     ],
   },
+  "short": "bezčestėn",
   "singular": {
     "acc": [
       "bezčestnogo / bezčestny",
@@ -129932,6 +131718,7 @@ exports[`adjective 24626 1`] = `
       "bezdomne",
     ],
   },
+  "short": "bezdomėn",
   "singular": {
     "acc": [
       "bezdomnogo / bezdomny",
@@ -130001,6 +131788,7 @@ exports[`adjective 24627 1`] = `
       "bezdȯnne",
     ],
   },
+  "short": "bezdȯnėn",
   "singular": {
     "acc": [
       "bezdȯnnogo / bezdȯnny",
@@ -130070,6 +131858,7 @@ exports[`adjective 24630 1`] = `
       "bezdušne",
     ],
   },
+  "short": "bezdušėn",
   "singular": {
     "acc": [
       "bezdušnogo / bezdušny",
@@ -130139,6 +131928,7 @@ exports[`adjective 24633 1`] = `
       "bezglåve",
     ],
   },
+  "short": "bezglåv",
   "singular": {
     "acc": [
       "bezglåvogo / bezglåvy",
@@ -130208,6 +131998,7 @@ exports[`adjective 24635 1`] = `
       "bezhvoste",
     ],
   },
+  "short": "bezhvost",
   "singular": {
     "acc": [
       "bezhvostogo / bezhvosty",
@@ -130277,6 +132068,7 @@ exports[`adjective 24637 1`] = `
       "bezkostne",
     ],
   },
+  "short": "bezkostėn",
   "singular": {
     "acc": [
       "bezkostnogo / bezkostny",
@@ -130346,6 +132138,7 @@ exports[`adjective 24638 1`] = `
       "bezkrȯvne",
     ],
   },
+  "short": "bezkrȯvėn",
   "singular": {
     "acc": [
       "bezkrȯvnogo / bezkrȯvny",
@@ -130415,6 +132208,7 @@ exports[`adjective 24644 1`] = `
       "bezljudne",
     ],
   },
+  "short": "bezljudėn",
   "singular": {
     "acc": [
       "bezljudnogo / bezljudny",
@@ -130484,6 +132278,7 @@ exports[`adjective 24646 1`] = `
       "bezmozge",
     ],
   },
+  "short": "bezmozȯg",
   "singular": {
     "acc": [
       "bezmozgogo / bezmozgy",
@@ -130553,6 +132348,7 @@ exports[`adjective 24647 1`] = `
       "beznoge",
     ],
   },
+  "short": "beznog",
   "singular": {
     "acc": [
       "beznogogo / beznogy",
@@ -130622,6 +132418,7 @@ exports[`adjective 24650 1`] = `
       "bezpamętne",
     ],
   },
+  "short": "bezpamętėn",
   "singular": {
     "acc": [
       "bezpamętnogo / bezpamętny",
@@ -130691,6 +132488,7 @@ exports[`adjective 24652 1`] = `
       "bezpere",
     ],
   },
+  "short": "bezper",
   "singular": {
     "acc": [
       "bezperogo / bezpery",
@@ -130760,6 +132558,7 @@ exports[`adjective 24653 1`] = `
       "bezplodne",
     ],
   },
+  "short": "bezplodėn",
   "singular": {
     "acc": [
       "bezplodnogo / bezplodny",
@@ -130829,6 +132628,7 @@ exports[`adjective 24654 1`] = `
       "neurodne",
     ],
   },
+  "short": "neurodėn",
   "singular": {
     "acc": [
       "neurodnogo / neurodny",
@@ -130898,6 +132698,7 @@ exports[`adjective 24655 1`] = `
       "bezroge",
     ],
   },
+  "short": "bezrog",
   "singular": {
     "acc": [
       "bezrogogo / bezrogy",
@@ -130967,6 +132768,7 @@ exports[`adjective 24656 1`] = `
       "bezrųke",
     ],
   },
+  "short": "bezrųk",
   "singular": {
     "acc": [
       "bezrųkogo / bezrųky",
@@ -131036,6 +132838,7 @@ exports[`adjective 24657 1`] = `
       "bezsiľne",
     ],
   },
+  "short": "bezsiľėn",
   "singular": {
     "acc": [
       "bezsiľnogo / bezsiľny",
@@ -131105,6 +132908,7 @@ exports[`adjective 24658 1`] = `
       "bezsněžne",
     ],
   },
+  "short": "bezsněžėn",
   "singular": {
     "acc": [
       "bezsněžnogo / bezsněžny",
@@ -131174,6 +132978,7 @@ exports[`adjective 24660 1`] = `
       "bezsȯnne",
     ],
   },
+  "short": "bezsȯnėn",
   "singular": {
     "acc": [
       "bezsȯnnogo / bezsȯnny",
@@ -131243,6 +133048,7 @@ exports[`adjective 24661 1`] = `
       "bezstrašne",
     ],
   },
+  "short": "bezstrašėn",
   "singular": {
     "acc": [
       "bezstrašnogo / bezstrašny",
@@ -131312,6 +133118,7 @@ exports[`adjective 24665 1`] = `
       "bezvinne",
     ],
   },
+  "short": "bezvinėn",
   "singular": {
     "acc": [
       "bezvinnogo / bezvinny",
@@ -131381,6 +133188,7 @@ exports[`adjective 24666 1`] = `
       "bezvlåse",
     ],
   },
+  "short": "bezvlås",
   "singular": {
     "acc": [
       "bezvlåsogo / bezvlåsy",
@@ -131450,6 +133258,7 @@ exports[`adjective 24668 1`] = `
       "bezvodne",
     ],
   },
+  "short": "bezvodėn",
   "singular": {
     "acc": [
       "bezvodnogo / bezvodny",
@@ -131519,6 +133328,7 @@ exports[`adjective 24671 1`] = `
       "beževe",
     ],
   },
+  "short": "bežev",
   "singular": {
     "acc": [
       "beževogo / beževy",
@@ -131588,6 +133398,7 @@ exports[`adjective 24672 1`] = `
       "bezzųbe",
     ],
   },
+  "short": "bezzųb",
   "singular": {
     "acc": [
       "bezzųbogo / bezzųby",
@@ -131657,6 +133468,7 @@ exports[`adjective 24684 1`] = `
       "blåtne",
     ],
   },
+  "short": "blåtėn",
   "singular": {
     "acc": [
       "blåtnogo / blåtny",
@@ -131726,6 +133538,7 @@ exports[`adjective 24703 1`] = `
       "bližnje",
     ],
   },
+  "short": "bližėn",
   "singular": {
     "acc": [
       "bližnjego / bližnji",
@@ -131795,6 +133608,7 @@ exports[`adjective 24703-1 1`] = `
       "bližne",
     ],
   },
+  "short": "bližėn",
   "singular": {
     "acc": [
       "bližnogo / bližny",
@@ -131864,6 +133678,7 @@ exports[`adjective 24713 1`] = `
       "blųdne",
     ],
   },
+  "short": "blųdėn",
   "singular": {
     "acc": [
       "blųdnogo / blųdny",
@@ -131933,6 +133748,7 @@ exports[`adjective 24717 1`] = `
       "blěskave",
     ],
   },
+  "short": "blěskav",
   "singular": {
     "acc": [
       "blěskavogo / blěskavy",
@@ -132002,6 +133818,7 @@ exports[`adjective 24721 1`] = `
       "bobove",
     ],
   },
+  "short": "bobov",
   "singular": {
     "acc": [
       "bobovogo / bobovy",
@@ -132071,6 +133888,7 @@ exports[`adjective 24728 1`] = `
       "bodlive",
     ],
   },
+  "short": "bodliv",
   "singular": {
     "acc": [
       "bodlivogo / bodlivy",
@@ -132140,6 +133958,7 @@ exports[`adjective 24748 1`] = `
       "bojne",
     ],
   },
+  "short": "bojėn",
   "singular": {
     "acc": [
       "bojnogo / bojny",
@@ -132209,6 +134028,7 @@ exports[`adjective 24764 1`] = `
       "bordove",
     ],
   },
+  "short": "bordov",
   "singular": {
     "acc": [
       "bordovogo / bordovy",
@@ -132278,6 +134098,7 @@ exports[`adjective 24772 1`] = `
       "bosonoge",
     ],
   },
+  "short": "bosonog",
   "singular": {
     "acc": [
       "bosonogogo / bosonogy",
@@ -132347,6 +134168,7 @@ exports[`adjective 24783 1`] = `
       "brådate",
     ],
   },
+  "short": "brådat",
   "singular": {
     "acc": [
       "brådatogo / brådaty",
@@ -132416,6 +134238,7 @@ exports[`adjective 24801 1`] = `
       "bratove",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bratovogo / bratov",
@@ -132485,6 +134308,7 @@ exports[`adjective 24808 1`] = `
       "brěgove",
     ],
   },
+  "short": "brěgov",
   "singular": {
     "acc": [
       "brěgovogo / brěgovy",
@@ -132554,6 +134378,7 @@ exports[`adjective 24824 1`] = `
       "brěžne",
     ],
   },
+  "short": "brěžėn",
   "singular": {
     "acc": [
       "brěžnogo / brěžny",
@@ -132623,6 +134448,7 @@ exports[`adjective 24828 1`] = `
       "brjuhate",
     ],
   },
+  "short": "brjuhat",
   "singular": {
     "acc": [
       "brjuhatogo / brjuhaty",
@@ -132692,6 +134518,7 @@ exports[`adjective 24867 1`] = `
       "bujne",
     ],
   },
+  "short": "bujėn",
   "singular": {
     "acc": [
       "bujnogo / bujny",
@@ -132761,6 +134588,7 @@ exports[`adjective 24878 1`] = `
       "buŕne",
     ],
   },
+  "short": "buŕėn",
   "singular": {
     "acc": [
       "buŕnogo / buŕny",
@@ -132830,6 +134658,7 @@ exports[`adjective 24885 1`] = `
       "byčje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "byčjego / byčji",
@@ -132899,6 +134728,7 @@ exports[`adjective 24935 1`] = `
       "cvětne",
     ],
   },
+  "short": "cvětėn",
   "singular": {
     "acc": [
       "cvětnogo / cvětny",
@@ -132968,6 +134798,7 @@ exports[`adjective 24953 1`] = `
       "čarovne",
     ],
   },
+  "short": "čarovėn",
   "singular": {
     "acc": [
       "čarovnogo / čarovny",
@@ -133037,6 +134868,7 @@ exports[`adjective 24969 1`] = `
       "čeľne",
     ],
   },
+  "short": "čeľėn",
   "singular": {
     "acc": [
       "čeľnogo / čeľny",
@@ -133106,6 +134938,7 @@ exports[`adjective 24982 1`] = `
       "črstve",
     ],
   },
+  "short": "črstv",
   "singular": {
     "acc": [
       "črstvogo / črstvy",
@@ -133175,6 +135008,7 @@ exports[`adjective 24984 1`] = `
       "črtove",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "črtovogo / črtov",
@@ -133244,6 +135078,7 @@ exports[`adjective 25015 1`] = `
       "čisľne",
     ],
   },
+  "short": "čisľėn",
   "singular": {
     "acc": [
       "čisľnogo / čisľny",
@@ -133313,6 +135148,7 @@ exports[`adjective 25031 1`] = `
       "člověčne",
     ],
   },
+  "short": "člověčėn",
   "singular": {
     "acc": [
       "člověčnogo / člověčny",
@@ -133382,6 +135218,7 @@ exports[`adjective 25032 1`] = `
       "člověčske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "člověčskogo / člověčsky",
@@ -133451,6 +135288,7 @@ exports[`adjective 25066 1`] = `
       "črvive",
     ],
   },
+  "short": "črviv",
   "singular": {
     "acc": [
       "črvivogo / črvivy",
@@ -133520,6 +135358,7 @@ exports[`adjective 25071 1`] = `
       "čubate",
     ],
   },
+  "short": "čubat",
   "singular": {
     "acc": [
       "čubatogo / čubaty",
@@ -133589,6 +135428,7 @@ exports[`adjective 25079 1`] = `
       "ćuđezemne",
     ],
   },
+  "short": "ćuđezemėn",
   "singular": {
     "acc": [
       "ćuđezemnogo / ćuđezemny",
@@ -133658,6 +135498,7 @@ exports[`adjective 25083 1`] = `
       "čutne",
     ],
   },
+  "short": "čutėn",
   "singular": {
     "acc": [
       "čutnogo / čutny",
@@ -133727,6 +135568,7 @@ exports[`adjective 25102 1`] = `
       "daljnje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "daljnjego / daljnji",
@@ -133796,6 +135638,7 @@ exports[`adjective 25102-1 1`] = `
       "daljne",
     ],
   },
+  "short": "daljėn",
   "singular": {
     "acc": [
       "daljnogo / daljny",
@@ -133865,6 +135708,7 @@ exports[`adjective 25123 1`] = `
       "darmove",
     ],
   },
+  "short": "darmov",
   "singular": {
     "acc": [
       "darmovogo / darmovy",
@@ -133934,6 +135778,7 @@ exports[`adjective 25147 1`] = `
       "debele",
     ],
   },
+  "short": "debel",
   "singular": {
     "acc": [
       "debelogo / debely",
@@ -134003,6 +135848,7 @@ exports[`adjective 25161 1`] = `
       "dědove",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dědovogo / dědov",
@@ -134072,6 +135918,7 @@ exports[`adjective 25163 1`] = `
       "deduktivne",
     ],
   },
+  "short": "deduktivėn",
   "singular": {
     "acc": [
       "deduktivnogo / deduktivny",
@@ -134141,6 +135988,7 @@ exports[`adjective 25168 1`] = `
       "degenerativne",
     ],
   },
+  "short": "degenerativėn",
   "singular": {
     "acc": [
       "degenerativnogo / degenerativny",
@@ -134210,6 +136058,7 @@ exports[`adjective 25184 1`] = `
       "delfińje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "delfińjego / delfińji",
@@ -134279,6 +136128,7 @@ exports[`adjective 25194 1`] = `
       "denne",
     ],
   },
+  "short": "denėn",
   "singular": {
     "acc": [
       "dennogo / denny",
@@ -134348,6 +136198,7 @@ exports[`adjective 25203 1`] = `
       "desne",
     ],
   },
+  "short": "desėn",
   "singular": {
     "acc": [
       "desnogo / desny",
@@ -134417,6 +136268,7 @@ exports[`adjective 25246 1`] = `
       "dežurne",
     ],
   },
+  "short": "dežurėn",
   "singular": {
     "acc": [
       "dežurnogo / dežurny",
@@ -134486,6 +136338,7 @@ exports[`adjective 25248 1`] = `
       "diamantove",
     ],
   },
+  "short": "diamantov",
   "singular": {
     "acc": [
       "diamantovogo / diamantovy",
@@ -134555,6 +136408,7 @@ exports[`adjective 25265 1`] = `
       "dnevne",
     ],
   },
+  "short": "dnevėn",
   "singular": {
     "acc": [
       "dnevnogo / dnevny",
@@ -134624,6 +136478,7 @@ exports[`adjective 25319 1`] = `
       "domove",
     ],
   },
+  "short": "domov",
   "singular": {
     "acc": [
       "domovogo / domovy",
@@ -134693,6 +136548,7 @@ exports[`adjective 25344 1`] = `
       "dȯščene",
     ],
   },
+  "short": "dȯščen",
   "singular": {
     "acc": [
       "dȯščenogo / dȯščeny",
@@ -134762,6 +136618,7 @@ exports[`adjective 25348 1`] = `
       "dovoljne",
     ],
   },
+  "short": "dovoljėn",
   "singular": {
     "acc": [
       "dovoljnogo / dovoljny",
@@ -134831,6 +136688,7 @@ exports[`adjective 25352 1`] = `
       "dȯžďeve",
     ],
   },
+  "short": "dȯžďev",
   "singular": {
     "acc": [
       "dȯžďevogo / dȯžďevy",
@@ -134900,6 +136758,7 @@ exports[`adjective 25355 1`] = `
       "dȯždlive",
     ],
   },
+  "short": "dȯždliv",
   "singular": {
     "acc": [
       "dȯždlivogo / dȯždlivy",
@@ -134969,6 +136828,7 @@ exports[`adjective 25375 1`] = `
       "drobne",
     ],
   },
+  "short": "drobėn",
   "singular": {
     "acc": [
       "drobnogo / drobny",
@@ -135038,6 +136898,7 @@ exports[`adjective 25395 1`] = `
       "dŕzke",
     ],
   },
+  "short": "dŕzȯk",
   "singular": {
     "acc": [
       "dŕzkogo / dŕzky",
@@ -135107,6 +136968,7 @@ exports[`adjective 25405 1`] = `
       "dųbove",
     ],
   },
+  "short": "dųbov",
   "singular": {
     "acc": [
       "dųbovogo / dųbovy",
@@ -135176,6 +137038,7 @@ exports[`adjective 25440 1`] = `
       "dvuglåve",
     ],
   },
+  "short": "dvuglåv",
   "singular": {
     "acc": [
       "dvuglåvogo / dvuglåvy",
@@ -135245,6 +137108,7 @@ exports[`adjective 25467 1`] = `
       "dirave",
     ],
   },
+  "short": "dirav",
   "singular": {
     "acc": [
       "diravogo / diravy",
@@ -135314,6 +137178,7 @@ exports[`adjective 25530 1`] = `
       "gadne",
     ],
   },
+  "short": "gadėn",
   "singular": {
     "acc": [
       "gadnogo / gadny",
@@ -135383,6 +137248,7 @@ exports[`adjective 25539 1`] = `
       "galantne",
     ],
   },
+  "short": "galantėn",
   "singular": {
     "acc": [
       "galantnogo / galantny",
@@ -135452,6 +137318,7 @@ exports[`adjective 25630 1`] = `
       "glåvate",
     ],
   },
+  "short": "glåvat",
   "singular": {
     "acc": [
       "glåvatogo / glåvaty",
@@ -135521,6 +137388,7 @@ exports[`adjective 25677 1`] = `
       "gněvlive",
     ],
   },
+  "short": "gněvliv",
   "singular": {
     "acc": [
       "gněvlivogo / gněvlivy",
@@ -135590,6 +137458,7 @@ exports[`adjective 25695 1`] = `
       "gnusne",
     ],
   },
+  "short": "gnusėn",
   "singular": {
     "acc": [
       "gnusnogo / gnusny",
@@ -135659,6 +137528,7 @@ exports[`adjective 25710 1`] = `
       "golobråde",
     ],
   },
+  "short": "golobråd",
   "singular": {
     "acc": [
       "golobrådogo / golobrådy",
@@ -135728,6 +137598,7 @@ exports[`adjective 25718 1`] = `
       "golųbje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "golųbjego / golųbji",
@@ -135797,6 +137668,7 @@ exports[`adjective 25722 1`] = `
       "gole",
     ],
   },
+  "short": "gol",
   "singular": {
     "acc": [
       "gologo / goly",
@@ -135866,6 +137738,7 @@ exports[`adjective 25743 1`] = `
       "gorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gorskogo / gorsky",
@@ -135935,6 +137808,7 @@ exports[`adjective 25765 1`] = `
       "govęďje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "govęďjego / govęďji",
@@ -136004,6 +137878,7 @@ exports[`adjective 25766 1`] = `
       "govněne",
     ],
   },
+  "short": "govněn",
   "singular": {
     "acc": [
       "govněnogo / govněny",
@@ -136073,6 +137948,7 @@ exports[`adjective 25789 1`] = `
       "gråhove",
     ],
   },
+  "short": "gråhov",
   "singular": {
     "acc": [
       "gråhovogo / gråhovy",
@@ -136142,6 +138018,7 @@ exports[`adjective 25813 1`] = `
       "grěšne",
     ],
   },
+  "short": "grěšėn",
   "singular": {
     "acc": [
       "grěšnogo / grěšny",
@@ -136211,6 +138088,7 @@ exports[`adjective 25860 1`] = `
       "grųdne",
     ],
   },
+  "short": "grųdėn",
   "singular": {
     "acc": [
       "grųdnogo / grųdny",
@@ -136280,6 +138158,7 @@ exports[`adjective 25863 1`] = `
       "gruševe",
     ],
   },
+  "short": "grušev",
   "singular": {
     "acc": [
       "gruševogo / gruševy",
@@ -136349,6 +138228,7 @@ exports[`adjective 25883 1`] = `
       "gųśje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gųśjego / gųśji",
@@ -136418,6 +138298,7 @@ exports[`adjective 25922 1`] = `
       "harmonične",
     ],
   },
+  "short": "harmoničėn",
   "singular": {
     "acc": [
       "harmoničnogo / harmoničny",
@@ -136487,6 +138368,7 @@ exports[`adjective 25937 1`] = `
       "hierarhične",
     ],
   },
+  "short": "hierarhičėn",
   "singular": {
     "acc": [
       "hierarhičnogo / hierarhičny",
@@ -136556,6 +138438,7 @@ exports[`adjective 25941 1`] = `
       "hieroglifne",
     ],
   },
+  "short": "hieroglifėn",
   "singular": {
     "acc": [
       "hieroglifnogo / hieroglifny",
@@ -136625,6 +138508,7 @@ exports[`adjective 25975 1`] = `
       "hmeljne",
     ],
   },
+  "short": "hmeljėn",
   "singular": {
     "acc": [
       "hmeljnogo / hmeljny",
@@ -136694,6 +138578,7 @@ exports[`adjective 26012 1`] = `
       "hrebetne",
     ],
   },
+  "short": "hrebetėn",
   "singular": {
     "acc": [
       "hrebetnogo / hrebetny",
@@ -136763,6 +138648,7 @@ exports[`adjective 26015 1`] = `
       "hrěnove",
     ],
   },
+  "short": "hrěnov",
   "singular": {
     "acc": [
       "hrěnovogo / hrěnovy",
@@ -136832,6 +138718,7 @@ exports[`adjective 26021 1`] = `
       "hrome",
     ],
   },
+  "short": "hrom",
   "singular": {
     "acc": [
       "hromogo / hromy",
@@ -136901,6 +138788,7 @@ exports[`adjective 26030 1`] = `
       "htive",
     ],
   },
+  "short": "htiv",
   "singular": {
     "acc": [
       "htivogo / htivy",
@@ -136970,6 +138858,7 @@ exports[`adjective 26033 1`] = `
       "hude",
     ],
   },
+  "short": "hud",
   "singular": {
     "acc": [
       "hudogo / hudy",
@@ -137039,6 +138928,7 @@ exports[`adjective 26040 1`] = `
       "pohvaľne",
     ],
   },
+  "short": "pohvaľėn",
   "singular": {
     "acc": [
       "pohvaľnogo / pohvaľny",
@@ -137108,6 +138998,7 @@ exports[`adjective 26041 1`] = `
       "hvalebne",
     ],
   },
+  "short": "hvalebėn",
   "singular": {
     "acc": [
       "hvalebnogo / hvalebny",
@@ -137177,6 +139068,7 @@ exports[`adjective 26059 1`] = `
       "idealistične",
     ],
   },
+  "short": "idealističėn",
   "singular": {
     "acc": [
       "idealističnogo / idealističny",
@@ -137246,6 +139138,7 @@ exports[`adjective 26074 1`] = `
       "idilične",
     ],
   },
+  "short": "idiličėn",
   "singular": {
     "acc": [
       "idiličnogo / idiličny",
@@ -137315,6 +139208,7 @@ exports[`adjective 26096 1`] = `
       "igrive",
     ],
   },
+  "short": "igriv",
   "singular": {
     "acc": [
       "igrivogo / igrivy",
@@ -137384,6 +139278,7 @@ exports[`adjective 26107 1`] = `
       "ilove",
     ],
   },
+  "short": "ilov",
   "singular": {
     "acc": [
       "ilovogo / ilovy",
@@ -137453,6 +139348,7 @@ exports[`adjective 26108 1`] = `
       "iluzorne",
     ],
   },
+  "short": "iluzorėn",
   "singular": {
     "acc": [
       "iluzornogo / iluzorny",
@@ -137522,6 +139418,7 @@ exports[`adjective 26152 1`] = `
       "ivove",
     ],
   },
+  "short": "ivov",
   "singular": {
     "acc": [
       "ivovogo / ivovy",
@@ -137591,6 +139488,7 @@ exports[`adjective 26264 1`] = `
       "izvěstne",
     ],
   },
+  "short": "izvěstėn",
   "singular": {
     "acc": [
       "izvěstnogo / izvěstny",
@@ -137660,6 +139558,7 @@ exports[`adjective 26275 1`] = `
       "jablȯčne",
     ],
   },
+  "short": "jablȯčėn",
   "singular": {
     "acc": [
       "jablȯčnogo / jablȯčny",
@@ -137729,6 +139628,7 @@ exports[`adjective 26282 1`] = `
       "jadovite",
     ],
   },
+  "short": "jadovit",
   "singular": {
     "acc": [
       "jadovitogo / jadovity",
@@ -137798,6 +139698,7 @@ exports[`adjective 26284 1`] = `
       "jagnęťje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "jagnęťjego / jagnęťji",
@@ -137867,6 +139768,7 @@ exports[`adjective 26289 1`] = `
       "jagodne",
     ],
   },
+  "short": "jagodėn",
   "singular": {
     "acc": [
       "jagodnogo / jagodny",
@@ -137936,6 +139838,7 @@ exports[`adjective 26291 1`] = `
       "jaječne",
     ],
   },
+  "short": "jaječėn",
   "singular": {
     "acc": [
       "jaječnogo / jaječny",
@@ -138005,6 +139908,7 @@ exports[`adjective 26296 1`] = `
       "jalove",
     ],
   },
+  "short": "jalov",
   "singular": {
     "acc": [
       "jalovogo / jalovy",
@@ -138074,6 +139978,7 @@ exports[`adjective 26304 1`] = `
       "jarke",
     ],
   },
+  "short": "jarȯk",
   "singular": {
     "acc": [
       "jarkogo / jarky",
@@ -138143,6 +140048,7 @@ exports[`adjective 26307 1`] = `
       "jarove",
     ],
   },
+  "short": "jarov",
   "singular": {
     "acc": [
       "jarovogo / jarovy",
@@ -138212,6 +140118,7 @@ exports[`adjective 26330 1`] = `
       "javorove",
     ],
   },
+  "short": "javorov",
   "singular": {
     "acc": [
       "javorovogo / javorovy",
@@ -138281,6 +140188,7 @@ exports[`adjective 26352 1`] = `
       "jednonoge",
     ],
   },
+  "short": "jednonog",
   "singular": {
     "acc": [
       "jednonogogo / jednonogy",
@@ -138350,6 +140258,7 @@ exports[`adjective 26353 1`] = `
       "jednooke",
     ],
   },
+  "short": "jednook",
   "singular": {
     "acc": [
       "jednookogo / jednooky",
@@ -138419,6 +140328,7 @@ exports[`adjective 26355 1`] = `
       "jednorųke",
     ],
   },
+  "short": "jednorųk",
   "singular": {
     "acc": [
       "jednorųkogo / jednorųky",
@@ -138488,6 +140398,7 @@ exports[`adjective 26367 1`] = `
       "jeleńje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "jeleńjego / jeleńji",
@@ -138557,6 +140468,7 @@ exports[`adjective 26378 1`] = `
       "jesennje",
     ],
   },
+  "short": "jesenėn",
   "singular": {
     "acc": [
       "jesennjego / jesennji",
@@ -138626,6 +140538,7 @@ exports[`adjective 26378-1 1`] = `
       "jesenne",
     ],
   },
+  "short": "jesenėn",
   "singular": {
     "acc": [
       "jesennogo / jesenny",
@@ -138695,6 +140608,7 @@ exports[`adjective 26408 1`] = `
       "june",
     ],
   },
+  "short": "jun",
   "singular": {
     "acc": [
       "junogo / juny",
@@ -138764,6 +140678,7 @@ exports[`adjective 26421 1`] = `
       "kabalistične",
     ],
   },
+  "short": "kabalističėn",
   "singular": {
     "acc": [
       "kabalističnogo / kabalističny",
@@ -138833,6 +140748,7 @@ exports[`adjective 26449 1`] = `
       "kaľne",
     ],
   },
+  "short": "kaľėn",
   "singular": {
     "acc": [
       "kaľnogo / kaľny",
@@ -138902,6 +140818,7 @@ exports[`adjective 26455 1`] = `
       "kameniste",
     ],
   },
+  "short": "kamenist",
   "singular": {
     "acc": [
       "kamenistogo / kamenisty",
@@ -138971,6 +140888,7 @@ exports[`adjective 26459 1`] = `
       "kamenne",
     ],
   },
+  "short": "kamenėn",
   "singular": {
     "acc": [
       "kamennogo / kamenny",
@@ -139040,6 +140958,7 @@ exports[`adjective 26488 1`] = `
       "kavove",
     ],
   },
+  "short": "kavov",
   "singular": {
     "acc": [
       "kavovogo / kavovy",
@@ -139109,6 +141028,7 @@ exports[`adjective 26537 1`] = `
       "klenove",
     ],
   },
+  "short": "klenov",
   "singular": {
     "acc": [
       "klenovogo / klenovy",
@@ -139178,6 +141098,7 @@ exports[`adjective 26616 1`] = `
       "kȯlzke",
     ],
   },
+  "short": "kȯlzȯk",
   "singular": {
     "acc": [
       "kȯlzkogo / kȯlzky",
@@ -139247,6 +141168,7 @@ exports[`adjective 26625 1`] = `
       "kombinatorne",
     ],
   },
+  "short": "kombinatorėn",
   "singular": {
     "acc": [
       "kombinatornogo / kombinatorny",
@@ -139316,6 +141238,7 @@ exports[`adjective 26652 1`] = `
       "konne",
     ],
   },
+  "short": "konėn",
   "singular": {
     "acc": [
       "konnogo / konny",
@@ -139385,6 +141308,7 @@ exports[`adjective 26657 1`] = `
       "konopjane",
     ],
   },
+  "short": "konopjan",
   "singular": {
     "acc": [
       "konopjanogo / konopjany",
@@ -139454,6 +141378,7 @@ exports[`adjective 26658 1`] = `
       "konske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "konskogo / konsky",
@@ -139523,6 +141448,7 @@ exports[`adjective 26678 1`] = `
       "koprivne",
     ],
   },
+  "short": "koprivėn",
   "singular": {
     "acc": [
       "koprivnogo / koprivny",
@@ -139592,6 +141518,7 @@ exports[`adjective 26696 1`] = `
       "korektne",
     ],
   },
+  "short": "korektėn",
   "singular": {
     "acc": [
       "korektnogo / korektny",
@@ -139661,6 +141588,7 @@ exports[`adjective 26699 1`] = `
       "koreniste",
     ],
   },
+  "short": "korenist",
   "singular": {
     "acc": [
       "korenistogo / korenisty",
@@ -139730,6 +141658,7 @@ exports[`adjective 26739 1`] = `
       "kosmate",
     ],
   },
+  "short": "kosmat",
   "singular": {
     "acc": [
       "kosmatogo / kosmaty",
@@ -139799,6 +141728,7 @@ exports[`adjective 26743 1`] = `
       "kosooke",
     ],
   },
+  "short": "kosook",
   "singular": {
     "acc": [
       "kosookogo / kosooky",
@@ -139868,6 +141798,7 @@ exports[`adjective 26744 1`] = `
       "kostěne",
     ],
   },
+  "short": "kostěn",
   "singular": {
     "acc": [
       "kostěnogo / kostěny",
@@ -139937,6 +141868,7 @@ exports[`adjective 26748 1`] = `
       "kostlive",
     ],
   },
+  "short": "kostliv",
   "singular": {
     "acc": [
       "kostlivogo / kostlivy",
@@ -140006,6 +141938,7 @@ exports[`adjective 26749 1`] = `
       "kostne",
     ],
   },
+  "short": "kostėn",
   "singular": {
     "acc": [
       "kostnogo / kostny",
@@ -140075,6 +142008,7 @@ exports[`adjective 26780 1`] = `
       "kovne",
     ],
   },
+  "short": "kovėn",
   "singular": {
     "acc": [
       "kovnogo / kovny",
@@ -140144,6 +142078,7 @@ exports[`adjective 26787 1`] = `
       "koźje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "koźjego / koźji",
@@ -140213,6 +142148,7 @@ exports[`adjective 26812 1`] = `
       "kråljeve",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kråljevogo / kråljev",
@@ -140282,6 +142218,7 @@ exports[`adjective 26829 1`] = `
       "kråstave",
     ],
   },
+  "short": "kråstav",
   "singular": {
     "acc": [
       "kråstavogo / kråstavy",
@@ -140351,6 +142288,7 @@ exports[`adjective 26833 1`] = `
       "kråtkonoge",
     ],
   },
+  "short": "kråtkonog",
   "singular": {
     "acc": [
       "kråtkonogogo / kråtkonogy",
@@ -140420,6 +142358,7 @@ exports[`adjective 26840 1`] = `
       "kråvje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kråvjego / kråvji",
@@ -140489,6 +142428,7 @@ exports[`adjective 26853 1`] = `
       "kremeniste",
     ],
   },
+  "short": "kremenist",
   "singular": {
     "acc": [
       "kremenistogo / kremenisty",
@@ -140558,6 +142498,7 @@ exports[`adjective 26856 1`] = `
       "kremenne",
     ],
   },
+  "short": "kremenėn",
   "singular": {
     "acc": [
       "kremennogo / kremenny",
@@ -140627,6 +142568,7 @@ exports[`adjective 26858 1`] = `
       "kremove",
     ],
   },
+  "short": "kremov",
   "singular": {
     "acc": [
       "kremovogo / kremovy",
@@ -140696,6 +142638,7 @@ exports[`adjective 26869 1`] = `
       "krěhke",
     ],
   },
+  "short": "krěhȯk",
   "singular": {
     "acc": [
       "krěhkogo / krěhky",
@@ -140765,6 +142708,7 @@ exports[`adjective 26882 1`] = `
       "krivoboke",
     ],
   },
+  "short": "krivobok",
   "singular": {
     "acc": [
       "krivobokogo / krivoboky",
@@ -140834,6 +142778,7 @@ exports[`adjective 26883 1`] = `
       "krivonoge",
     ],
   },
+  "short": "krivonog",
   "singular": {
     "acc": [
       "krivonogogo / krivonogy",
@@ -140903,6 +142848,7 @@ exports[`adjective 26911 1`] = `
       "krotke",
     ],
   },
+  "short": "krotȯk",
   "singular": {
     "acc": [
       "krotkogo / krotky",
@@ -140972,6 +142918,7 @@ exports[`adjective 26925 1`] = `
       "krųgove",
     ],
   },
+  "short": "krųgov",
   "singular": {
     "acc": [
       "krųgovogo / krųgovy",
@@ -141041,6 +142988,7 @@ exports[`adjective 26931 1`] = `
       "krute",
     ],
   },
+  "short": "krut",
   "singular": {
     "acc": [
       "krutogo / kruty",
@@ -141110,6 +143058,7 @@ exports[`adjective 26943 1`] = `
       "krilate",
     ],
   },
+  "short": "krilat",
   "singular": {
     "acc": [
       "krilatogo / krilaty",
@@ -141179,6 +143128,7 @@ exports[`adjective 26958 1`] = `
       "kųdlate",
     ],
   },
+  "short": "kųdlat",
   "singular": {
     "acc": [
       "kųdlatogo / kųdlaty",
@@ -141248,6 +143198,7 @@ exports[`adjective 26960 1`] = `
       "kųdrave",
     ],
   },
+  "short": "kųdrav",
   "singular": {
     "acc": [
       "kųdravogo / kųdravy",
@@ -141317,6 +143268,7 @@ exports[`adjective 26968 1`] = `
       "kuljgave",
     ],
   },
+  "short": "kuljgav",
   "singular": {
     "acc": [
       "kuljgavogo / kuljgavy",
@@ -141386,6 +143338,7 @@ exports[`adjective 26994 1`] = `
       "kuŕje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kuŕjego / kuŕji",
@@ -141455,6 +143408,7 @@ exports[`adjective 27007 1`] = `
       "kuse",
     ],
   },
+  "short": "kus",
   "singular": {
     "acc": [
       "kusogo / kusy",
@@ -141524,6 +143478,7 @@ exports[`adjective 27011 1`] = `
       "kųtne",
     ],
   },
+  "short": "kųtėn",
   "singular": {
     "acc": [
       "kųtnogo / kųtny",
@@ -141593,6 +143548,7 @@ exports[`adjective 27028 1`] = `
       "labęďje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "labęďjego / labęďji",
@@ -141662,6 +143618,7 @@ exports[`adjective 27040 1`] = `
       "lakome",
     ],
   },
+  "short": "lakom",
   "singular": {
     "acc": [
       "lakomogo / lakomy",
@@ -141731,6 +143688,7 @@ exports[`adjective 27068 1`] = `
       "lěčebne",
     ],
   },
+  "short": "lěčebėn",
   "singular": {
     "acc": [
       "lěčebnogo / lěčebny",
@@ -141800,6 +143758,7 @@ exports[`adjective 27074 1`] = `
       "leděne",
     ],
   },
+  "short": "leděn",
   "singular": {
     "acc": [
       "leděnogo / leděny",
@@ -141869,6 +143828,7 @@ exports[`adjective 27156 1`] = `
       "lětnje",
     ],
   },
+  "short": "lětėn",
   "singular": {
     "acc": [
       "lětnjego / lětnji",
@@ -141938,6 +143898,7 @@ exports[`adjective 27156-1 1`] = `
       "lětne",
     ],
   },
+  "short": "lětėn",
   "singular": {
     "acc": [
       "lětnogo / lětny",
@@ -142007,6 +143968,7 @@ exports[`adjective 27196 1`] = `
       "lilove",
     ],
   },
+  "short": "lilov",
   "singular": {
     "acc": [
       "lilovogo / lilovy",
@@ -142076,6 +144038,7 @@ exports[`adjective 27214 1`] = `
       "liśje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "liśjego / liśji",
@@ -142145,6 +144108,7 @@ exports[`adjective 27219 1`] = `
       "listne",
     ],
   },
+  "short": "listėn",
   "singular": {
     "acc": [
       "listnogo / listny",
@@ -142214,6 +144178,7 @@ exports[`adjective 27228 1`] = `
       "izlišnje",
     ],
   },
+  "short": "izlišėn",
   "singular": {
     "acc": [
       "izlišnjego / izlišnji",
@@ -142283,6 +144248,7 @@ exports[`adjective 27228-1 1`] = `
       "izlišne",
     ],
   },
+  "short": "izlišėn",
   "singular": {
     "acc": [
       "izlišnogo / izlišny",
@@ -142352,6 +144318,7 @@ exports[`adjective 27236 1`] = `
       "livne",
     ],
   },
+  "short": "livėn",
   "singular": {
     "acc": [
       "livnogo / livny",
@@ -142421,6 +144388,7 @@ exports[`adjective 27242 1`] = `
       "ljněne",
     ],
   },
+  "short": "ljněn",
   "singular": {
     "acc": [
       "ljněnogo / ljněny",
@@ -142490,6 +144458,7 @@ exports[`adjective 27245 1`] = `
       "ljubime",
     ],
   },
+  "short": "ljubim",
   "singular": {
     "acc": [
       "ljubimogo / ljubimy",
@@ -142559,6 +144528,7 @@ exports[`adjective 27259 1`] = `
       "ljudne",
     ],
   },
+  "short": "ljudėn",
   "singular": {
     "acc": [
       "ljudnogo / ljudny",
@@ -142628,6 +144598,7 @@ exports[`adjective 27267 1`] = `
       "ljute",
     ],
   },
+  "short": "ljut",
   "singular": {
     "acc": [
       "ljutogo / ljuty",
@@ -142697,6 +144668,7 @@ exports[`adjective 27314 1`] = `
       "lovečske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lovečskogo / lovečsky",
@@ -142766,6 +144738,7 @@ exports[`adjective 27321 1`] = `
       "lovne",
     ],
   },
+  "short": "lovėn",
   "singular": {
     "acc": [
       "lovnogo / lovny",
@@ -142835,6 +144808,7 @@ exports[`adjective 27338 1`] = `
       "lude",
     ],
   },
+  "short": "lud",
   "singular": {
     "acc": [
       "ludogo / ludy",
@@ -142904,6 +144878,7 @@ exports[`adjective 27345 1`] = `
       "lukave",
     ],
   },
+  "short": "lukav",
   "singular": {
     "acc": [
       "lukavogo / lukavy",
@@ -142973,6 +144948,7 @@ exports[`adjective 27405 1`] = `
       "malinove",
     ],
   },
+  "short": "malinov",
   "singular": {
     "acc": [
       "malinovogo / malinovy",
@@ -143042,6 +145018,7 @@ exports[`adjective 27412 1`] = `
       "maloljudne",
     ],
   },
+  "short": "maloljudėn",
   "singular": {
     "acc": [
       "maloljudnogo / maloljudny",
@@ -143111,6 +145088,7 @@ exports[`adjective 27416 1`] = `
       "malovodne",
     ],
   },
+  "short": "malovodėn",
   "singular": {
     "acc": [
       "malovodnogo / malovodny",
@@ -143180,6 +145158,7 @@ exports[`adjective 27423 1`] = `
       "mamine",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "maminogo / mamin",
@@ -143249,6 +145228,7 @@ exports[`adjective 27429 1`] = `
       "mamlive",
     ],
   },
+  "short": "mamliv",
   "singular": {
     "acc": [
       "mamlivogo / mamlivy",
@@ -143318,6 +145298,7 @@ exports[`adjective 27449 1`] = `
       "materiaľne",
     ],
   },
+  "short": "materiaľėn",
   "singular": {
     "acc": [
       "materiaľnogo / materiaľny",
@@ -143387,6 +145368,7 @@ exports[`adjective 27450 1`] = `
       "materine",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "materinogo / materin",
@@ -143456,6 +145438,7 @@ exports[`adjective 27474 1`] = `
       "mědne",
     ],
   },
+  "short": "mědėn",
   "singular": {
     "acc": [
       "mědnogo / mědny",
@@ -143525,6 +145508,7 @@ exports[`adjective 27474-1 1`] = `
       "měděne",
     ],
   },
+  "short": "měděn",
   "singular": {
     "acc": [
       "měděnogo / měděny",
@@ -143594,6 +145578,7 @@ exports[`adjective 27478 1`] = `
       "medonosne",
     ],
   },
+  "short": "medonosėn",
   "singular": {
     "acc": [
       "medonosnogo / medonosny",
@@ -143663,6 +145648,7 @@ exports[`adjective 27481 1`] = `
       "medove",
     ],
   },
+  "short": "medov",
   "singular": {
     "acc": [
       "medovogo / medovy",
@@ -143732,6 +145718,7 @@ exports[`adjective 27488 1`] = `
       "medvěďje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "medvěďjego / medvěďji",
@@ -143801,6 +145788,7 @@ exports[`adjective 27490 1`] = `
       "međne",
     ],
   },
+  "short": "međėn",
   "singular": {
     "acc": [
       "međnogo / međny",
@@ -143870,6 +145858,7 @@ exports[`adjective 27527 1`] = `
       "měnlive",
     ],
   },
+  "short": "měnliv",
   "singular": {
     "acc": [
       "měnlivogo / měnlivy",
@@ -143939,6 +145928,7 @@ exports[`adjective 27539 1`] = `
       "měrne",
     ],
   },
+  "short": "měrėn",
   "singular": {
     "acc": [
       "měrnogo / měrny",
@@ -144008,6 +145998,7 @@ exports[`adjective 27552 1`] = `
       "męsiste",
     ],
   },
+  "short": "męsist",
   "singular": {
     "acc": [
       "męsistogo / męsisty",
@@ -144077,6 +146068,7 @@ exports[`adjective 27554 1`] = `
       "męsne",
     ],
   },
+  "short": "męsėn",
   "singular": {
     "acc": [
       "męsnogo / męsny",
@@ -144146,6 +146138,7 @@ exports[`adjective 27575 1`] = `
       "mętežne",
     ],
   },
+  "short": "mętežėn",
   "singular": {
     "acc": [
       "mętežnogo / mętežny",
@@ -144215,6 +146208,7 @@ exports[`adjective 27599 1`] = `
       "milostive",
     ],
   },
+  "short": "milostiv",
   "singular": {
     "acc": [
       "milostivogo / milostivy",
@@ -144284,6 +146278,7 @@ exports[`adjective 27637 1`] = `
       "mlådenske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "mlådenskogo / mlådensky",
@@ -144353,6 +146348,7 @@ exports[`adjective 27674 1`] = `
       "mnogočisľne",
     ],
   },
+  "short": "mnogočisľėn",
   "singular": {
     "acc": [
       "mnogočisľnogo / mnogočisľny",
@@ -144422,6 +146418,7 @@ exports[`adjective 27681 1`] = `
       "močarne",
     ],
   },
+  "short": "močarėn",
   "singular": {
     "acc": [
       "močarnogo / močarny",
@@ -144491,6 +146488,7 @@ exports[`adjective 27695 1`] = `
       "modrooke",
     ],
   },
+  "short": "modrook",
   "singular": {
     "acc": [
       "modrookogo / modrooky",
@@ -144560,6 +146558,7 @@ exports[`adjective 27700 1`] = `
       "mogųtne",
     ],
   },
+  "short": "mogųtėn",
   "singular": {
     "acc": [
       "mogųtnogo / mogųtny",
@@ -144629,6 +146628,7 @@ exports[`adjective 27718 1`] = `
       "mȯlčalive",
     ],
   },
+  "short": "mȯlčaliv",
   "singular": {
     "acc": [
       "mȯlčalivogo / mȯlčalivy",
@@ -144698,6 +146698,7 @@ exports[`adjective 27722 1`] = `
       "moldavske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "moldavskogo / moldavsky",
@@ -144767,6 +146768,7 @@ exports[`adjective 27754 1`] = `
       "moŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "moŕskogo / moŕsky",
@@ -144836,6 +146838,7 @@ exports[`adjective 27795 1`] = `
       "mråvje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "mråvjego / mråvji",
@@ -144905,6 +146908,7 @@ exports[`adjective 27800 1`] = `
       "mråzne",
     ],
   },
+  "short": "mråzėn",
   "singular": {
     "acc": [
       "mråznogo / mråzny",
@@ -144974,6 +146978,7 @@ exports[`adjective 27828 1`] = `
       "mųčiteljne",
     ],
   },
+  "short": "mųčiteljėn",
   "singular": {
     "acc": [
       "mųčiteljnogo / mųčiteljny",
@@ -145043,6 +147048,7 @@ exports[`adjective 27871 1`] = `
       "mųževe",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "mųževogo / mųžev",
@@ -145112,6 +147118,7 @@ exports[`adjective 27886 1`] = `
       "mysljenne",
     ],
   },
+  "short": "mysljenėn",
   "singular": {
     "acc": [
       "mysljennogo / mysljenny",
@@ -145181,6 +147188,7 @@ exports[`adjective 27898 1`] = `
       "myšaste",
     ],
   },
+  "short": "myšast",
   "singular": {
     "acc": [
       "myšastogo / myšasty",
@@ -145250,6 +147258,7 @@ exports[`adjective 27952 1`] = `
       "nadežne",
     ],
   },
+  "short": "nadežėn",
   "singular": {
     "acc": [
       "nadežnogo / nadežny",
@@ -145319,6 +147328,7 @@ exports[`adjective 27981 1`] = `
       "nagorne",
     ],
   },
+  "short": "nagorėn",
   "singular": {
     "acc": [
       "nagornogo / nagorny",
@@ -145388,6 +147398,7 @@ exports[`adjective 28012 1`] = `
       "najemne",
     ],
   },
+  "short": "najemėn",
   "singular": {
     "acc": [
       "najemnogo / najemny",
@@ -145457,6 +147468,7 @@ exports[`adjective 28040 1`] = `
       "naklonjene",
     ],
   },
+  "short": "naklonjen",
   "singular": {
     "acc": [
       "naklonjenogo / naklonjeny",
@@ -145526,6 +147538,7 @@ exports[`adjective 28123 1`] = `
       "napråzdne",
     ],
   },
+  "short": "napråzdėn",
   "singular": {
     "acc": [
       "napråzdnogo / napråzdny",
@@ -145595,6 +147608,7 @@ exports[`adjective 28157 1`] = `
       "narožne",
     ],
   },
+  "short": "narožėn",
   "singular": {
     "acc": [
       "narožnogo / narožny",
@@ -145664,6 +147678,7 @@ exports[`adjective 28219 1`] = `
       "nastěnne",
     ],
   },
+  "short": "nastěnėn",
   "singular": {
     "acc": [
       "nastěnnogo / nastěnny",
@@ -145733,6 +147748,7 @@ exports[`adjective 28225 1`] = `
       "nastojčive",
     ],
   },
+  "short": "nastojčiv",
   "singular": {
     "acc": [
       "nastojčivogo / nastojčivy",
@@ -145802,6 +147818,7 @@ exports[`adjective 28357 1`] = `
       "nazemne",
     ],
   },
+  "short": "nazemėn",
   "singular": {
     "acc": [
       "nazemnogo / nazemny",
@@ -145871,6 +147888,7 @@ exports[`adjective 28376 1`] = `
       "nečestive",
     ],
   },
+  "short": "nečestiv",
   "singular": {
     "acc": [
       "nečestivogo / nečestivy",
@@ -145940,6 +147958,7 @@ exports[`adjective 28378 1`] = `
       "nečestne",
     ],
   },
+  "short": "nečestėn",
   "singular": {
     "acc": [
       "nečestnogo / nečestny",
@@ -146009,6 +148028,7 @@ exports[`adjective 28389 1`] = `
       "nedobre",
     ],
   },
+  "short": "nedobr",
   "singular": {
     "acc": [
       "nedobrogo / nedobry",
@@ -146078,6 +148098,7 @@ exports[`adjective 28398 1`] = `
       "negodne",
     ],
   },
+  "short": "negodėn",
   "singular": {
     "acc": [
       "negodnogo / negodny",
@@ -146147,6 +148168,7 @@ exports[`adjective 28414 1`] = `
       "neljudske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "neljudskogo / neljudsky",
@@ -146216,6 +148238,7 @@ exports[`adjective 28417 1`] = `
       "nemale",
     ],
   },
+  "short": "nemal",
   "singular": {
     "acc": [
       "nemalogo / nemaly",
@@ -146285,6 +148308,7 @@ exports[`adjective 28423 1`] = `
       "nemilostive",
     ],
   },
+  "short": "nemilostiv",
   "singular": {
     "acc": [
       "nemilostivogo / nemilostivy",
@@ -146354,6 +148378,7 @@ exports[`adjective 28425 1`] = `
       "nemile",
     ],
   },
+  "short": "nemil",
   "singular": {
     "acc": [
       "nemilogo / nemily",
@@ -146423,6 +148448,7 @@ exports[`adjective 28427 1`] = `
       "nemirne",
     ],
   },
+  "short": "nemirėn",
   "singular": {
     "acc": [
       "nemirnogo / nemirny",
@@ -146492,6 +148518,7 @@ exports[`adjective 28431 1`] = `
       "nemnoge",
     ],
   },
+  "short": "nemnog",
   "singular": {
     "acc": [
       "nemnogogo / nemnogy",
@@ -146561,6 +148588,7 @@ exports[`adjective 28438 1`] = `
       "nemųdre",
     ],
   },
+  "short": "nemųdr",
   "singular": {
     "acc": [
       "nemųdrogo / nemųdry",
@@ -146630,6 +148658,7 @@ exports[`adjective 28441 1`] = `
       "nenasytne",
     ],
   },
+  "short": "nenasytėn",
   "singular": {
     "acc": [
       "nenasytnogo / nenasytny",
@@ -146699,6 +148728,7 @@ exports[`adjective 28446 1`] = `
       "nenavistne",
     ],
   },
+  "short": "nenavistėn",
   "singular": {
     "acc": [
       "nenavistnogo / nenavistny",
@@ -146768,6 +148798,7 @@ exports[`adjective 28447 1`] = `
       "neobjętne",
     ],
   },
+  "short": "neobjętėn",
   "singular": {
     "acc": [
       "neobjętnogo / neobjętny",
@@ -146837,6 +148868,7 @@ exports[`adjective 28450 1`] = `
       "neodstųpne",
     ],
   },
+  "short": "neodstųpėn",
   "singular": {
     "acc": [
       "neodstųpnogo / neodstųpny",
@@ -146906,6 +148938,7 @@ exports[`adjective 28455 1`] = `
       "neparne",
     ],
   },
+  "short": "neparėn",
   "singular": {
     "acc": [
       "neparnogo / neparny",
@@ -146975,6 +149008,7 @@ exports[`adjective 28457 1`] = `
       "neplodne",
     ],
   },
+  "short": "neplodėn",
   "singular": {
     "acc": [
       "neplodnogo / neplodny",
@@ -147044,6 +149078,7 @@ exports[`adjective 28459 1`] = `
       "nepodobne",
     ],
   },
+  "short": "nepodobėn",
   "singular": {
     "acc": [
       "nepodobnogo / nepodobny",
@@ -147113,6 +149148,7 @@ exports[`adjective 28464 1`] = `
       "nepokorne",
     ],
   },
+  "short": "nepokorėn",
   "singular": {
     "acc": [
       "nepokornogo / nepokorny",
@@ -147182,6 +149218,7 @@ exports[`adjective 28465 1`] = `
       "nepȯlne",
     ],
   },
+  "short": "nepȯln",
   "singular": {
     "acc": [
       "nepȯlnogo / nepȯlny",
@@ -147251,6 +149288,7 @@ exports[`adjective 28466 1`] = `
       "neporędne",
     ],
   },
+  "short": "neporędėn",
   "singular": {
     "acc": [
       "neporędnogo / neporędny",
@@ -147320,6 +149358,7 @@ exports[`adjective 28468 1`] = `
       "neporočne",
     ],
   },
+  "short": "neporočėn",
   "singular": {
     "acc": [
       "neporočnogo / neporočny",
@@ -147389,6 +149428,7 @@ exports[`adjective 28471 1`] = `
       "nepostojanne",
     ],
   },
+  "short": "nepostojanėn",
   "singular": {
     "acc": [
       "nepostojannogo / nepostojanny",
@@ -147458,6 +149498,7 @@ exports[`adjective 28476 1`] = `
       "nepravdive",
     ],
   },
+  "short": "nepravdiv",
   "singular": {
     "acc": [
       "nepravdivogo / nepravdivy",
@@ -147527,6 +149568,7 @@ exports[`adjective 28480 1`] = `
       "neprave",
     ],
   },
+  "short": "neprav",
   "singular": {
     "acc": [
       "nepravogo / nepravy",
@@ -147596,6 +149638,7 @@ exports[`adjective 28482 1`] = `
       "neprěstanne",
     ],
   },
+  "short": "neprěstanėn",
   "singular": {
     "acc": [
       "neprěstannogo / neprěstanny",
@@ -147665,6 +149708,7 @@ exports[`adjective 28484 1`] = `
       "neprigodne",
     ],
   },
+  "short": "neprigodėn",
   "singular": {
     "acc": [
       "neprigodnogo / neprigodny",
@@ -147734,6 +149778,7 @@ exports[`adjective 28487 1`] = `
       "neprijateljske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "neprijateljskogo / neprijateljsky",
@@ -147803,6 +149848,7 @@ exports[`adjective 28490 1`] = `
       "neprijatne",
     ],
   },
+  "short": "neprijatėn",
   "singular": {
     "acc": [
       "neprijatnogo / neprijatny",
@@ -147872,6 +149918,7 @@ exports[`adjective 28493 1`] = `
       "neprijemne",
     ],
   },
+  "short": "neprijemėn",
   "singular": {
     "acc": [
       "neprijemnogo / neprijemny",
@@ -147941,6 +149988,7 @@ exports[`adjective 28494 1`] = `
       "neprimětne",
     ],
   },
+  "short": "neprimětėn",
   "singular": {
     "acc": [
       "neprimětnogo / neprimětny",
@@ -148010,6 +150058,7 @@ exports[`adjective 28496 1`] = `
       "nepristojne",
     ],
   },
+  "short": "nepristojėn",
   "singular": {
     "acc": [
       "nepristojnogo / nepristojny",
@@ -148079,6 +150128,7 @@ exports[`adjective 28498 1`] = `
       "nepristųpne",
     ],
   },
+  "short": "nepristųpėn",
   "singular": {
     "acc": [
       "nepristųpnogo / nepristųpny",
@@ -148148,6 +150198,7 @@ exports[`adjective 28499 1`] = `
       "nepritomne",
     ],
   },
+  "short": "nepritomėn",
   "singular": {
     "acc": [
       "nepritomnogo / nepritomny",
@@ -148217,6 +150268,7 @@ exports[`adjective 28501 1`] = `
       "neprohodne",
     ],
   },
+  "short": "neprohodėn",
   "singular": {
     "acc": [
       "neprohodnogo / neprohodny",
@@ -148286,6 +150338,7 @@ exports[`adjective 28502 1`] = `
       "neråbotne",
     ],
   },
+  "short": "neråbotėn",
   "singular": {
     "acc": [
       "neråbotnogo / neråbotny",
@@ -148355,6 +150408,7 @@ exports[`adjective 28504 1`] = `
       "bezradostne",
     ],
   },
+  "short": "bezradostėn",
   "singular": {
     "acc": [
       "bezradostnogo / bezradostny",
@@ -148424,6 +150478,7 @@ exports[`adjective 28505 1`] = `
       "neråzlųčne",
     ],
   },
+  "short": "neråzlųčėn",
   "singular": {
     "acc": [
       "neråzlųčnogo / neråzlųčny",
@@ -148493,6 +150548,7 @@ exports[`adjective 28507 1`] = `
       "neråzumne",
     ],
   },
+  "short": "neråzumėn",
   "singular": {
     "acc": [
       "neråzumnogo / neråzumny",
@@ -148562,6 +150618,7 @@ exports[`adjective 28516 1`] = `
       "neskromne",
     ],
   },
+  "short": "neskromėn",
   "singular": {
     "acc": [
       "neskromnogo / neskromny",
@@ -148631,6 +150688,7 @@ exports[`adjective 28517 1`] = `
       "neslavne",
     ],
   },
+  "short": "neslavėn",
   "singular": {
     "acc": [
       "neslavnogo / neslavny",
@@ -148700,6 +150758,7 @@ exports[`adjective 28518 1`] = `
       "neslyhane",
     ],
   },
+  "short": "neslyhan",
   "singular": {
     "acc": [
       "neslyhanogo / neslyhany",
@@ -148769,6 +150828,7 @@ exports[`adjective 28532 1`] = `
       "netrězve",
     ],
   },
+  "short": "netrězv",
   "singular": {
     "acc": [
       "netrězvogo / netrězvy",
@@ -148838,6 +150898,7 @@ exports[`adjective 28533 1`] = `
       "netŕpělive",
     ],
   },
+  "short": "netŕpěliv",
   "singular": {
     "acc": [
       "netŕpělivogo / netŕpělivy",
@@ -148907,6 +150968,7 @@ exports[`adjective 28535 1`] = `
       "neučene",
     ],
   },
+  "short": "neučen",
   "singular": {
     "acc": [
       "neučenogo / neučeny",
@@ -148976,6 +151038,7 @@ exports[`adjective 28536 1`] = `
       "neučtive",
     ],
   },
+  "short": "neučtiv",
   "singular": {
     "acc": [
       "neučtivogo / neučtivy",
@@ -149045,6 +151108,7 @@ exports[`adjective 28538 1`] = `
       "neugasime",
     ],
   },
+  "short": "neugasim",
   "singular": {
     "acc": [
       "neugasimogo / neugasimy",
@@ -149114,6 +151178,7 @@ exports[`adjective 28541 1`] = `
       "neuměrne",
     ],
   },
+  "short": "neuměrėn",
   "singular": {
     "acc": [
       "neuměrnogo / neuměrny",
@@ -149183,6 +151248,7 @@ exports[`adjective 28542 1`] = `
       "neumne",
     ],
   },
+  "short": "neumėn",
   "singular": {
     "acc": [
       "neumnogo / neumny",
@@ -149252,6 +151318,7 @@ exports[`adjective 28543 1`] = `
       "neumysľne",
     ],
   },
+  "short": "neumysľėn",
   "singular": {
     "acc": [
       "neumysľnogo / neumysľny",
@@ -149321,6 +151388,7 @@ exports[`adjective 28546 1`] = `
       "neuspěšne",
     ],
   },
+  "short": "neuspěšėn",
   "singular": {
     "acc": [
       "neuspěšnogo / neuspěšny",
@@ -149390,6 +151458,7 @@ exports[`adjective 28548 1`] = `
       "neutěšime",
     ],
   },
+  "short": "neutěšim",
   "singular": {
     "acc": [
       "neutěšimogo / neutěšimy",
@@ -149459,6 +151528,7 @@ exports[`adjective 28551 1`] = `
       "nevelike",
     ],
   },
+  "short": "nevelik",
   "singular": {
     "acc": [
       "nevelikogo / neveliky",
@@ -149528,6 +151598,7 @@ exports[`adjective 28556 1`] = `
       "nevěrne",
     ],
   },
+  "short": "nevěrėn",
   "singular": {
     "acc": [
       "nevěrnogo / nevěrny",
@@ -149597,6 +151668,7 @@ exports[`adjective 28568 1`] = `
       "nevinovate",
     ],
   },
+  "short": "nevinovat",
   "singular": {
     "acc": [
       "nevinovatogo / nevinovaty",
@@ -149666,6 +151738,7 @@ exports[`adjective 28577 1`] = `
       "nevoljne",
     ],
   },
+  "short": "nevoljėn",
   "singular": {
     "acc": [
       "nevoljnogo / nevoljny",
@@ -149735,6 +151808,7 @@ exports[`adjective 28582 1`] = `
       "nezdråve",
     ],
   },
+  "short": "nezdråv",
   "singular": {
     "acc": [
       "nezdråvogo / nezdråvy",
@@ -149804,6 +151878,7 @@ exports[`adjective 28587 1`] = `
       "nezle",
     ],
   },
+  "short": "nezȯl",
   "singular": {
     "acc": [
       "nezlogo / nezly",
@@ -149873,6 +151948,7 @@ exports[`adjective 28590 1`] = `
       "neznane",
     ],
   },
+  "short": "neznan",
   "singular": {
     "acc": [
       "neznanogo / neznany",
@@ -149942,6 +152018,7 @@ exports[`adjective 28619 1`] = `
       "nizinne",
     ],
   },
+  "short": "nizinėn",
   "singular": {
     "acc": [
       "nizinnogo / nizinny",
@@ -150011,6 +152088,7 @@ exports[`adjective 28651 1`] = `
       "noroviste",
     ],
   },
+  "short": "norovist",
   "singular": {
     "acc": [
       "norovistogo / norovisty",
@@ -150080,6 +152158,7 @@ exports[`adjective 28660 1`] = `
       "nosne",
     ],
   },
+  "short": "nosėn",
   "singular": {
     "acc": [
       "nosnogo / nosny",
@@ -150149,6 +152228,7 @@ exports[`adjective 28663 1`] = `
       "nosove",
     ],
   },
+  "short": "nosov",
   "singular": {
     "acc": [
       "nosovogo / nosovy",
@@ -150218,6 +152298,7 @@ exports[`adjective 28707 1`] = `
       "nužne",
     ],
   },
+  "short": "nužėn",
   "singular": {
     "acc": [
       "nužnogo / nužny",
@@ -150287,6 +152368,7 @@ exports[`adjective 28729 1`] = `
       "obědne",
     ],
   },
+  "short": "obědėn",
   "singular": {
     "acc": [
       "obědnogo / obědny",
@@ -150356,6 +152438,7 @@ exports[`adjective 28783 1`] = `
       "oblåčne",
     ],
   },
+  "short": "oblåčėn",
   "singular": {
     "acc": [
       "oblåčnogo / oblåčny",
@@ -150425,6 +152508,7 @@ exports[`adjective 28946 1`] = `
       "obširne",
     ],
   },
+  "short": "obširėn",
   "singular": {
     "acc": [
       "obširnogo / obširny",
@@ -150494,6 +152578,7 @@ exports[`adjective 29033 1`] = `
       "očne",
     ],
   },
+  "short": "očėn",
   "singular": {
     "acc": [
       "očnogo / očny",
@@ -150563,6 +152648,7 @@ exports[`adjective 29057 1`] = `
       "odčajane",
     ],
   },
+  "short": "odčajan",
   "singular": {
     "acc": [
       "odčajanogo / odčajany",
@@ -150632,6 +152718,7 @@ exports[`adjective 29308 1`] = `
       "ognjene",
     ],
   },
+  "short": "ognjen",
   "singular": {
     "acc": [
       "ognjenogo / ognjeny",
@@ -150701,6 +152788,7 @@ exports[`adjective 29353 1`] = `
       "ohrånne",
     ],
   },
+  "short": "ohrånėn",
   "singular": {
     "acc": [
       "ohrånnogo / ohrånny",
@@ -150770,6 +152858,7 @@ exports[`adjective 29373 1`] = `
       "okolične",
     ],
   },
+  "short": "okoličėn",
   "singular": {
     "acc": [
       "okoličnogo / okoličny",
@@ -150839,6 +152928,7 @@ exports[`adjective 29380 1`] = `
       "okȯnne",
     ],
   },
+  "short": "okȯnėn",
   "singular": {
     "acc": [
       "okȯnnogo / okȯnny",
@@ -150908,6 +152998,7 @@ exports[`adjective 29386 1`] = `
       "okovane",
     ],
   },
+  "short": "okovan",
   "singular": {
     "acc": [
       "okovanogo / okovany",
@@ -150977,6 +153068,7 @@ exports[`adjective 29392 1`] = `
       "okrajne",
     ],
   },
+  "short": "okrajėn",
   "singular": {
     "acc": [
       "okrajnogo / okrajny",
@@ -151046,6 +153138,7 @@ exports[`adjective 29411 1`] = `
       "okrųgle",
     ],
   },
+  "short": "okrųgl",
   "singular": {
     "acc": [
       "okrųglogo / okrųgly",
@@ -151115,6 +153208,7 @@ exports[`adjective 29432 1`] = `
       "olověne",
     ],
   },
+  "short": "olověn",
   "singular": {
     "acc": [
       "olověnogo / olověny",
@@ -151184,6 +153278,7 @@ exports[`adjective 29531 1`] = `
       "oporne",
     ],
   },
+  "short": "oporėn",
   "singular": {
     "acc": [
       "opornogo / oporny",
@@ -151253,6 +153348,7 @@ exports[`adjective 29567 1`] = `
       "orěhove",
     ],
   },
+  "short": "orěhov",
   "singular": {
     "acc": [
       "orěhovogo / orěhovy",
@@ -151322,6 +153418,7 @@ exports[`adjective 29572 1`] = `
       "orľje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "orľjego / orľji",
@@ -151391,6 +153488,7 @@ exports[`adjective 29576 1`] = `
       "orne",
     ],
   },
+  "short": "orėn",
   "singular": {
     "acc": [
       "ornogo / orny",
@@ -151460,6 +153558,7 @@ exports[`adjective 29582 1`] = `
       "orųžne",
     ],
   },
+  "short": "orųžėn",
   "singular": {
     "acc": [
       "orųžnogo / orųžny",
@@ -151529,6 +153628,7 @@ exports[`adjective 29594 1`] = `
       "osědle",
     ],
   },
+  "short": "osědl",
   "singular": {
     "acc": [
       "osědlogo / osědly",
@@ -151598,6 +153698,7 @@ exports[`adjective 29666 1`] = `
       "ośeve",
     ],
   },
+  "short": "ośev",
   "singular": {
     "acc": [
       "ośevogo / ośevy",
@@ -151667,6 +153768,7 @@ exports[`adjective 29754 1`] = `
       "otravne",
     ],
   },
+  "short": "otravėn",
   "singular": {
     "acc": [
       "otravnogo / otravny",
@@ -151736,6 +153838,7 @@ exports[`adjective 29796 1`] = `
       "ozime",
     ],
   },
+  "short": "ozim",
   "singular": {
     "acc": [
       "ozimogo / ozimy",
@@ -151805,6 +153908,7 @@ exports[`adjective 29828 1`] = `
       "vpale",
     ],
   },
+  "short": "vpal",
   "singular": {
     "acc": [
       "vpalogo / vpaly",
@@ -151874,6 +153978,7 @@ exports[`adjective 29856 1`] = `
       "parazitne",
     ],
   },
+  "short": "parazitėn",
   "singular": {
     "acc": [
       "parazitnogo / parazitny",
@@ -151943,6 +154048,7 @@ exports[`adjective 29861 1`] = `
       "parne",
     ],
   },
+  "short": "parėn",
   "singular": {
     "acc": [
       "parnogo / parny",
@@ -152012,6 +154118,7 @@ exports[`adjective 29869 1`] = `
       "pčeline",
     ],
   },
+  "short": "pčelin",
   "singular": {
     "acc": [
       "pčelinogo / pčeliny",
@@ -152081,6 +154188,7 @@ exports[`adjective 29871 1`] = `
       "pčeľje",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pčeľjego / pčeľji",
@@ -152150,6 +154258,7 @@ exports[`adjective 29873 1`] = `
       "pekľne",
     ],
   },
+  "short": "pekľėn",
   "singular": {
     "acc": [
       "pekľnogo / pekľny",
@@ -152219,6 +154328,7 @@ exports[`adjective 29883 1`] = `
       "personaľne",
     ],
   },
+  "short": "personaľėn",
   "singular": {
     "acc": [
       "personaľnogo / personaľny",
@@ -152288,6 +154398,7 @@ exports[`adjective 29886 1`] = `
       "pěsȯčne",
     ],
   },
+  "short": "pěsȯčėn",
   "singular": {
     "acc": [
       "pěsȯčnogo / pěsȯčny",
@@ -152357,6 +154468,7 @@ exports[`adjective 29961 1`] = `
       "povinne",
     ],
   },
+  "short": "povinėn",
   "singular": {
     "acc": [
       "povinnogo / povinny",
@@ -152426,6 +154538,7 @@ exports[`adjective 29984 1`] = `
       "prědpotopne",
     ],
   },
+  "short": "prědpotopėn",
   "singular": {
     "acc": [
       "prědpotopnogo / prědpotopny",
@@ -152495,6 +154608,7 @@ exports[`adjective 30012 1`] = `
       "principiaľne",
     ],
   },
+  "short": "principiaľėn",
   "singular": {
     "acc": [
       "principiaľnogo / principiaľny",
@@ -152564,6 +154678,7 @@ exports[`adjective 30030 1`] = `
       "prošćaľne",
     ],
   },
+  "short": "prošćaľėn",
   "singular": {
     "acc": [
       "prošćaľnogo / prošćaľny",
@@ -152633,6 +154748,7 @@ exports[`adjective 30042 1`] = `
       "purpurne",
     ],
   },
+  "short": "purpurėn",
   "singular": {
     "acc": [
       "purpurnogo / purpurny",
@@ -152702,6 +154818,7 @@ exports[`adjective 30051 1`] = `
       "råbske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "råbskogo / råbsky",
@@ -152771,6 +154888,7 @@ exports[`adjective 30056 1`] = `
       "rade",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "radogo / rad",
@@ -152840,6 +154958,7 @@ exports[`adjective 30064 1`] = `
       "rajske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "rajskogo / rajsky",
@@ -152909,6 +155028,7 @@ exports[`adjective 30077 1`] = `
       "ramenne",
     ],
   },
+  "short": "ramenėn",
   "singular": {
     "acc": [
       "ramennogo / ramenny",
@@ -152978,6 +155098,7 @@ exports[`adjective 30079 1`] = `
       "rannje",
     ],
   },
+  "short": "ranėn",
   "singular": {
     "acc": [
       "rannjego / rannji",
@@ -153047,6 +155168,7 @@ exports[`adjective 30079-1 1`] = `
       "rane",
     ],
   },
+  "short": "ran",
   "singular": {
     "acc": [
       "ranogo / rany",
@@ -153116,6 +155238,7 @@ exports[`adjective 30186 1`] = `
       "råzgovorne",
     ],
   },
+  "short": "råzgovorėn",
   "singular": {
     "acc": [
       "råzgovornogo / råzgovorny",
@@ -153185,6 +155308,7 @@ exports[`adjective 30210 1`] = `
       "råzhodne",
     ],
   },
+  "short": "råzhodėn",
   "singular": {
     "acc": [
       "råzhodnogo / råzhodny",
@@ -153254,6 +155378,7 @@ exports[`adjective 30242 1`] = `
       "råzkošne",
     ],
   },
+  "short": "råzkošėn",
   "singular": {
     "acc": [
       "råzkošnogo / råzkošny",
@@ -153323,6 +155448,7 @@ exports[`adjective 30586 1`] = `
       "råzvodne",
     ],
   },
+  "short": "råzvodėn",
   "singular": {
     "acc": [
       "råzvodnogo / råzvodny",
@@ -153392,6 +155518,7 @@ exports[`adjective 30623 1`] = `
       "råbotne",
     ],
   },
+  "short": "råbotėn",
   "singular": {
     "acc": [
       "råbotnogo / råbotny",
@@ -153461,6 +155588,7 @@ exports[`adjective 30650 1`] = `
       "ryđe",
     ],
   },
+  "short": "ryđ",
   "singular": {
     "acc": [
       "ryđego / ryđi",
@@ -153530,6 +155658,7 @@ exports[`adjective 30682 1`] = `
       "sěteve",
     ],
   },
+  "short": "sětev",
   "singular": {
     "acc": [
       "sětevogo / sětevy",
@@ -153599,6 +155728,7 @@ exports[`adjective 30685 1`] = `
       "silabične",
     ],
   },
+  "short": "silabičėn",
   "singular": {
     "acc": [
       "silabičnogo / silabičny",
@@ -153668,6 +155798,7 @@ exports[`adjective 30688 1`] = `
       "simpatične",
     ],
   },
+  "short": "simpatičėn",
   "singular": {
     "acc": [
       "simpatičnogo / simpatičny",
@@ -153737,6 +155868,7 @@ exports[`adjective 30724 1`] = `
       "služebne",
     ],
   },
+  "short": "služebėn",
   "singular": {
     "acc": [
       "služebnogo / služebny",
@@ -153806,6 +155938,7 @@ exports[`adjective 30771 1`] = `
       "srěbriste",
     ],
   },
+  "short": "srěbrist",
   "singular": {
     "acc": [
       "srěbristogo / srěbristy",
@@ -153875,6 +156008,7 @@ exports[`adjective 30811 1`] = `
       "studene",
     ],
   },
+  "short": "studen",
   "singular": {
     "acc": [
       "studenogo / studeny",
@@ -153944,6 +156078,7 @@ exports[`adjective 30814 1`] = `
       "sųdne",
     ],
   },
+  "short": "sųdėn",
   "singular": {
     "acc": [
       "sųdnogo / sųdny",
@@ -154013,6 +156148,7 @@ exports[`adjective 30822 1`] = `
       "svętȯčne",
     ],
   },
+  "short": "svętȯčėn",
   "singular": {
     "acc": [
       "svętȯčnogo / svętȯčny",
@@ -154082,6 +156218,7 @@ exports[`adjective 30825 1`] = `
       "světle",
     ],
   },
+  "short": "světl",
   "singular": {
     "acc": [
       "světlogo / světly",
@@ -154151,6 +156288,7 @@ exports[`adjective 30864 1`] = `
       "tajemne",
     ],
   },
+  "short": "tajemėn",
   "singular": {
     "acc": [
       "tajemnogo / tajemny",
@@ -154220,6 +156358,7 @@ exports[`adjective 30890 1`] = `
       "turkysove",
     ],
   },
+  "short": "turkysov",
   "singular": {
     "acc": [
       "turkysovogo / turkysovy",
@@ -154289,6 +156428,7 @@ exports[`adjective 30898 1`] = `
       "tȯnke",
     ],
   },
+  "short": "tȯnȯk",
   "singular": {
     "acc": [
       "tȯnkogo / tȯnky",
@@ -154358,6 +156498,7 @@ exports[`adjective 30913 1`] = `
       "trvale",
     ],
   },
+  "short": "trval",
   "singular": {
     "acc": [
       "trvalogo / trvaly",
@@ -154427,6 +156568,7 @@ exports[`adjective 30961 1`] = `
       "uvularne",
     ],
   },
+  "short": "uvularėn",
   "singular": {
     "acc": [
       "uvularnogo / uvularny",
@@ -154496,6 +156638,7 @@ exports[`adjective 30980 1`] = `
       "vakantne",
     ],
   },
+  "short": "vakantėn",
   "singular": {
     "acc": [
       "vakantnogo / vakantny",
@@ -154565,6 +156708,7 @@ exports[`adjective 31027 1`] = `
       "varvarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "varvarskogo / varvarsky",
@@ -154634,6 +156778,7 @@ exports[`adjective 31039 1`] = `
       "vavilonske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vavilonskogo / vavilonsky",
@@ -154703,6 +156848,7 @@ exports[`adjective 31065 1`] = `
       "vegetarianske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vegetarianskogo / vegetariansky",
@@ -154772,6 +156918,7 @@ exports[`adjective 31066 1`] = `
       "vegetativne",
     ],
   },
+  "short": "vegetativėn",
   "singular": {
     "acc": [
       "vegetativnogo / vegetativny",
@@ -154841,6 +156988,7 @@ exports[`adjective 31091 1`] = `
       "velikosvetske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "velikosvetskogo / velikosvetsky",
@@ -154910,6 +157058,7 @@ exports[`adjective 31092 1`] = `
       "velarne",
     ],
   },
+  "short": "velarėn",
   "singular": {
     "acc": [
       "velarnogo / velarny",
@@ -154979,6 +157128,7 @@ exports[`adjective 31102 1`] = `
       "vędle",
     ],
   },
+  "short": "vędl",
   "singular": {
     "acc": [
       "vędlogo / vędly",
@@ -155048,6 +157198,7 @@ exports[`adjective 31107 1`] = `
       "venerične",
     ],
   },
+  "short": "veneričėn",
   "singular": {
     "acc": [
       "veneričnogo / veneričny",
@@ -155117,6 +157268,7 @@ exports[`adjective 31116 1`] = `
       "venozne",
     ],
   },
+  "short": "venozėn",
   "singular": {
     "acc": [
       "venoznogo / venozny",
@@ -155186,6 +157338,7 @@ exports[`adjective 31126 1`] = `
       "verbaľne",
     ],
   },
+  "short": "verbaľėn",
   "singular": {
     "acc": [
       "verbaľnogo / verbaľny",
@@ -155255,6 +157408,7 @@ exports[`adjective 31165 1`] = `
       "vethe",
     ],
   },
+  "short": "veth",
   "singular": {
     "acc": [
       "vethogo / vethy",
@@ -155324,6 +157478,7 @@ exports[`adjective 31225 1`] = `
       "višnjeve",
     ],
   },
+  "short": "višnjev",
   "singular": {
     "acc": [
       "višnjevogo / višnjevy",
@@ -155393,6 +157548,7 @@ exports[`adjective 31228 1`] = `
       "vitalistične",
     ],
   },
+  "short": "vitalističėn",
   "singular": {
     "acc": [
       "vitalističnogo / vitalističny",
@@ -155462,6 +157618,7 @@ exports[`adjective 31242 1`] = `
       "vizuaľne",
     ],
   },
+  "short": "vizuaľėn",
   "singular": {
     "acc": [
       "vizuaľnogo / vizuaľny",
@@ -155531,6 +157688,7 @@ exports[`adjective 31248 1`] = `
       "vkųsne",
     ],
   },
+  "short": "vkųsėn",
   "singular": {
     "acc": [
       "vkųsnogo / vkųsny",
@@ -155600,6 +157758,7 @@ exports[`adjective 31286 1`] = `
       "vojinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vojinskogo / vojinsky",
@@ -155669,6 +157828,7 @@ exports[`adjective 31343 1`] = `
       "vȯzvyšene",
     ],
   },
+  "short": "vȯzvyšen",
   "singular": {
     "acc": [
       "vȯzvyšenogo / vȯzvyšeny",
@@ -155738,6 +157898,7 @@ exports[`adjective 31399 1`] = `
       "vulgarne",
     ],
   },
+  "short": "vulgarėn",
   "singular": {
     "acc": [
       "vulgarnogo / vulgarny",
@@ -155807,6 +157968,7 @@ exports[`adjective 31507 1`] = `
       "zaklęte",
     ],
   },
+  "short": "zaklęt",
   "singular": {
     "acc": [
       "zaklętogo / zaklęty",
@@ -155876,6 +158038,7 @@ exports[`adjective 31513 1`] = `
       "zakonoměrne",
     ],
   },
+  "short": "zakonoměrėn",
   "singular": {
     "acc": [
       "zakonoměrnogo / zakonoměrny",
@@ -155945,6 +158108,7 @@ exports[`adjective 31523 1`] = `
       "zamknųte",
     ],
   },
+  "short": "zamknųt",
   "singular": {
     "acc": [
       "zamknųtogo / zamknųty",
@@ -156014,6 +158178,7 @@ exports[`adjective 31526 1`] = `
       "zamoŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "zamoŕskogo / zamoŕsky",
@@ -156083,6 +158248,7 @@ exports[`adjective 31548 1`] = `
       "zarđavěle",
     ],
   },
+  "short": "zarđavěl",
   "singular": {
     "acc": [
       "zarđavělogo / zarđavěly",
@@ -156152,6 +158318,7 @@ exports[`adjective 31571 1`] = `
       "zatųhle",
     ],
   },
+  "short": "zatųhl",
   "singular": {
     "acc": [
       "zatųhlogo / zatųhly",
@@ -156221,6 +158388,7 @@ exports[`adjective 31587 1`] = `
       "zavidne",
     ],
   },
+  "short": "zavidėn",
   "singular": {
     "acc": [
       "zavidnogo / zavidny",
@@ -156290,6 +158458,7 @@ exports[`adjective 31597 1`] = `
       "zavzęte",
     ],
   },
+  "short": "zavzęt",
   "singular": {
     "acc": [
       "zavzętogo / zavzęty",
@@ -156359,6 +158528,7 @@ exports[`adjective 31614 1`] = `
       "zemnovodne",
     ],
   },
+  "short": "zemnovodėn",
   "singular": {
     "acc": [
       "zemnovodnogo / zemnovodny",
@@ -156428,6 +158598,7 @@ exports[`adjective 31627 1`] = `
       "zlåtiste",
     ],
   },
+  "short": "zlåtist",
   "singular": {
     "acc": [
       "zlåtistogo / zlåtisty",
@@ -156497,6 +158668,7 @@ exports[`adjective 31630 1`] = `
       "zlåtouste",
     ],
   },
+  "short": "zlåtoust",
   "singular": {
     "acc": [
       "zlåtoustogo / zlåtousty",
@@ -156566,6 +158738,7 @@ exports[`adjective 31636 1`] = `
       "zlonaměrne",
     ],
   },
+  "short": "zlonaměrėn",
   "singular": {
     "acc": [
       "zlonaměrnogo / zlonaměrny",
@@ -156635,6 +158808,7 @@ exports[`adjective 31640 1`] = `
       "zlověšće",
     ],
   },
+  "short": "zlověšć",
   "singular": {
     "acc": [
       "zlověšćego / zlověšći",
@@ -156704,6 +158878,7 @@ exports[`adjective 31657 1`] = `
       "zodiakaľne",
     ],
   },
+  "short": "zodiakaľėn",
   "singular": {
     "acc": [
       "zodiakaľnogo / zodiakaľny",
@@ -156773,6 +158948,7 @@ exports[`adjective 31662 1`] = `
       "zoologične",
     ],
   },
+  "short": "zoologičėn",
   "singular": {
     "acc": [
       "zoologičnogo / zoologičny",
@@ -156842,6 +159018,7 @@ exports[`adjective 31668 1`] = `
       "zrěle",
     ],
   },
+  "short": "zrěl",
   "singular": {
     "acc": [
       "zrělogo / zrěly",
@@ -156911,6 +159088,7 @@ exports[`adjective 31684 1`] = `
       "zvězdne",
     ],
   },
+  "short": "zvězdėn",
   "singular": {
     "acc": [
       "zvězdnogo / zvězdny",
@@ -156980,6 +159158,7 @@ exports[`adjective 31717 1`] = `
       "banaľne",
     ],
   },
+  "short": "banaľėn",
   "singular": {
     "acc": [
       "banaľnogo / banaľny",
@@ -157049,6 +159228,7 @@ exports[`adjective 31733 1`] = `
       "bezkrile",
     ],
   },
+  "short": "bezkril",
   "singular": {
     "acc": [
       "bezkrilogo / bezkrily",
@@ -157118,6 +159298,7 @@ exports[`adjective 31747 1`] = `
       "prezidentske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "prezidentskogo / prezidentsky",
@@ -157187,6 +159368,7 @@ exports[`adjective 31774 1`] = `
       "nezabytne",
     ],
   },
+  "short": "nezabytėn",
   "singular": {
     "acc": [
       "nezabytnogo / nezabytny",
@@ -157256,6 +159438,7 @@ exports[`adjective 31777 1`] = `
       "interlingvistične",
     ],
   },
+  "short": "interlingvističėn",
   "singular": {
     "acc": [
       "interlingvističnogo / interlingvističny",
@@ -157325,6 +159508,7 @@ exports[`adjective 31784 1`] = `
       "bolězlive",
     ],
   },
+  "short": "bolězliv",
   "singular": {
     "acc": [
       "bolězlivogo / bolězlivy",
@@ -157394,6 +159578,7 @@ exports[`adjective 31793 1`] = `
       "fataľne",
     ],
   },
+  "short": "fataľėn",
   "singular": {
     "acc": [
       "fataľnogo / fataľny",
@@ -157463,6 +159648,7 @@ exports[`adjective 31831 1`] = `
       "drěmlive",
     ],
   },
+  "short": "drěmliv",
   "singular": {
     "acc": [
       "drěmlivogo / drěmlivy",
@@ -157532,6 +159718,7 @@ exports[`adjective 31839 1`] = `
       "međukontinentaľne",
     ],
   },
+  "short": "međukontinentaľėn",
   "singular": {
     "acc": [
       "međukontinentaľnogo / međukontinentaľny",
@@ -157601,6 +159788,7 @@ exports[`adjective 31840 1`] = `
       "međuzvězdne",
     ],
   },
+  "short": "međuzvězdėn",
   "singular": {
     "acc": [
       "međuzvězdnogo / međuzvězdny",
@@ -157670,6 +159858,7 @@ exports[`adjective 31841 1`] = `
       "međugrådske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "međugrådskogo / međugrådsky",
@@ -157739,6 +159928,7 @@ exports[`adjective 31842 1`] = `
       "međuregionaľne",
     ],
   },
+  "short": "međuregionaľėn",
   "singular": {
     "acc": [
       "međuregionaľnogo / međuregionaľny",
@@ -157808,6 +159998,7 @@ exports[`adjective 31871 1`] = `
       "trivyměrne",
     ],
   },
+  "short": "trivyměrėn",
   "singular": {
     "acc": [
       "trivyměrnogo / trivyměrny",
@@ -157877,6 +160068,7 @@ exports[`adjective 31872 1`] = `
       "dvuvyměrne",
     ],
   },
+  "short": "dvuvyměrėn",
   "singular": {
     "acc": [
       "dvuvyměrnogo / dvuvyměrny",
@@ -157946,6 +160138,7 @@ exports[`adjective 31916 1`] = `
       "hrupkave",
     ],
   },
+  "short": "hrupkav",
   "singular": {
     "acc": [
       "hrupkavogo / hrupkavy",
@@ -158015,6 +160208,7 @@ exports[`adjective 31979 1`] = `
       "języčkove",
     ],
   },
+  "short": "języčkov",
   "singular": {
     "acc": [
       "języčkovogo / języčkovy",
@@ -158084,6 +160278,7 @@ exports[`adjective 31991 1`] = `
       "neškodlive",
     ],
   },
+  "short": "neškodliv",
   "singular": {
     "acc": [
       "neškodlivogo / neškodlivy",
@@ -158153,6 +160348,7 @@ exports[`adjective 32029 1`] = `
       "kreativne",
     ],
   },
+  "short": "kreativėn",
   "singular": {
     "acc": [
       "kreativnogo / kreativny",
@@ -158222,6 +160418,7 @@ exports[`adjective 32036 1`] = `
       "paršive",
     ],
   },
+  "short": "paršiv",
   "singular": {
     "acc": [
       "paršivogo / paršivy",
@@ -158291,6 +160488,7 @@ exports[`adjective 32060 1`] = `
       "pornografične",
     ],
   },
+  "short": "pornografičėn",
   "singular": {
     "acc": [
       "pornografičnogo / pornografičny",
@@ -158360,6 +160558,7 @@ exports[`adjective 32069 1`] = `
       "rutinne",
     ],
   },
+  "short": "rutinėn",
   "singular": {
     "acc": [
       "rutinnogo / rutinny",
@@ -158429,6 +160628,7 @@ exports[`adjective 32071 1`] = `
       "ciklične",
     ],
   },
+  "short": "cikličėn",
   "singular": {
     "acc": [
       "cikličnogo / cikličny",
@@ -158498,6 +160698,7 @@ exports[`adjective 32090 1`] = `
       "košerne",
     ],
   },
+  "short": "košerėn",
   "singular": {
     "acc": [
       "košernogo / košerny",
@@ -158567,6 +160768,7 @@ exports[`adjective 32098 1`] = `
       "periferijne",
     ],
   },
+  "short": "periferijėn",
   "singular": {
     "acc": [
       "periferijnogo / periferijny",
@@ -158636,6 +160838,7 @@ exports[`adjective 32111 1`] = `
       "diagnostične",
     ],
   },
+  "short": "diagnostičėn",
   "singular": {
     "acc": [
       "diagnostičnogo / diagnostičny",
@@ -158705,6 +160908,7 @@ exports[`adjective 32128 1`] = `
       "mimične",
     ],
   },
+  "short": "mimičėn",
   "singular": {
     "acc": [
       "mimičnogo / mimičny",
@@ -158774,6 +160978,7 @@ exports[`adjective 32146 1`] = `
       "lakonične",
     ],
   },
+  "short": "lakoničėn",
   "singular": {
     "acc": [
       "lakoničnogo / lakoničny",
@@ -158843,6 +161048,7 @@ exports[`adjective 32167 1`] = `
       "lěvorųke",
     ],
   },
+  "short": "lěvorųk",
   "singular": {
     "acc": [
       "lěvorųkogo / lěvorųky",
@@ -158912,6 +161118,7 @@ exports[`adjective 32168 1`] = `
       "pravorųke",
     ],
   },
+  "short": "pravorųk",
   "singular": {
     "acc": [
       "pravorųkogo / pravorųky",
@@ -158981,6 +161188,7 @@ exports[`adjective 32169 1`] = `
       "desnorųke",
     ],
   },
+  "short": "desnorųk",
   "singular": {
     "acc": [
       "desnorųkogo / desnorųky",
@@ -159050,6 +161258,7 @@ exports[`adjective 32176 1`] = `
       "lihvaŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lihvaŕskogo / lihvaŕsky",
@@ -159119,6 +161328,7 @@ exports[`adjective 32205 1`] = `
       "ljstive",
     ],
   },
+  "short": "ljstiv",
   "singular": {
     "acc": [
       "ljstivogo / ljstivy",
@@ -159188,6 +161398,7 @@ exports[`adjective 32212 1`] = `
       "svirěpe",
     ],
   },
+  "short": "svirěp",
   "singular": {
     "acc": [
       "svirěpogo / svirěpy",
@@ -159257,6 +161468,7 @@ exports[`adjective 32226 1`] = `
       "maloměrne",
     ],
   },
+  "short": "maloměrėn",
   "singular": {
     "acc": [
       "maloměrnogo / maloměrny",
@@ -159326,6 +161538,7 @@ exports[`adjective 32227 1`] = `
       "nedoråzvite",
     ],
   },
+  "short": "nedoråzvit",
   "singular": {
     "acc": [
       "nedoråzvitogo / nedoråzvity",
@@ -159395,6 +161608,7 @@ exports[`adjective 32231 1`] = `
       "kursivne",
     ],
   },
+  "short": "kursivėn",
   "singular": {
     "acc": [
       "kursivnogo / kursivny",
@@ -159464,6 +161678,7 @@ exports[`adjective 32240 1`] = `
       "ritmične",
     ],
   },
+  "short": "ritmičėn",
   "singular": {
     "acc": [
       "ritmičnogo / ritmičny",
@@ -159533,6 +161748,7 @@ exports[`adjective 32246 1`] = `
       "međudŕžavne",
     ],
   },
+  "short": "međudŕžavėn",
   "singular": {
     "acc": [
       "međudŕžavnogo / međudŕžavny",
@@ -159602,6 +161818,7 @@ exports[`adjective 32255 1`] = `
       "monolitne",
     ],
   },
+  "short": "monolitėn",
   "singular": {
     "acc": [
       "monolitnogo / monolitny",
@@ -159671,6 +161888,7 @@ exports[`adjective 32257 1`] = `
       "mobiľne",
     ],
   },
+  "short": "mobiľėn",
   "singular": {
     "acc": [
       "mobiľnogo / mobiľny",
@@ -159740,6 +161958,7 @@ exports[`adjective 32278 1`] = `
       "flegmatične",
     ],
   },
+  "short": "flegmatičėn",
   "singular": {
     "acc": [
       "flegmatičnogo / flegmatičny",
@@ -159809,6 +162028,7 @@ exports[`adjective 32285 1`] = `
       "moraľne",
     ],
   },
+  "short": "moraľėn",
   "singular": {
     "acc": [
       "moraľnogo / moraľny",
@@ -159878,6 +162098,7 @@ exports[`adjective 32286 1`] = `
       "nemoraľne",
     ],
   },
+  "short": "nemoraľėn",
   "singular": {
     "acc": [
       "nemoraľnogo / nemoraľny",
@@ -159947,6 +162168,7 @@ exports[`adjective 32318 1`] = `
       "myslime",
     ],
   },
+  "short": "myslim",
   "singular": {
     "acc": [
       "myslimogo / myslimy",
@@ -160016,6 +162238,7 @@ exports[`adjective 32326 1`] = `
       "jednopole",
     ],
   },
+  "short": "jednopol",
   "singular": {
     "acc": [
       "jednopologo / jednopoly",
@@ -160085,6 +162308,7 @@ exports[`adjective 32329 1`] = `
       "pęťdesętničske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pęťdesętničskogo / pęťdesętničsky",
@@ -160154,6 +162378,7 @@ exports[`adjective 32341 1`] = `
       "sirijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sirijskogo / sirijsky",
@@ -160223,6 +162448,7 @@ exports[`adjective 32342 1`] = `
       "skore",
     ],
   },
+  "short": "skor",
   "singular": {
     "acc": [
       "skorogo / skory",
@@ -160292,6 +162518,7 @@ exports[`adjective 32387 1`] = `
       "nenadežne",
     ],
   },
+  "short": "nenadežėn",
   "singular": {
     "acc": [
       "nenadežnogo / nenadežny",
@@ -160361,6 +162588,7 @@ exports[`adjective 32389 1`] = `
       "utopične",
     ],
   },
+  "short": "utopičėn",
   "singular": {
     "acc": [
       "utopičnogo / utopičny",
@@ -160430,6 +162658,7 @@ exports[`adjective 32400 1`] = `
       "izvinjajųće",
     ],
   },
+  "short": "izvinjajųć",
   "singular": {
     "acc": [
       "izvinjajųćego / izvinjajųći",
@@ -160499,6 +162728,7 @@ exports[`adjective 32413 1`] = `
       "međuplanetarne",
     ],
   },
+  "short": "međuplanetarėn",
   "singular": {
     "acc": [
       "međuplanetarnogo / međuplanetarny",
@@ -160568,6 +162798,7 @@ exports[`adjective 32431 1`] = `
       "veterinaŕne",
     ],
   },
+  "short": "veterinaŕėn",
   "singular": {
     "acc": [
       "veterinaŕnogo / veterinaŕny",
@@ -160637,6 +162868,7 @@ exports[`adjective 32449 1`] = `
       "libanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "libanskogo / libansky",
@@ -160706,6 +162938,7 @@ exports[`adjective 32451 1`] = `
       "nepaľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "nepaľskogo / nepaľsky",
@@ -160775,6 +163008,7 @@ exports[`adjective 32452 1`] = `
       "švejcarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "švejcarskogo / švejcarsky",
@@ -160844,6 +163078,7 @@ exports[`adjective 32453 1`] = `
       "katarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "katarskogo / katarsky",
@@ -160913,6 +163148,7 @@ exports[`adjective 32455 1`] = `
       "kongolezske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kongolezskogo / kongolezsky",
@@ -160982,6 +163218,7 @@ exports[`adjective 32465 1`] = `
       "dobronaměrne",
     ],
   },
+  "short": "dobronaměrėn",
   "singular": {
     "acc": [
       "dobronaměrnogo / dobronaměrny",
@@ -161051,6 +163288,7 @@ exports[`adjective 32481 1`] = `
       "trajne",
     ],
   },
+  "short": "trajėn",
   "singular": {
     "acc": [
       "trajnogo / trajny",
@@ -161120,6 +163358,7 @@ exports[`adjective 32486 1`] = `
       "trevožne",
     ],
   },
+  "short": "trevožėn",
   "singular": {
     "acc": [
       "trevožnogo / trevožny",
@@ -161189,6 +163428,7 @@ exports[`adjective 32510 1`] = `
       "pljuševe",
     ],
   },
+  "short": "pljušev",
   "singular": {
     "acc": [
       "pljuševogo / pljuševy",
@@ -161258,6 +163498,7 @@ exports[`adjective 32530 1`] = `
       "ambiciozne",
     ],
   },
+  "short": "ambiciozėn",
   "singular": {
     "acc": [
       "ambicioznogo / ambiciozny",
@@ -161327,6 +163568,7 @@ exports[`adjective 32531 1`] = `
       "čestiljubive",
     ],
   },
+  "short": "čestiljubiv",
   "singular": {
     "acc": [
       "čestiljubivogo / čestiljubivy",
@@ -161396,6 +163638,7 @@ exports[`adjective 32532 1`] = `
       "pretenciozne",
     ],
   },
+  "short": "pretenciozėn",
   "singular": {
     "acc": [
       "pretencioznogo / pretenciozny",
@@ -161465,6 +163708,7 @@ exports[`adjective 32543 1`] = `
       "aksiaľne",
     ],
   },
+  "short": "aksiaľėn",
   "singular": {
     "acc": [
       "aksiaľnogo / aksiaľny",
@@ -161534,6 +163778,7 @@ exports[`adjective 32565 1`] = `
       "mnogokråtne",
     ],
   },
+  "short": "mnogokråtėn",
   "singular": {
     "acc": [
       "mnogokråtnogo / mnogokråtny",
@@ -161603,6 +163848,7 @@ exports[`adjective 32583 1`] = `
       "vȯzklicaľne",
     ],
   },
+  "short": "vȯzklicaľėn",
   "singular": {
     "acc": [
       "vȯzklicaľnogo / vȯzklicaľny",
@@ -161672,6 +163918,7 @@ exports[`adjective 32623 1`] = `
       "nenaměrne",
     ],
   },
+  "short": "nenaměrėn",
   "singular": {
     "acc": [
       "nenaměrnogo / nenaměrny",
@@ -161741,6 +163988,7 @@ exports[`adjective 32623-1 1`] = `
       "nenaměrjene",
     ],
   },
+  "short": "nenaměrjen",
   "singular": {
     "acc": [
       "nenaměrjenogo / nenaměrjeny",
@@ -161810,6 +164058,7 @@ exports[`adjective 32674 1`] = `
       "ruse",
     ],
   },
+  "short": "rus",
   "singular": {
     "acc": [
       "rusogo / rusy",
@@ -161879,6 +164128,7 @@ exports[`adjective 32675 1`] = `
       "rude",
     ],
   },
+  "short": "rud",
   "singular": {
     "acc": [
       "rudogo / rudy",
@@ -161948,6 +164198,7 @@ exports[`adjective 32716 1`] = `
       "zamševe",
     ],
   },
+  "short": "zamšev",
   "singular": {
     "acc": [
       "zamševogo / zamševy",
@@ -162017,6 +164268,7 @@ exports[`adjective 32727 1`] = `
       "apriorne",
     ],
   },
+  "short": "apriorėn",
   "singular": {
     "acc": [
       "apriornogo / apriorny",
@@ -162086,6 +164338,7 @@ exports[`adjective 32728 1`] = `
       "aposteriorne",
     ],
   },
+  "short": "aposteriorėn",
   "singular": {
     "acc": [
       "aposteriornogo / aposteriorny",
@@ -162155,6 +164408,7 @@ exports[`adjective 32740 1`] = `
       "kolektivne",
     ],
   },
+  "short": "kolektivėn",
   "singular": {
     "acc": [
       "kolektivnogo / kolektivny",
@@ -162224,6 +164478,7 @@ exports[`adjective 32743 1`] = `
       "totalitarne",
     ],
   },
+  "short": "totalitarėn",
   "singular": {
     "acc": [
       "totalitarnogo / totalitarny",
@@ -162293,6 +164548,7 @@ exports[`adjective 32744 1`] = `
       "totaľne",
     ],
   },
+  "short": "totaľėn",
   "singular": {
     "acc": [
       "totaľnogo / totaľny",
@@ -162362,6 +164618,7 @@ exports[`adjective 32763 1`] = `
       "vųgȯljne",
     ],
   },
+  "short": "vųgȯljėn",
   "singular": {
     "acc": [
       "vųgȯljnogo / vųgȯljny",
@@ -162431,6 +164688,7 @@ exports[`adjective 32794 1`] = `
       "uměstne",
     ],
   },
+  "short": "uměstėn",
   "singular": {
     "acc": [
       "uměstnogo / uměstny",
@@ -162500,6 +164758,7 @@ exports[`adjective 32818 1`] = `
       "nahmurjene",
     ],
   },
+  "short": "nahmurjen",
   "singular": {
     "acc": [
       "nahmurjenogo / nahmurjeny",
@@ -162569,6 +164828,7 @@ exports[`adjective 32837 1`] = `
       "žiľne",
     ],
   },
+  "short": "žiľėn",
   "singular": {
     "acc": [
       "žiľnogo / žiľny",
@@ -162638,6 +164898,7 @@ exports[`adjective 32840 1`] = `
       "slovne",
     ],
   },
+  "short": "slovėn",
   "singular": {
     "acc": [
       "slovnogo / slovny",
@@ -162672,18 +164933,9 @@ exports[`adjective 32840 1`] = `
 exports[`adjective 32852 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "seksuaľno privlěkateljnějši",
-      "seksuaľno privlěkateljněje",
-    ],
-    "positive": [
-      "seksuaľno privlěkateljny",
-      "seksuaľno privlěkateljno",
-    ],
-    "superlative": [
-      "najseksuaľno privlěkateljnějši",
-      "najseksuaľno privlěkateljněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -162707,6 +164959,7 @@ exports[`adjective 32852 1`] = `
       "seksuaľno privlěkateljne",
     ],
   },
+  "short": "seksuaľno privlěkateljėn",
   "singular": {
     "acc": [
       "seksuaľno privlěkateljnogo / seksuaľno privlěkateljny",
@@ -162776,6 +165029,7 @@ exports[`adjective 32853 1`] = `
       "sekśe",
     ],
   },
+  "short": "seks",
   "singular": {
     "acc": [
       "sekśego / seksi",
@@ -162845,6 +165099,7 @@ exports[`adjective 32888 1`] = `
       "smrščene",
     ],
   },
+  "short": "smrščen",
   "singular": {
     "acc": [
       "smrščenogo / smrščeny",
@@ -162914,6 +165169,7 @@ exports[`adjective 32900 1`] = `
       "koketne",
     ],
   },
+  "short": "koketėn",
   "singular": {
     "acc": [
       "koketnogo / koketny",
@@ -162983,6 +165239,7 @@ exports[`adjective 32932 1`] = `
       "subjektivne",
     ],
   },
+  "short": "subjektivėn",
   "singular": {
     "acc": [
       "subjektivnogo / subjektivny",
@@ -163052,6 +165309,7 @@ exports[`adjective 32942 1`] = `
       "ovdověle",
     ],
   },
+  "short": "ovdověl",
   "singular": {
     "acc": [
       "ovdovělogo / ovdověly",
@@ -163121,6 +165379,7 @@ exports[`adjective 32975 1`] = `
       "pozlåćene",
     ],
   },
+  "short": "pozlåćen",
   "singular": {
     "acc": [
       "pozlåćenogo / pozlåćeny",
@@ -163190,6 +165449,7 @@ exports[`adjective 32985 1`] = `
       "žoviaľne",
     ],
   },
+  "short": "žoviaľėn",
   "singular": {
     "acc": [
       "žoviaľnogo / žoviaľny",
@@ -163259,6 +165519,7 @@ exports[`adjective 32987 1`] = `
       "teatraľne",
     ],
   },
+  "short": "teatraľėn",
   "singular": {
     "acc": [
       "teatraľnogo / teatraľny",
@@ -163328,6 +165589,7 @@ exports[`adjective 33005 1`] = `
       "gluhoněme",
     ],
   },
+  "short": "gluhoněm",
   "singular": {
     "acc": [
       "gluhoněmogo / gluhoněmy",
@@ -163397,6 +165659,7 @@ exports[`adjective 33015 1`] = `
       "prijemlive",
     ],
   },
+  "short": "prijemliv",
   "singular": {
     "acc": [
       "prijemlivogo / prijemlivy",
@@ -163466,6 +165729,7 @@ exports[`adjective 33016 1`] = `
       "neprijemlive",
     ],
   },
+  "short": "neprijemliv",
   "singular": {
     "acc": [
       "neprijemlivogo / neprijemlivy",
@@ -163535,6 +165799,7 @@ exports[`adjective 33028 1`] = `
       "slåne",
     ],
   },
+  "short": "slån",
   "singular": {
     "acc": [
       "slånogo / slåny",
@@ -163604,6 +165869,7 @@ exports[`adjective 33029 1`] = `
       "posoljene",
     ],
   },
+  "short": "posoljen",
   "singular": {
     "acc": [
       "posoljenogo / posoljeny",
@@ -163673,6 +165939,7 @@ exports[`adjective 33030 1`] = `
       "soljene",
     ],
   },
+  "short": "soljen",
   "singular": {
     "acc": [
       "soljenogo / soljeny",
@@ -163742,6 +166009,7 @@ exports[`adjective 33035 1`] = `
       "dekadentske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dekadentskogo / dekadentsky",
@@ -163811,6 +166079,7 @@ exports[`adjective 33037 1`] = `
       "dȯlgohvoste",
     ],
   },
+  "short": "dȯlgohvost",
   "singular": {
     "acc": [
       "dȯlgohvostogo / dȯlgohvosty",
@@ -163880,6 +166149,7 @@ exports[`adjective 33039 1`] = `
       "nadųte",
     ],
   },
+  "short": "nadųt",
   "singular": {
     "acc": [
       "nadųtogo / nadųty",
@@ -163949,6 +166219,7 @@ exports[`adjective 33105 1`] = `
       "neobhodime",
     ],
   },
+  "short": "neobhodim",
   "singular": {
     "acc": [
       "neobhodimogo / neobhodimy",
@@ -164018,6 +166289,7 @@ exports[`adjective 33111 1`] = `
       "neizběžne",
     ],
   },
+  "short": "neizběžėn",
   "singular": {
     "acc": [
       "neizběžnogo / neizběžny",
@@ -164087,6 +166359,7 @@ exports[`adjective 33116 1`] = `
       "neodvråtime",
     ],
   },
+  "short": "neodvråtim",
   "singular": {
     "acc": [
       "neodvråtimogo / neodvråtimy",
@@ -164156,6 +166429,7 @@ exports[`adjective 33118 1`] = `
       "neminujeme",
     ],
   },
+  "short": "neminujem",
   "singular": {
     "acc": [
       "neminujemogo / neminujemy",
@@ -164225,6 +166499,7 @@ exports[`adjective 33123 1`] = `
       "bezbožne",
     ],
   },
+  "short": "bezbožėn",
   "singular": {
     "acc": [
       "bezbožnogo / bezbožny",
@@ -164294,6 +166569,7 @@ exports[`adjective 33136 1`] = `
       "neizměrime",
     ],
   },
+  "short": "neizměrim",
   "singular": {
     "acc": [
       "neizměrimogo / neizměrimy",
@@ -164363,6 +166639,7 @@ exports[`adjective 33138 1`] = `
       "bezměrne",
     ],
   },
+  "short": "bezměrėn",
   "singular": {
     "acc": [
       "bezměrnogo / bezměrny",
@@ -164432,6 +166709,7 @@ exports[`adjective 33156 1`] = `
       "bezuspěšne",
     ],
   },
+  "short": "bezuspěšėn",
   "singular": {
     "acc": [
       "bezuspěšnogo / bezuspěšny",
@@ -164501,6 +166779,7 @@ exports[`adjective 33157 1`] = `
       "bezutěšne",
     ],
   },
+  "short": "bezutěšėn",
   "singular": {
     "acc": [
       "bezutěšnogo / bezutěšny",
@@ -164570,6 +166849,7 @@ exports[`adjective 33202 1`] = `
       "negramotne",
     ],
   },
+  "short": "negramotėn",
   "singular": {
     "acc": [
       "negramotnogo / negramotny",
@@ -164639,6 +166919,7 @@ exports[`adjective 33205 1`] = `
       "gramotne",
     ],
   },
+  "short": "gramotėn",
   "singular": {
     "acc": [
       "gramotnogo / gramotny",
@@ -164708,6 +166989,7 @@ exports[`adjective 33229 1`] = `
       "neodčuđajeme",
     ],
   },
+  "short": "neodčuđajem",
   "singular": {
     "acc": [
       "neodčuđajemogo / neodčuđajemy",
@@ -164777,6 +167059,7 @@ exports[`adjective 33229-1 1`] = `
       "neodčuđime",
     ],
   },
+  "short": "neodčuđim",
   "singular": {
     "acc": [
       "neodčuđimogo / neodčuđimy",
@@ -164846,6 +167129,7 @@ exports[`adjective 33232 1`] = `
       "bezpriměrne",
     ],
   },
+  "short": "bezpriměrėn",
   "singular": {
     "acc": [
       "bezpriměrnogo / bezpriměrny",
@@ -164915,6 +167199,7 @@ exports[`adjective 33236 1`] = `
       "bezprikladne",
     ],
   },
+  "short": "bezprikladėn",
   "singular": {
     "acc": [
       "bezprikladnogo / bezprikladny",
@@ -164984,6 +167269,7 @@ exports[`adjective 33261 1`] = `
       "neniščime",
     ],
   },
+  "short": "neniščim",
   "singular": {
     "acc": [
       "neniščimogo / neniščimy",
@@ -165053,6 +167339,7 @@ exports[`adjective 33262 1`] = `
       "niščęće",
     ],
   },
+  "short": "niščęć",
   "singular": {
     "acc": [
       "niščęćego / niščęći",
@@ -165122,6 +167409,7 @@ exports[`adjective 33372 1`] = `
       "masivne",
     ],
   },
+  "short": "masivėn",
   "singular": {
     "acc": [
       "masivnogo / masivny",
@@ -165191,6 +167479,7 @@ exports[`adjective 33385 1`] = `
       "posrěbrjene",
     ],
   },
+  "short": "posrěbrjen",
   "singular": {
     "acc": [
       "posrěbrjenogo / posrěbrjeny",
@@ -165260,6 +167549,7 @@ exports[`adjective 33390 1`] = `
       "urazlive",
     ],
   },
+  "short": "urazliv",
   "singular": {
     "acc": [
       "urazlivogo / urazlivy",
@@ -165329,6 +167619,7 @@ exports[`adjective 33392 1`] = `
       "uražene",
     ],
   },
+  "short": "uražen",
   "singular": {
     "acc": [
       "uraženogo / uraženy",
@@ -165398,6 +167689,7 @@ exports[`adjective 33398 1`] = `
       "jednokråtne",
     ],
   },
+  "short": "jednokråtėn",
   "singular": {
     "acc": [
       "jednokråtnogo / jednokråtny",
@@ -165467,6 +167759,7 @@ exports[`adjective 33467 1`] = `
       "neoskvŕnjene",
     ],
   },
+  "short": "neoskvŕnjen",
   "singular": {
     "acc": [
       "neoskvŕnjenogo / neoskvŕnjeny",
@@ -165536,6 +167829,7 @@ exports[`adjective 33476 1`] = `
       "obscenne",
     ],
   },
+  "short": "obscenėn",
   "singular": {
     "acc": [
       "obscennogo / obscenny",
@@ -165605,6 +167899,7 @@ exports[`adjective 33492 1`] = `
       "odsųtne",
     ],
   },
+  "short": "odsųtėn",
   "singular": {
     "acc": [
       "odsųtnogo / odsųtny",
@@ -165674,6 +167969,7 @@ exports[`adjective 33496 1`] = `
       "pritomne",
     ],
   },
+  "short": "pritomėn",
   "singular": {
     "acc": [
       "pritomnogo / pritomny",
@@ -165743,6 +168039,7 @@ exports[`adjective 33503 1`] = `
       "haotične",
     ],
   },
+  "short": "haotičėn",
   "singular": {
     "acc": [
       "haotičnogo / haotičny",
@@ -165812,6 +168109,7 @@ exports[`adjective 33535 1`] = `
       "gigantske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gigantskogo / gigantsky",
@@ -165881,6 +168179,7 @@ exports[`adjective 33552 1`] = `
       "pråzdnične",
     ],
   },
+  "short": "pråzdničėn",
   "singular": {
     "acc": [
       "pråzdničnogo / pråzdničny",
@@ -165950,6 +168249,7 @@ exports[`adjective 33561 1`] = `
       "zadnjepodnebne",
     ],
   },
+  "short": "zadnjepodnebėn",
   "singular": {
     "acc": [
       "zadnjepodnebnogo / zadnjepodnebny",
@@ -166019,6 +168319,7 @@ exports[`adjective 33564 1`] = `
       "aksamitne",
     ],
   },
+  "short": "aksamitėn",
   "singular": {
     "acc": [
       "aksamitnogo / aksamitny",
@@ -166088,6 +168389,7 @@ exports[`adjective 33567 1`] = `
       "endemične",
     ],
   },
+  "short": "endemičėn",
   "singular": {
     "acc": [
       "endemičnogo / endemičny",
@@ -166157,6 +168459,7 @@ exports[`adjective 33583 1`] = `
       "taksonomične",
     ],
   },
+  "short": "taksonomičėn",
   "singular": {
     "acc": [
       "taksonomičnogo / taksonomičny",
@@ -166226,6 +168529,7 @@ exports[`adjective 33585 1`] = `
       "proročske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "proročskogo / proročsky",
@@ -166295,6 +168599,7 @@ exports[`adjective 33630 1`] = `
       "zagrobne",
     ],
   },
+  "short": "zagrobėn",
   "singular": {
     "acc": [
       "zagrobnogo / zagrobny",
@@ -166364,6 +168669,7 @@ exports[`adjective 33634 1`] = `
       "nepopravime",
     ],
   },
+  "short": "nepopravim",
   "singular": {
     "acc": [
       "nepopravimogo / nepopravimy",
@@ -166433,6 +168739,7 @@ exports[`adjective 33664 1`] = `
       "šovinistične",
     ],
   },
+  "short": "šovinističėn",
   "singular": {
     "acc": [
       "šovinističnogo / šovinističny",
@@ -166502,6 +168809,7 @@ exports[`adjective 33708 1`] = `
       "povoljne",
     ],
   },
+  "short": "povoljėn",
   "singular": {
     "acc": [
       "povoljnogo / povoljny",
@@ -166571,6 +168879,7 @@ exports[`adjective 33722 1`] = `
       "kuriozne",
     ],
   },
+  "short": "kuriozėn",
   "singular": {
     "acc": [
       "kurioznogo / kuriozny",
@@ -166640,6 +168949,7 @@ exports[`adjective 33729 1`] = `
       "protestantske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "protestantskogo / protestantsky",
@@ -166709,6 +169019,7 @@ exports[`adjective 33821 1`] = `
       "nepromokajeme",
     ],
   },
+  "short": "nepromokajem",
   "singular": {
     "acc": [
       "nepromokajemogo / nepromokajemy",
@@ -166778,6 +169089,7 @@ exports[`adjective 33822 1`] = `
       "vodoodporne",
     ],
   },
+  "short": "vodoodporėn",
   "singular": {
     "acc": [
       "vodoodpornogo / vodoodporny",
@@ -166847,6 +169159,7 @@ exports[`adjective 34419 1`] = `
       "marginaľne",
     ],
   },
+  "short": "marginaľėn",
   "singular": {
     "acc": [
       "marginaľnogo / marginaľny",
@@ -166916,6 +169229,7 @@ exports[`adjective 34434 1`] = `
       "bezvkųsne",
     ],
   },
+  "short": "bezvkųsėn",
   "singular": {
     "acc": [
       "bezvkųsnogo / bezvkųsny",
@@ -166985,6 +169299,7 @@ exports[`adjective 34438 1`] = `
       "mle",
     ],
   },
+  "short": "mȯl",
   "singular": {
     "acc": [
       "mlogo / mly",
@@ -167054,6 +169369,7 @@ exports[`adjective 34439 1`] = `
       "mlave",
     ],
   },
+  "short": "mlav",
   "singular": {
     "acc": [
       "mlavogo / mlavy",
@@ -167123,6 +169439,7 @@ exports[`adjective 34475 1`] = `
       "pomyljene",
     ],
   },
+  "short": "pomyljen",
   "singular": {
     "acc": [
       "pomyljenogo / pomyljeny",
@@ -167192,6 +169509,7 @@ exports[`adjective 34510 1`] = `
       "zapozdněle",
     ],
   },
+  "short": "zapozdněl",
   "singular": {
     "acc": [
       "zapozdnělogo / zapozdněly",
@@ -167261,6 +169579,7 @@ exports[`adjective 34512 1`] = `
       "zaostale",
     ],
   },
+  "short": "zaostal",
   "singular": {
     "acc": [
       "zaostalogo / zaostaly",
@@ -167330,6 +169649,7 @@ exports[`adjective 34515 1`] = `
       "neråzvite",
     ],
   },
+  "short": "neråzvit",
   "singular": {
     "acc": [
       "neråzvitogo / neråzvity",
@@ -167399,6 +169719,7 @@ exports[`adjective 34602 1`] = `
       "oskųdne",
     ],
   },
+  "short": "oskųdėn",
   "singular": {
     "acc": [
       "oskųdnogo / oskųdny",
@@ -167468,6 +169789,7 @@ exports[`adjective 34631 1`] = `
       "podmoŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "podmoŕskogo / podmoŕsky",
@@ -167537,6 +169859,7 @@ exports[`adjective 34677 1`] = `
       "frustrovane",
     ],
   },
+  "short": "frustrovan",
   "singular": {
     "acc": [
       "frustrovanogo / frustrovany",
@@ -167606,6 +169929,7 @@ exports[`adjective 34687 1`] = `
       "otųpěle",
     ],
   },
+  "short": "otųpěl",
   "singular": {
     "acc": [
       "otųpělogo / otųpěly",
@@ -167675,6 +169999,7 @@ exports[`adjective 34758 1`] = `
       "globaľne",
     ],
   },
+  "short": "globaľėn",
   "singular": {
     "acc": [
       "globaľnogo / globaľny",
@@ -167744,6 +170069,7 @@ exports[`adjective 34779 1`] = `
       "majstrovske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "majstrovskogo / majstrovsky",
@@ -167813,6 +170139,7 @@ exports[`adjective 34781 1`] = `
       "kiriličske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kiriličskogo / kiriličsky",
@@ -167882,6 +170209,7 @@ exports[`adjective 34781-1 1`] = `
       "kirilske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kirilskogo / kirilsky",
@@ -167951,6 +170279,7 @@ exports[`adjective 34783 1`] = `
       "feudaľne",
     ],
   },
+  "short": "feudaľėn",
   "singular": {
     "acc": [
       "feudaľnogo / feudaľny",
@@ -168020,6 +170349,7 @@ exports[`adjective 34836 1`] = `
       "prědvidime",
     ],
   },
+  "short": "prědvidim",
   "singular": {
     "acc": [
       "prědvidimogo / prědvidimy",
@@ -168089,6 +170419,7 @@ exports[`adjective 34837 1`] = `
       "prědvidlive",
     ],
   },
+  "short": "prědvidliv",
   "singular": {
     "acc": [
       "prědvidlivogo / prědvidlivy",
@@ -168158,6 +170489,7 @@ exports[`adjective 34838 1`] = `
       "neprědvidime",
     ],
   },
+  "short": "neprědvidim",
   "singular": {
     "acc": [
       "neprědvidimogo / neprědvidimy",
@@ -168227,6 +170559,7 @@ exports[`adjective 34839 1`] = `
       "neprědvidlive",
     ],
   },
+  "short": "neprědvidliv",
   "singular": {
     "acc": [
       "neprědvidlivogo / neprědvidlivy",
@@ -168296,6 +170629,7 @@ exports[`adjective 34842 1`] = `
       "prototipične",
     ],
   },
+  "short": "prototipičėn",
   "singular": {
     "acc": [
       "prototipičnogo / prototipičny",
@@ -168365,6 +170699,7 @@ exports[`adjective 34843 1`] = `
       "subtiľne",
     ],
   },
+  "short": "subtiľėn",
   "singular": {
     "acc": [
       "subtiľnogo / subtiľny",
@@ -168434,6 +170769,7 @@ exports[`adjective 34852 1`] = `
       "interaktivne",
     ],
   },
+  "short": "interaktivėn",
   "singular": {
     "acc": [
       "interaktivnogo / interaktivny",
@@ -168503,6 +170839,7 @@ exports[`adjective 34854 1`] = `
       "popeliste",
     ],
   },
+  "short": "popelist",
   "singular": {
     "acc": [
       "popelistogo / popelisty",
@@ -168572,6 +170909,7 @@ exports[`adjective 34855 1`] = `
       "pepeliste",
     ],
   },
+  "short": "pepelist",
   "singular": {
     "acc": [
       "pepelistogo / pepelisty",
@@ -168641,6 +170979,7 @@ exports[`adjective 34861 1`] = `
       "ponižajųće",
     ],
   },
+  "short": "ponižajųć",
   "singular": {
     "acc": [
       "ponižajųćego / ponižajųći",
@@ -168710,6 +171049,7 @@ exports[`adjective 34876 1`] = `
       "svojevrěmenne",
     ],
   },
+  "short": "svojevrěmenėn",
   "singular": {
     "acc": [
       "svojevrěmennogo / svojevrěmenny",
@@ -168779,6 +171119,7 @@ exports[`adjective 34880 1`] = `
       "včasne",
     ],
   },
+  "short": "včasėn",
   "singular": {
     "acc": [
       "včasnogo / včasny",
@@ -168848,6 +171189,7 @@ exports[`adjective 34915 1`] = `
       "negybke",
     ],
   },
+  "short": "negybȯk",
   "singular": {
     "acc": [
       "negybkogo / negybky",
@@ -168917,6 +171259,7 @@ exports[`adjective 34916 1`] = `
       "vsestrånne",
     ],
   },
+  "short": "vsestrånėn",
   "singular": {
     "acc": [
       "vsestrånnogo / vsestrånny",
@@ -168986,6 +171329,7 @@ exports[`adjective 34917 1`] = `
       "mnogostrånne",
     ],
   },
+  "short": "mnogostrånėn",
   "singular": {
     "acc": [
       "mnogostrånnogo / mnogostrånny",
@@ -169055,6 +171399,7 @@ exports[`adjective 34924 1`] = `
       "cělodnevne",
     ],
   },
+  "short": "cělodnevėn",
   "singular": {
     "acc": [
       "cělodnevnogo / cělodnevny",
@@ -169124,6 +171469,7 @@ exports[`adjective 34925 1`] = `
       "cělodenne",
     ],
   },
+  "short": "cělodenėn",
   "singular": {
     "acc": [
       "cělodennogo / cělodenny",
@@ -169193,6 +171539,7 @@ exports[`adjective 34929 1`] = `
       "råzbojne",
     ],
   },
+  "short": "råzbojėn",
   "singular": {
     "acc": [
       "råzbojnogo / råzbojny",
@@ -169262,6 +171609,7 @@ exports[`adjective 34937 1`] = `
       "posmŕtne",
     ],
   },
+  "short": "posmŕtėn",
   "singular": {
     "acc": [
       "posmŕtnogo / posmŕtny",
@@ -169331,6 +171679,7 @@ exports[`adjective 34939 1`] = `
       "smŕteljne",
     ],
   },
+  "short": "smŕteljėn",
   "singular": {
     "acc": [
       "smŕteljnogo / smŕteljny",
@@ -169400,6 +171749,7 @@ exports[`adjective 34941 1`] = `
       "onȯgdašnje",
     ],
   },
+  "short": "onȯgdašėn",
   "singular": {
     "acc": [
       "onȯgdašnjego / onȯgdašnji",
@@ -169469,6 +171819,7 @@ exports[`adjective 34941-1 1`] = `
       "onȯgdašne",
     ],
   },
+  "short": "onȯgdašėn",
   "singular": {
     "acc": [
       "onȯgdašnogo / onȯgdašny",
@@ -169538,6 +171889,7 @@ exports[`adjective 34952 1`] = `
       "tolerantne",
     ],
   },
+  "short": "tolerantėn",
   "singular": {
     "acc": [
       "tolerantnogo / tolerantny",
@@ -169607,6 +171959,7 @@ exports[`adjective 34962 1`] = `
       "stresove",
     ],
   },
+  "short": "stresov",
   "singular": {
     "acc": [
       "stresovogo / stresovy",
@@ -169676,6 +172029,7 @@ exports[`adjective 34963 1`] = `
       "tropične",
     ],
   },
+  "short": "tropičėn",
   "singular": {
     "acc": [
       "tropičnogo / tropičny",
@@ -169745,6 +172099,7 @@ exports[`adjective 34965 1`] = `
       "turistične",
     ],
   },
+  "short": "turističėn",
   "singular": {
     "acc": [
       "turističnogo / turističny",
@@ -169814,6 +172169,7 @@ exports[`adjective 34972 1`] = `
       "udačne",
     ],
   },
+  "short": "udačėn",
   "singular": {
     "acc": [
       "udačnogo / udačny",
@@ -169883,6 +172239,7 @@ exports[`adjective 34974 1`] = `
       "neudačne",
     ],
   },
+  "short": "neudačėn",
   "singular": {
     "acc": [
       "neudačnogo / neudačny",
@@ -169952,6 +172309,7 @@ exports[`adjective 34978 1`] = `
       "šikarne",
     ],
   },
+  "short": "šikarėn",
   "singular": {
     "acc": [
       "šikarnogo / šikarny",
@@ -170021,6 +172379,7 @@ exports[`adjective 34980 1`] = `
       "neumolime",
     ],
   },
+  "short": "neumolim",
   "singular": {
     "acc": [
       "neumolimogo / neumolimy",
@@ -170090,6 +172449,7 @@ exports[`adjective 34986 1`] = `
       "ovaľne",
     ],
   },
+  "short": "ovaľėn",
   "singular": {
     "acc": [
       "ovaľnogo / ovaľny",
@@ -170159,6 +172519,7 @@ exports[`adjective 35009 1`] = `
       "zloradne",
     ],
   },
+  "short": "zloradėn",
   "singular": {
     "acc": [
       "zloradnogo / zloradny",
@@ -170228,6 +172589,7 @@ exports[`adjective 35017 1`] = `
       "literaturne",
     ],
   },
+  "short": "literaturėn",
   "singular": {
     "acc": [
       "literaturnogo / literaturny",
@@ -170297,6 +172659,7 @@ exports[`adjective 35018 1`] = `
       "južnoafrikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "južnoafrikanskogo / južnoafrikansky",
@@ -170366,6 +172729,7 @@ exports[`adjective 35020 1`] = `
       "atlantične",
     ],
   },
+  "short": "atlantičėn",
   "singular": {
     "acc": [
       "atlantičnogo / atlantičny",
@@ -170435,6 +172799,7 @@ exports[`adjective 35021 1`] = `
       "olimpijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "olimpijskogo / olimpijsky",
@@ -170504,6 +172869,7 @@ exports[`adjective 35023 1`] = `
       "svŕbęće",
     ],
   },
+  "short": "svŕbęć",
   "singular": {
     "acc": [
       "svŕbęćego / svŕbęći",
@@ -170573,6 +172939,7 @@ exports[`adjective 35025 1`] = `
       "pravopisne",
     ],
   },
+  "short": "pravopisėn",
   "singular": {
     "acc": [
       "pravopisnogo / pravopisny",
@@ -170642,6 +173009,7 @@ exports[`adjective 35026 1`] = `
       "unikaľne",
     ],
   },
+  "short": "unikaľėn",
   "singular": {
     "acc": [
       "unikaľnogo / unikaľny",
@@ -170711,6 +173079,7 @@ exports[`adjective 35029 1`] = `
       "gosteprijemne",
     ],
   },
+  "short": "gosteprijemėn",
   "singular": {
     "acc": [
       "gosteprijemnogo / gosteprijemny",
@@ -170780,6 +173149,7 @@ exports[`adjective 35030 1`] = `
       "gostinne",
     ],
   },
+  "short": "gostinėn",
   "singular": {
     "acc": [
       "gostinnogo / gostinny",
@@ -170849,6 +173219,7 @@ exports[`adjective 35034 1`] = `
       "teplovate",
     ],
   },
+  "short": "teplovat",
   "singular": {
     "acc": [
       "teplovatogo / teplovaty",
@@ -170918,6 +173289,7 @@ exports[`adjective 35037 1`] = `
       "dråžne",
     ],
   },
+  "short": "dråžėn",
   "singular": {
     "acc": [
       "dråžnogo / dråžny",
@@ -170987,6 +173359,7 @@ exports[`adjective 35047 1`] = `
       "konvencionaľne",
     ],
   },
+  "short": "konvencionaľėn",
   "singular": {
     "acc": [
       "konvencionaľnogo / konvencionaľny",
@@ -171056,6 +173429,7 @@ exports[`adjective 35054 1`] = `
       "škotske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "škotskogo / škotsky",
@@ -171125,6 +173499,7 @@ exports[`adjective 35058 1`] = `
       "velsske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "velsskogo / velssky",
@@ -171194,6 +173569,7 @@ exports[`adjective 35061 1`] = `
       "parlamentarne",
     ],
   },
+  "short": "parlamentarėn",
   "singular": {
     "acc": [
       "parlamentarnogo / parlamentarny",
@@ -171263,6 +173639,7 @@ exports[`adjective 35063 1`] = `
       "uraľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "uraľskogo / uraľsky",
@@ -171332,6 +173709,7 @@ exports[`adjective 35069 1`] = `
       "netolerantne",
     ],
   },
+  "short": "netolerantėn",
   "singular": {
     "acc": [
       "netolerantnogo / netolerantny",
@@ -171401,6 +173779,7 @@ exports[`adjective 35075 1`] = `
       "neizgodne",
     ],
   },
+  "short": "neizgodėn",
   "singular": {
     "acc": [
       "neizgodnogo / neizgodny",
@@ -171470,6 +173849,7 @@ exports[`adjective 35082 1`] = `
       "realistične",
     ],
   },
+  "short": "realističėn",
   "singular": {
     "acc": [
       "realističnogo / realističny",
@@ -171539,6 +173919,7 @@ exports[`adjective 35083 1`] = `
       "podrobne",
     ],
   },
+  "short": "podrobėn",
   "singular": {
     "acc": [
       "podrobnogo / podrobny",
@@ -171608,6 +173989,7 @@ exports[`adjective 35088 1`] = `
       "bibliografične",
     ],
   },
+  "short": "bibliografičėn",
   "singular": {
     "acc": [
       "bibliografičnogo / bibliografičny",
@@ -171677,6 +174059,7 @@ exports[`adjective 35095 1`] = `
       "atletične",
     ],
   },
+  "short": "atletičėn",
   "singular": {
     "acc": [
       "atletičnogo / atletičny",
@@ -171746,6 +174129,7 @@ exports[`adjective 35110 1`] = `
       "estetične",
     ],
   },
+  "short": "estetičėn",
   "singular": {
     "acc": [
       "estetičnogo / estetičny",
@@ -171815,6 +174199,7 @@ exports[`adjective 35115 1`] = `
       "obrånne",
     ],
   },
+  "short": "obrånėn",
   "singular": {
     "acc": [
       "obrånnogo / obrånny",
@@ -171884,6 +174269,7 @@ exports[`adjective 35125 1`] = `
       "bezbrånne",
     ],
   },
+  "short": "bezbrånėn",
   "singular": {
     "acc": [
       "bezbrånnogo / bezbrånny",
@@ -171953,6 +174339,7 @@ exports[`adjective 35126 1`] = `
       "bezzaščitne",
     ],
   },
+  "short": "bezzaščitėn",
   "singular": {
     "acc": [
       "bezzaščitnogo / bezzaščitny",
@@ -172022,6 +174409,7 @@ exports[`adjective 35127 1`] = `
       "polovične",
     ],
   },
+  "short": "polovičėn",
   "singular": {
     "acc": [
       "polovičnogo / polovičny",
@@ -172091,6 +174479,7 @@ exports[`adjective 35129 1`] = `
       "geopolitične",
     ],
   },
+  "short": "geopolitičėn",
   "singular": {
     "acc": [
       "geopolitičnogo / geopolitičny",
@@ -172160,6 +174549,7 @@ exports[`adjective 35130 1`] = `
       "sakraľne",
     ],
   },
+  "short": "sakraľėn",
   "singular": {
     "acc": [
       "sakraľnogo / sakraľny",
@@ -172229,6 +174619,7 @@ exports[`adjective 35133 1`] = `
       "vȯzhodnoevropejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "vȯzhodnoevropejskogo / vȯzhodnoevropejsky",
@@ -172298,6 +174689,7 @@ exports[`adjective 35134 1`] = `
       "zapadnoevropejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "zapadnoevropejskogo / zapadnoevropejsky",
@@ -172367,6 +174759,7 @@ exports[`adjective 35135 1`] = `
       "sěvernoevropejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sěvernoevropejskogo / sěvernoevropejsky",
@@ -172436,6 +174829,7 @@ exports[`adjective 35136 1`] = `
       "južnoevropejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "južnoevropejskogo / južnoevropejsky",
@@ -172505,6 +174899,7 @@ exports[`adjective 35142 1`] = `
       "obsęžne",
     ],
   },
+  "short": "obsęžėn",
   "singular": {
     "acc": [
       "obsęžnogo / obsęžny",
@@ -172574,6 +174969,7 @@ exports[`adjective 35150 1`] = `
       "samodostatȯčne",
     ],
   },
+  "short": "samodostatȯčėn",
   "singular": {
     "acc": [
       "samodostatȯčnogo / samodostatȯčny",
@@ -172643,6 +175039,7 @@ exports[`adjective 35151 1`] = `
       "segdašnje",
     ],
   },
+  "short": "segdašėn",
   "singular": {
     "acc": [
       "segdašnjego / segdašnji",
@@ -172712,6 +175109,7 @@ exports[`adjective 35151-1 1`] = `
       "segdašne",
     ],
   },
+  "short": "segdašėn",
   "singular": {
     "acc": [
       "segdašnogo / segdašny",
@@ -172781,6 +175179,7 @@ exports[`adjective 35152 1`] = `
       "pradavne",
     ],
   },
+  "short": "pradavėn",
   "singular": {
     "acc": [
       "pradavnogo / pradavny",
@@ -172850,6 +175249,7 @@ exports[`adjective 35153 1`] = `
       "vsekake",
     ],
   },
+  "short": "vsekak",
   "singular": {
     "acc": [
       "vsekakogo / vsekaky",
@@ -172919,6 +175319,7 @@ exports[`adjective 35156 1`] = `
       "nepraktične",
     ],
   },
+  "short": "nepraktičėn",
   "singular": {
     "acc": [
       "nepraktičnogo / nepraktičny",
@@ -172988,6 +175389,7 @@ exports[`adjective 35158 1`] = `
       "dogovorne",
     ],
   },
+  "short": "dogovorėn",
   "singular": {
     "acc": [
       "dogovornogo / dogovorny",
@@ -173057,6 +175459,7 @@ exports[`adjective 35161 1`] = `
       "intuitivne",
     ],
   },
+  "short": "intuitivėn",
   "singular": {
     "acc": [
       "intuitivnogo / intuitivny",
@@ -173126,6 +175529,7 @@ exports[`adjective 35163 1`] = `
       "sentimentaľne",
     ],
   },
+  "short": "sentimentaľėn",
   "singular": {
     "acc": [
       "sentimentaľnogo / sentimentaľny",
@@ -173195,6 +175599,7 @@ exports[`adjective 35164 1`] = `
       "neoficiaľne",
     ],
   },
+  "short": "neoficiaľėn",
   "singular": {
     "acc": [
       "neoficiaľnogo / neoficiaľny",
@@ -173264,6 +175669,7 @@ exports[`adjective 35166 1`] = `
       "opcionaľne",
     ],
   },
+  "short": "opcionaľėn",
   "singular": {
     "acc": [
       "opcionaľnogo / opcionaľny",
@@ -173333,6 +175739,7 @@ exports[`adjective 35167 1`] = `
       "fakultativne",
     ],
   },
+  "short": "fakultativėn",
   "singular": {
     "acc": [
       "fakultativnogo / fakultativny",
@@ -173402,6 +175809,7 @@ exports[`adjective 35168 1`] = `
       "crkȯvne",
     ],
   },
+  "short": "crkȯvėn",
   "singular": {
     "acc": [
       "crkȯvnogo / crkȯvny",
@@ -173471,6 +175879,7 @@ exports[`adjective 35174 1`] = `
       "produktivne",
     ],
   },
+  "short": "produktivėn",
   "singular": {
     "acc": [
       "produktivnogo / produktivny",
@@ -173540,6 +175949,7 @@ exports[`adjective 35179 1`] = `
       "promysľne",
     ],
   },
+  "short": "promysľėn",
   "singular": {
     "acc": [
       "promysľnogo / promysľny",
@@ -173609,6 +176019,7 @@ exports[`adjective 35180 1`] = `
       "industriaľne",
     ],
   },
+  "short": "industriaľėn",
   "singular": {
     "acc": [
       "industriaľnogo / industriaľny",
@@ -173678,6 +176089,7 @@ exports[`adjective 35189 1`] = `
       "higienične",
     ],
   },
+  "short": "higieničėn",
   "singular": {
     "acc": [
       "higieničnogo / higieničny",
@@ -173747,6 +176159,7 @@ exports[`adjective 35194 1`] = `
       "keramične",
     ],
   },
+  "short": "keramičėn",
   "singular": {
     "acc": [
       "keramičnogo / keramičny",
@@ -173816,6 +176229,7 @@ exports[`adjective 35195 1`] = `
       "kulinarne",
     ],
   },
+  "short": "kulinarėn",
   "singular": {
     "acc": [
       "kulinarnogo / kulinarny",
@@ -173885,6 +176299,7 @@ exports[`adjective 35196 1`] = `
       "kuhaŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kuhaŕskogo / kuhaŕsky",
@@ -173954,6 +176369,7 @@ exports[`adjective 35198 1`] = `
       "primitivne",
     ],
   },
+  "short": "primitivėn",
   "singular": {
     "acc": [
       "primitivnogo / primitivny",
@@ -174023,6 +176439,7 @@ exports[`adjective 35202 1`] = `
       "nepravdopodobne",
     ],
   },
+  "short": "nepravdopodobėn",
   "singular": {
     "acc": [
       "nepravdopodobnogo / nepravdopodobny",
@@ -174092,6 +176509,7 @@ exports[`adjective 35204 1`] = `
       "udiviteljne",
     ],
   },
+  "short": "udiviteljėn",
   "singular": {
     "acc": [
       "udiviteljnogo / udiviteljny",
@@ -174161,6 +176579,7 @@ exports[`adjective 35206 1`] = `
       "obiľne",
     ],
   },
+  "short": "obiľėn",
   "singular": {
     "acc": [
       "obiľnogo / obiľny",
@@ -174230,6 +176649,7 @@ exports[`adjective 35208 1`] = `
       "elementarne",
     ],
   },
+  "short": "elementarėn",
   "singular": {
     "acc": [
       "elementarnogo / elementarny",
@@ -174299,6 +176719,7 @@ exports[`adjective 35209 1`] = `
       "rudimentarne",
     ],
   },
+  "short": "rudimentarėn",
   "singular": {
     "acc": [
       "rudimentarnogo / rudimentarny",
@@ -174368,6 +176789,7 @@ exports[`adjective 35220 1`] = `
       "sråvniteljne",
     ],
   },
+  "short": "sråvniteljėn",
   "singular": {
     "acc": [
       "sråvniteljnogo / sråvniteljny",
@@ -174437,6 +176859,7 @@ exports[`adjective 35221 1`] = `
       "vključiteljne",
     ],
   },
+  "short": "vključiteljėn",
   "singular": {
     "acc": [
       "vključiteljnogo / vključiteljny",
@@ -174506,6 +176929,7 @@ exports[`adjective 35232 1`] = `
       "ustavne",
     ],
   },
+  "short": "ustavėn",
   "singular": {
     "acc": [
       "ustavnogo / ustavny",
@@ -174575,6 +176999,7 @@ exports[`adjective 35233 1`] = `
       "konstitucijne",
     ],
   },
+  "short": "konstitucijėn",
   "singular": {
     "acc": [
       "konstitucijnogo / konstitucijny",
@@ -174644,6 +177069,7 @@ exports[`adjective 35234 1`] = `
       "krymske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "krymskogo / krymsky",
@@ -174713,6 +177139,7 @@ exports[`adjective 35241 1`] = `
       "prěvažajųće",
     ],
   },
+  "short": "prěvažajųć",
   "singular": {
     "acc": [
       "prěvažajųćego / prěvažajųći",
@@ -174782,6 +177209,7 @@ exports[`adjective 35256 1`] = `
       "nesȯvŕšene",
     ],
   },
+  "short": "nesȯvŕšen",
   "singular": {
     "acc": [
       "nesȯvŕšenogo / nesȯvŕšeny",
@@ -174851,6 +177279,7 @@ exports[`adjective 35263 1`] = `
       "odnositeljne",
     ],
   },
+  "short": "odnositeljėn",
   "singular": {
     "acc": [
       "odnositeljnogo / odnositeljny",
@@ -174920,6 +177349,7 @@ exports[`adjective 35264 1`] = `
       "nejasne",
     ],
   },
+  "short": "nejasėn",
   "singular": {
     "acc": [
       "nejasnogo / nejasny",
@@ -174989,6 +177419,7 @@ exports[`adjective 35266 1`] = `
       "včerašnje",
     ],
   },
+  "short": "včerašėn",
   "singular": {
     "acc": [
       "včerašnjego / včerašnji",
@@ -175058,6 +177489,7 @@ exports[`adjective 35266-1 1`] = `
       "včerašne",
     ],
   },
+  "short": "včerašėn",
   "singular": {
     "acc": [
       "včerašnogo / včerašny",
@@ -175127,6 +177559,7 @@ exports[`adjective 35267 1`] = `
       "ekologične",
     ],
   },
+  "short": "ekologičėn",
   "singular": {
     "acc": [
       "ekologičnogo / ekologičny",
@@ -175196,6 +177629,7 @@ exports[`adjective 35273 1`] = `
       "značime",
     ],
   },
+  "short": "značim",
   "singular": {
     "acc": [
       "značimogo / značimy",
@@ -175265,6 +177699,7 @@ exports[`adjective 35276 1`] = `
       "nestabiľne",
     ],
   },
+  "short": "nestabiľėn",
   "singular": {
     "acc": [
       "nestabiľnogo / nestabiľny",
@@ -175334,6 +177769,7 @@ exports[`adjective 35278 1`] = `
       "internetne",
     ],
   },
+  "short": "internetėn",
   "singular": {
     "acc": [
       "internetnogo / internetny",
@@ -175403,6 +177839,7 @@ exports[`adjective 35279 1`] = `
       "demografične",
     ],
   },
+  "short": "demografičėn",
   "singular": {
     "acc": [
       "demografičnogo / demografičny",
@@ -175472,6 +177909,7 @@ exports[`adjective 35281 1`] = `
       "arhivne",
     ],
   },
+  "short": "arhivėn",
   "singular": {
     "acc": [
       "arhivnogo / arhivny",
@@ -175541,6 +177979,7 @@ exports[`adjective 35282 1`] = `
       "kråtkotrajne",
     ],
   },
+  "short": "kråtkotrajėn",
   "singular": {
     "acc": [
       "kråtkotrajnogo / kråtkotrajny",
@@ -175610,6 +178049,7 @@ exports[`adjective 35284 1`] = `
       "triviaľne",
     ],
   },
+  "short": "triviaľėn",
   "singular": {
     "acc": [
       "triviaľnogo / triviaľny",
@@ -175679,6 +178119,7 @@ exports[`adjective 35289 1`] = `
       "dovŕšene",
     ],
   },
+  "short": "dovŕšen",
   "singular": {
     "acc": [
       "dovŕšenogo / dovŕšeny",
@@ -175748,6 +178189,7 @@ exports[`adjective 35290 1`] = `
       "nedovŕšene",
     ],
   },
+  "short": "nedovŕšen",
   "singular": {
     "acc": [
       "nedovŕšenogo / nedovŕšeny",
@@ -175817,6 +178259,7 @@ exports[`adjective 35293 1`] = `
       "binarne",
     ],
   },
+  "short": "binarėn",
   "singular": {
     "acc": [
       "binarnogo / binarny",
@@ -175886,6 +178329,7 @@ exports[`adjective 35303 1`] = `
       "funkcionaľne",
     ],
   },
+  "short": "funkcionaľėn",
   "singular": {
     "acc": [
       "funkcionaľnogo / funkcionaľny",
@@ -175955,6 +178399,7 @@ exports[`adjective 35305 1`] = `
       "mlådežne",
     ],
   },
+  "short": "mlådežėn",
   "singular": {
     "acc": [
       "mlådežnogo / mlådežny",
@@ -176024,6 +178469,7 @@ exports[`adjective 35306 1`] = `
       "opisateljne",
     ],
   },
+  "short": "opisateljėn",
   "singular": {
     "acc": [
       "opisateljnogo / opisateljny",
@@ -176093,6 +178539,7 @@ exports[`adjective 35308 1`] = `
       "dȯlgotrajne",
     ],
   },
+  "short": "dȯlgotrajėn",
   "singular": {
     "acc": [
       "dȯlgotrajnogo / dȯlgotrajny",
@@ -176162,6 +178609,7 @@ exports[`adjective 35315 1`] = `
       "papirne",
     ],
   },
+  "short": "papirėn",
   "singular": {
     "acc": [
       "papirnogo / papirny",
@@ -176231,6 +178679,7 @@ exports[`adjective 35320 1`] = `
       "primarne",
     ],
   },
+  "short": "primarėn",
   "singular": {
     "acc": [
       "primarnogo / primarny",
@@ -176300,6 +178749,7 @@ exports[`adjective 35321 1`] = `
       "sekundarne",
     ],
   },
+  "short": "sekundarėn",
   "singular": {
     "acc": [
       "sekundarnogo / sekundarny",
@@ -176369,6 +178819,7 @@ exports[`adjective 35323 1`] = `
       "kvantitativne",
     ],
   },
+  "short": "kvantitativėn",
   "singular": {
     "acc": [
       "kvantitativnogo / kvantitativny",
@@ -176438,6 +178889,7 @@ exports[`adjective 35324 1`] = `
       "neosporime",
     ],
   },
+  "short": "neosporim",
   "singular": {
     "acc": [
       "neosporimogo / neosporimy",
@@ -176507,6 +178959,7 @@ exports[`adjective 35336 1`] = `
       "anahronične",
     ],
   },
+  "short": "anahroničėn",
   "singular": {
     "acc": [
       "anahroničnogo / anahroničny",
@@ -176576,6 +179029,7 @@ exports[`adjective 35338 1`] = `
       "avstrijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "avstrijskogo / avstrijsky",
@@ -176645,6 +179099,7 @@ exports[`adjective 35340 1`] = `
       "balkanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "balkanskogo / balkansky",
@@ -176714,6 +179169,7 @@ exports[`adjective 35341 1`] = `
       "bizantijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bizantijskogo / bizantijsky",
@@ -176783,6 +179239,7 @@ exports[`adjective 35345 1`] = `
       "osmanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "osmanskogo / osmansky",
@@ -176852,6 +179309,7 @@ exports[`adjective 35361 1`] = `
       "poluvojenne",
     ],
   },
+  "short": "poluvojenėn",
   "singular": {
     "acc": [
       "poluvojennogo / poluvojenny",
@@ -176921,6 +179379,7 @@ exports[`adjective 35375 1`] = `
       "kompatibiľne",
     ],
   },
+  "short": "kompatibiľėn",
   "singular": {
     "acc": [
       "kompatibiľnogo / kompatibiľny",
@@ -176990,6 +179449,7 @@ exports[`adjective 35377 1`] = `
       "sųměstime",
     ],
   },
+  "short": "sųměstim",
   "singular": {
     "acc": [
       "sųměstimogo / sųměstimy",
@@ -177059,6 +179519,7 @@ exports[`adjective 35384 1`] = `
       "umŕle",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "umŕlogo / umŕly",
@@ -177128,6 +179589,7 @@ exports[`adjective 35384-1 1`] = `
       "umrěle",
     ],
   },
+  "short": "umrěl",
   "singular": {
     "acc": [
       "umrělogo / umrěly",
@@ -177197,6 +179659,7 @@ exports[`adjective 35385 1`] = `
       "pokojne",
     ],
   },
+  "short": "pokojėn",
   "singular": {
     "acc": [
       "pokojnogo / pokojny",
@@ -177266,6 +179729,7 @@ exports[`adjective 35388 1`] = `
       "nejestvujųće",
     ],
   },
+  "short": "nejestvujųć",
   "singular": {
     "acc": [
       "nejestvujųćego / nejestvujųći",
@@ -177335,6 +179799,7 @@ exports[`adjective 35389 1`] = `
       "nedějųće",
     ],
   },
+  "short": "nedějųć",
   "singular": {
     "acc": [
       "nedějųćego / nedějųći",
@@ -177404,6 +179869,7 @@ exports[`adjective 35391 1`] = `
       "faktične",
     ],
   },
+  "short": "faktičėn",
   "singular": {
     "acc": [
       "faktičnogo / faktičny",
@@ -177473,6 +179939,7 @@ exports[`adjective 35392 1`] = `
       "vladne",
     ],
   },
+  "short": "vladėn",
   "singular": {
     "acc": [
       "vladnogo / vladny",
@@ -177542,6 +180009,7 @@ exports[`adjective 35396 1`] = `
       "nadnacionaľne",
     ],
   },
+  "short": "nadnacionaľėn",
   "singular": {
     "acc": [
       "nadnacionaľnogo / nadnacionaľny",
@@ -177611,6 +180079,7 @@ exports[`adjective 35398 1`] = `
       "hronologične",
     ],
   },
+  "short": "hronologičėn",
   "singular": {
     "acc": [
       "hronologičnogo / hronologičny",
@@ -177680,6 +180149,7 @@ exports[`adjective 35399 1`] = `
       "poštne",
     ],
   },
+  "short": "poštėn",
   "singular": {
     "acc": [
       "poštnogo / poštny",
@@ -177749,6 +180219,7 @@ exports[`adjective 35404 1`] = `
       "zaljubjene",
     ],
   },
+  "short": "zaljubjen",
   "singular": {
     "acc": [
       "zaljubjenogo / zaljubjeny",
@@ -177818,6 +180289,7 @@ exports[`adjective 35410 1`] = `
       "bezkarne",
     ],
   },
+  "short": "bezkarėn",
   "singular": {
     "acc": [
       "bezkarnogo / bezkarny",
@@ -177887,6 +180359,7 @@ exports[`adjective 35413 1`] = `
       "nekaznive",
     ],
   },
+  "short": "nekazniv",
   "singular": {
     "acc": [
       "nekaznivogo / nekaznivy",
@@ -177956,6 +180429,7 @@ exports[`adjective 35414 1`] = `
       "opravnjene",
     ],
   },
+  "short": "opravnjen",
   "singular": {
     "acc": [
       "opravnjenogo / opravnjeny",
@@ -178025,6 +180499,7 @@ exports[`adjective 35446 1`] = `
       "mečtateljne",
     ],
   },
+  "short": "mečtateljėn",
   "singular": {
     "acc": [
       "mečtateljnogo / mečtateljny",
@@ -178094,6 +180569,7 @@ exports[`adjective 35454 1`] = `
       "strastne",
     ],
   },
+  "short": "strastėn",
   "singular": {
     "acc": [
       "strastnogo / strastny",
@@ -178163,6 +180639,7 @@ exports[`adjective 35456 1`] = `
       "hriple",
     ],
   },
+  "short": "hripl",
   "singular": {
     "acc": [
       "hriplogo / hriply",
@@ -178232,6 +180709,7 @@ exports[`adjective 35462 1`] = `
       "patriotične",
     ],
   },
+  "short": "patriotičėn",
   "singular": {
     "acc": [
       "patriotičnogo / patriotičny",
@@ -178301,6 +180779,7 @@ exports[`adjective 35464 1`] = `
       "sporadične",
     ],
   },
+  "short": "sporadičėn",
   "singular": {
     "acc": [
       "sporadičnogo / sporadičny",
@@ -178370,6 +180849,7 @@ exports[`adjective 35466 1`] = `
       "provinciaľne",
     ],
   },
+  "short": "provinciaľėn",
   "singular": {
     "acc": [
       "provinciaľnogo / provinciaľny",
@@ -178439,6 +180919,7 @@ exports[`adjective 35467 1`] = `
       "skameněle",
     ],
   },
+  "short": "skameněl",
   "singular": {
     "acc": [
       "skamenělogo / skameněly",
@@ -178508,6 +180989,7 @@ exports[`adjective 35471 1`] = `
       "poželane",
     ],
   },
+  "short": "poželan",
   "singular": {
     "acc": [
       "poželanogo / poželany",
@@ -178577,6 +181059,7 @@ exports[`adjective 35504 1`] = `
       "legitimne",
     ],
   },
+  "short": "legitimėn",
   "singular": {
     "acc": [
       "legitimnogo / legitimny",
@@ -178646,6 +181129,7 @@ exports[`adjective 35511 1`] = `
       "neizgovorlive",
     ],
   },
+  "short": "neizgovorliv",
   "singular": {
     "acc": [
       "neizgovorlivogo / neizgovorlivy",
@@ -178715,6 +181199,7 @@ exports[`adjective 35520 1`] = `
       "republikanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "republikanskogo / republikansky",
@@ -178784,6 +181269,7 @@ exports[`adjective 35525 1`] = `
       "prěměnne",
     ],
   },
+  "short": "prěměnėn",
   "singular": {
     "acc": [
       "prěměnnogo / prěměnny",
@@ -178853,6 +181339,7 @@ exports[`adjective 35527 1`] = `
       "korporativne",
     ],
   },
+  "short": "korporativėn",
   "singular": {
     "acc": [
       "korporativnogo / korporativny",
@@ -178922,6 +181409,7 @@ exports[`adjective 35551 1`] = `
       "prividne",
     ],
   },
+  "short": "prividėn",
   "singular": {
     "acc": [
       "prividnogo / prividny",
@@ -178991,6 +181479,7 @@ exports[`adjective 35552 1`] = `
       "proniklive",
     ],
   },
+  "short": "pronikliv",
   "singular": {
     "acc": [
       "proniklivogo / proniklivy",
@@ -179060,6 +181549,7 @@ exports[`adjective 35554 1`] = `
       "genetične",
     ],
   },
+  "short": "genetičėn",
   "singular": {
     "acc": [
       "genetičnogo / genetičny",
@@ -179129,6 +181619,7 @@ exports[`adjective 35556 1`] = `
       "sȯstavne",
     ],
   },
+  "short": "sȯstavėn",
   "singular": {
     "acc": [
       "sȯstavnogo / sȯstavny",
@@ -179198,6 +181689,7 @@ exports[`adjective 35559 1`] = `
       "islamske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "islamskogo / islamsky",
@@ -179267,6 +181759,7 @@ exports[`adjective 35561 1`] = `
       "ranime",
     ],
   },
+  "short": "ranim",
   "singular": {
     "acc": [
       "ranimogo / ranimy",
@@ -179336,6 +181829,7 @@ exports[`adjective 35588 1`] = `
       "pikantne",
     ],
   },
+  "short": "pikantėn",
   "singular": {
     "acc": [
       "pikantnogo / pikantny",
@@ -179405,6 +181899,7 @@ exports[`adjective 35596 1`] = `
       "žiťjesposobne",
     ],
   },
+  "short": "žiťjesposobėn",
   "singular": {
     "acc": [
       "žiťjesposobnogo / žiťjesposobny",
@@ -179474,6 +181969,7 @@ exports[`adjective 35597 1`] = `
       "kategorične",
     ],
   },
+  "short": "kategoričėn",
   "singular": {
     "acc": [
       "kategoričnogo / kategoričny",
@@ -179543,6 +182039,7 @@ exports[`adjective 35599 1`] = `
       "blågozvučne",
     ],
   },
+  "short": "blågozvučėn",
   "singular": {
     "acc": [
       "blågozvučnogo / blågozvučny",
@@ -179612,6 +182109,7 @@ exports[`adjective 35605 1`] = `
       "syte",
     ],
   },
+  "short": "syt",
   "singular": {
     "acc": [
       "sytogo / syty",
@@ -179681,6 +182179,7 @@ exports[`adjective 35606 1`] = `
       "sȯvěstne",
     ],
   },
+  "short": "sȯvěstėn",
   "singular": {
     "acc": [
       "sȯvěstnogo / sȯvěstny",
@@ -179750,6 +182249,7 @@ exports[`adjective 35607 1`] = `
       "skrupulozne",
     ],
   },
+  "short": "skrupulozėn",
   "singular": {
     "acc": [
       "skrupuloznogo / skrupulozny",
@@ -179819,6 +182319,7 @@ exports[`adjective 35611 1`] = `
       "prědavničske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "prědavničskogo / prědavničsky",
@@ -179888,6 +182389,7 @@ exports[`adjective 35618 1`] = `
       "nesčisljene",
     ],
   },
+  "short": "nesčisljen",
   "singular": {
     "acc": [
       "nesčisljenogo / nesčisljeny",
@@ -179957,6 +182459,7 @@ exports[`adjective 35620 1`] = `
       "vseprisųtne",
     ],
   },
+  "short": "vseprisųtėn",
   "singular": {
     "acc": [
       "vseprisųtnogo / vseprisųtny",
@@ -180026,6 +182529,7 @@ exports[`adjective 35635 1`] = `
       "arogantne",
     ],
   },
+  "short": "arogantėn",
   "singular": {
     "acc": [
       "arogantnogo / arogantny",
@@ -180095,6 +182599,7 @@ exports[`adjective 35636 1`] = `
       "nesposobne",
     ],
   },
+  "short": "nesposobėn",
   "singular": {
     "acc": [
       "nesposobnogo / nesposobny",
@@ -180164,6 +182669,7 @@ exports[`adjective 35638 1`] = `
       "neuměstne",
     ],
   },
+  "short": "neuměstėn",
   "singular": {
     "acc": [
       "neuměstnogo / neuměstny",
@@ -180233,6 +182739,7 @@ exports[`adjective 35640 1`] = `
       "optimaľne",
     ],
   },
+  "short": "optimaľėn",
   "singular": {
     "acc": [
       "optimaľnogo / optimaľny",
@@ -180302,6 +182809,7 @@ exports[`adjective 35641 1`] = `
       "nepoznajeme",
     ],
   },
+  "short": "nepoznajem",
   "singular": {
     "acc": [
       "nepoznajemogo / nepoznajemy",
@@ -180371,6 +182879,7 @@ exports[`adjective 35659 1`] = `
       "arhitekturne",
     ],
   },
+  "short": "arhitekturėn",
   "singular": {
     "acc": [
       "arhitekturnogo / arhitekturny",
@@ -180437,6 +182946,7 @@ exports[`adjective 35660 1`] = `
       "boljše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "boljšego / boljši",
@@ -180500,6 +183010,7 @@ exports[`adjective 35661 1`] = `
       "najboljše",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "najboljšego / najboljši",
@@ -180569,6 +183080,7 @@ exports[`adjective 35662 1`] = `
       "kyjevske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kyjevskogo / kyjevsky",
@@ -180638,6 +183150,7 @@ exports[`adjective 35663 1`] = `
       "kornijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kornijskogo / kornijsky",
@@ -180707,6 +183220,7 @@ exports[`adjective 35666 1`] = `
       "nedoslědne",
     ],
   },
+  "short": "nedoslědėn",
   "singular": {
     "acc": [
       "nedoslědnogo / nedoslědny",
@@ -180776,6 +183290,7 @@ exports[`adjective 35673 1`] = `
       "energetične",
     ],
   },
+  "short": "energetičėn",
   "singular": {
     "acc": [
       "energetičnogo / energetičny",
@@ -180845,6 +183360,7 @@ exports[`adjective 35674 1`] = `
       "energične",
     ],
   },
+  "short": "energičėn",
   "singular": {
     "acc": [
       "energičnogo / energičny",
@@ -180914,6 +183430,7 @@ exports[`adjective 35675 1`] = `
       "nuklearne",
     ],
   },
+  "short": "nuklearėn",
   "singular": {
     "acc": [
       "nuklearnogo / nuklearny",
@@ -180983,6 +183500,7 @@ exports[`adjective 35678 1`] = `
       "glagolične",
     ],
   },
+  "short": "glagoličėn",
   "singular": {
     "acc": [
       "glagoličnogo / glagoličny",
@@ -181052,6 +183570,7 @@ exports[`adjective 35678-1 1`] = `
       "glagoľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "glagoľskogo / glagoľsky",
@@ -181121,6 +183640,7 @@ exports[`adjective 35683 1`] = `
       "ekumenične",
     ],
   },
+  "short": "ekumeničėn",
   "singular": {
     "acc": [
       "ekumeničnogo / ekumeničny",
@@ -181190,6 +183710,7 @@ exports[`adjective 35684 1`] = `
       "grafične",
     ],
   },
+  "short": "grafičėn",
   "singular": {
     "acc": [
       "grafičnogo / grafičny",
@@ -181259,6 +183780,7 @@ exports[`adjective 35687 1`] = `
       "kaligrafične",
     ],
   },
+  "short": "kaligrafičėn",
   "singular": {
     "acc": [
       "kaligrafičnogo / kaligrafičny",
@@ -181328,6 +183850,7 @@ exports[`adjective 35690 1`] = `
       "neoddělime",
     ],
   },
+  "short": "neoddělim",
   "singular": {
     "acc": [
       "neoddělimogo / neoddělimy",
@@ -181397,6 +183920,7 @@ exports[`adjective 35701 1`] = `
       "vųglate",
     ],
   },
+  "short": "vųglat",
   "singular": {
     "acc": [
       "vųglatogo / vųglaty",
@@ -181466,6 +183990,7 @@ exports[`adjective 35711 1`] = `
       "linearne",
     ],
   },
+  "short": "linearėn",
   "singular": {
     "acc": [
       "linearnogo / linearny",
@@ -181535,6 +184060,7 @@ exports[`adjective 35713 1`] = `
       "trakijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "trakijskogo / trakijsky",
@@ -181604,6 +184130,7 @@ exports[`adjective 35715 1`] = `
       "neolitične",
     ],
   },
+  "short": "neolitičėn",
   "singular": {
     "acc": [
       "neolitičnogo / neolitičny",
@@ -181673,6 +184200,7 @@ exports[`adjective 35722 1`] = `
       "skandinavske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "skandinavskogo / skandinavsky",
@@ -181742,6 +184270,7 @@ exports[`adjective 35724 1`] = `
       "bavarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "bavarskogo / bavarsky",
@@ -181811,6 +184340,7 @@ exports[`adjective 35731 1`] = `
       "pivovarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pivovarskogo / pivovarsky",
@@ -181880,6 +184410,7 @@ exports[`adjective 35741 1`] = `
       "holandske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "holandskogo / holandsky",
@@ -181949,6 +184480,7 @@ exports[`adjective 35744 1`] = `
       "humanistične",
     ],
   },
+  "short": "humanističėn",
   "singular": {
     "acc": [
       "humanističnogo / humanističny",
@@ -182018,6 +184550,7 @@ exports[`adjective 35745 1`] = `
       "međukulturne",
     ],
   },
+  "short": "međukulturėn",
   "singular": {
     "acc": [
       "međukulturnogo / međukulturny",
@@ -182087,6 +184620,7 @@ exports[`adjective 35749 1`] = `
       "civilizovane",
     ],
   },
+  "short": "civilizovan",
   "singular": {
     "acc": [
       "civilizovanogo / civilizovany",
@@ -182156,6 +184690,7 @@ exports[`adjective 35751 1`] = `
       "fašistične",
     ],
   },
+  "short": "fašističėn",
   "singular": {
     "acc": [
       "fašističnogo / fašističny",
@@ -182225,6 +184760,7 @@ exports[`adjective 35753 1`] = `
       "inovativne",
     ],
   },
+  "short": "inovativėn",
   "singular": {
     "acc": [
       "inovativnogo / inovativny",
@@ -182294,6 +184830,7 @@ exports[`adjective 35756 1`] = `
       "infračrvene",
     ],
   },
+  "short": "infračrven",
   "singular": {
     "acc": [
       "infračrvenogo / infračrveny",
@@ -182363,6 +184900,7 @@ exports[`adjective 35757 1`] = `
       "ultrafioletove",
     ],
   },
+  "short": "ultrafioletov",
   "singular": {
     "acc": [
       "ultrafioletovogo / ultrafioletovy",
@@ -182432,6 +184970,7 @@ exports[`adjective 35761 1`] = `
       "sferične",
     ],
   },
+  "short": "sferičėn",
   "singular": {
     "acc": [
       "sferičnogo / sferičny",
@@ -182501,6 +185040,7 @@ exports[`adjective 35762 1`] = `
       "vnězemne",
     ],
   },
+  "short": "vnězemėn",
   "singular": {
     "acc": [
       "vnězemnogo / vnězemny",
@@ -182570,6 +185110,7 @@ exports[`adjective 35779 1`] = `
       "prigranične",
     ],
   },
+  "short": "prigraničėn",
   "singular": {
     "acc": [
       "prigraničnogo / prigraničny",
@@ -182639,6 +185180,7 @@ exports[`adjective 35780 1`] = `
       "frankske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "frankskogo / franksky",
@@ -182708,6 +185250,7 @@ exports[`adjective 35788 1`] = `
       "atraktivne",
     ],
   },
+  "short": "atraktivėn",
   "singular": {
     "acc": [
       "atraktivnogo / atraktivny",
@@ -182777,6 +185320,7 @@ exports[`adjective 35789 1`] = `
       "egzotične",
     ],
   },
+  "short": "egzotičėn",
   "singular": {
     "acc": [
       "egzotičnogo / egzotičny",
@@ -182846,6 +185390,7 @@ exports[`adjective 35792 1`] = `
       "folklorne",
     ],
   },
+  "short": "folklorėn",
   "singular": {
     "acc": [
       "folklornogo / folklorny",
@@ -182915,6 +185460,7 @@ exports[`adjective 35796 1`] = `
       "luteranske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "luteranskogo / luteransky",
@@ -182984,6 +185530,7 @@ exports[`adjective 35797 1`] = `
       "multikulturne",
     ],
   },
+  "short": "multikulturėn",
   "singular": {
     "acc": [
       "multikulturnogo / multikulturny",
@@ -183053,6 +185600,7 @@ exports[`adjective 35799 1`] = `
       "muslimanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "muslimanskogo / muslimansky",
@@ -183122,6 +185670,7 @@ exports[`adjective 35806 1`] = `
       "zemske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "zemskogo / zemsky",
@@ -183191,6 +185740,7 @@ exports[`adjective 35810 1`] = `
       "intrigujųće",
     ],
   },
+  "short": "intrigujųć",
   "singular": {
     "acc": [
       "intrigujųćego / intrigujųći",
@@ -183260,6 +185810,7 @@ exports[`adjective 35811 1`] = `
       "periodične",
     ],
   },
+  "short": "periodičėn",
   "singular": {
     "acc": [
       "periodičnogo / periodičny",
@@ -183329,6 +185880,7 @@ exports[`adjective 35813 1`] = `
       "geriatrične",
     ],
   },
+  "short": "geriatričėn",
   "singular": {
     "acc": [
       "geriatričnogo / geriatričny",
@@ -183398,6 +185950,7 @@ exports[`adjective 35815 1`] = `
       "imunne",
     ],
   },
+  "short": "imunėn",
   "singular": {
     "acc": [
       "imunnogo / imunny",
@@ -183467,6 +186020,7 @@ exports[`adjective 35820 1`] = `
       "preventivne",
     ],
   },
+  "short": "preventivėn",
   "singular": {
     "acc": [
       "preventivnogo / preventivny",
@@ -183536,6 +186090,7 @@ exports[`adjective 35838 1`] = `
       "koptske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "koptskogo / koptsky",
@@ -183605,6 +186160,7 @@ exports[`adjective 35840 1`] = `
       "moravske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "moravskogo / moravsky",
@@ -183674,6 +186230,7 @@ exports[`adjective 35841 1`] = `
       "numerične",
     ],
   },
+  "short": "numeričėn",
   "singular": {
     "acc": [
       "numeričnogo / numeričny",
@@ -183743,6 +186300,7 @@ exports[`adjective 35845 1`] = `
       "steriľne",
     ],
   },
+  "short": "steriľėn",
   "singular": {
     "acc": [
       "steriľnogo / steriľny",
@@ -183812,6 +186370,7 @@ exports[`adjective 35851 1`] = `
       "sdešnje",
     ],
   },
+  "short": "sdešėn",
   "singular": {
     "acc": [
       "sdešnjego / sdešnji",
@@ -183881,6 +186440,7 @@ exports[`adjective 35851-1 1`] = `
       "sdešne",
     ],
   },
+  "short": "sdešėn",
   "singular": {
     "acc": [
       "sdešnogo / sdešny",
@@ -183950,6 +186510,7 @@ exports[`adjective 35853 1`] = `
       "zanepokojene",
     ],
   },
+  "short": "zanepokojen",
   "singular": {
     "acc": [
       "zanepokojenogo / zanepokojeny",
@@ -184019,6 +186580,7 @@ exports[`adjective 35855 1`] = `
       "sarkastične",
     ],
   },
+  "short": "sarkastičėn",
   "singular": {
     "acc": [
       "sarkastičnogo / sarkastičny",
@@ -184088,6 +186650,7 @@ exports[`adjective 35863 1`] = `
       "neostråžne",
     ],
   },
+  "short": "neostråžėn",
   "singular": {
     "acc": [
       "neostråžnogo / neostråžny",
@@ -184157,6 +186720,7 @@ exports[`adjective 35879 1`] = `
       "međugrådne",
     ],
   },
+  "short": "međugrådėn",
   "singular": {
     "acc": [
       "međugrådnogo / međugrådny",
@@ -184226,6 +186790,7 @@ exports[`adjective 35881 1`] = `
       "neprivykle",
     ],
   },
+  "short": "neprivykl",
   "singular": {
     "acc": [
       "neprivyklogo / neprivykly",
@@ -184295,6 +186860,7 @@ exports[`adjective 35885 1`] = `
       "obvęzne",
     ],
   },
+  "short": "obvęzėn",
   "singular": {
     "acc": [
       "obvęznogo / obvęzny",
@@ -184364,6 +186930,7 @@ exports[`adjective 35894 1`] = `
       "episkopaľne",
     ],
   },
+  "short": "episkopaľėn",
   "singular": {
     "acc": [
       "episkopaľnogo / episkopaľny",
@@ -184433,6 +187000,7 @@ exports[`adjective 35901 1`] = `
       "persijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "persijskogo / persijsky",
@@ -184502,6 +187070,7 @@ exports[`adjective 35908 1`] = `
       "dalmatinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "dalmatinskogo / dalmatinsky",
@@ -184571,6 +187140,7 @@ exports[`adjective 35914 1`] = `
       "kanonične",
     ],
   },
+  "short": "kanoničėn",
   "singular": {
     "acc": [
       "kanoničnogo / kanoničny",
@@ -184640,6 +187210,7 @@ exports[`adjective 35916 1`] = `
       "neefektivne",
     ],
   },
+  "short": "neefektivėn",
   "singular": {
     "acc": [
       "neefektivnogo / neefektivny",
@@ -184709,6 +187280,7 @@ exports[`adjective 35919 1`] = `
       "epičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "epičskogo / epičsky",
@@ -184778,6 +187350,7 @@ exports[`adjective 35920 1`] = `
       "legendarne",
     ],
   },
+  "short": "legendarėn",
   "singular": {
     "acc": [
       "legendarnogo / legendarny",
@@ -184847,6 +187420,7 @@ exports[`adjective 35925 1`] = `
       "spekulativne",
     ],
   },
+  "short": "spekulativėn",
   "singular": {
     "acc": [
       "spekulativnogo / spekulativny",
@@ -184916,6 +187490,7 @@ exports[`adjective 35926 1`] = `
       "gotske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gotskogo / gotsky",
@@ -184985,6 +187560,7 @@ exports[`adjective 35927 1`] = `
       "gotičske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "gotičskogo / gotičsky",
@@ -185054,6 +187630,7 @@ exports[`adjective 35930 1`] = `
       "obrazovateljne",
     ],
   },
+  "short": "obrazovateljėn",
   "singular": {
     "acc": [
       "obrazovateljnogo / obrazovateljny",
@@ -185123,6 +187700,7 @@ exports[`adjective 35937 1`] = `
       "finitne",
     ],
   },
+  "short": "finitėn",
   "singular": {
     "acc": [
       "finitnogo / finitny",
@@ -185192,6 +187770,7 @@ exports[`adjective 35938 1`] = `
       "odgovarjajųće",
     ],
   },
+  "short": "odgovarjajųć",
   "singular": {
     "acc": [
       "odgovarjajųćego / odgovarjajųći",
@@ -185261,6 +187840,7 @@ exports[`adjective 35940 1`] = `
       "caŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "caŕskogo / caŕsky",
@@ -185330,6 +187910,7 @@ exports[`adjective 35942 1`] = `
       "dialektične",
     ],
   },
+  "short": "dialektičėn",
   "singular": {
     "acc": [
       "dialektičnogo / dialektičny",
@@ -185399,6 +187980,7 @@ exports[`adjective 35943 1`] = `
       "diahronične",
     ],
   },
+  "short": "diahroničėn",
   "singular": {
     "acc": [
       "diahroničnogo / diahroničny",
@@ -185468,6 +188050,7 @@ exports[`adjective 35947 1`] = `
       "melodične",
     ],
   },
+  "short": "melodičėn",
   "singular": {
     "acc": [
       "melodičnogo / melodičny",
@@ -185537,6 +188120,7 @@ exports[`adjective 35955 1`] = `
       "nedŕžavne",
     ],
   },
+  "short": "nedŕžavėn",
   "singular": {
     "acc": [
       "nedŕžavnogo / nedŕžavny",
@@ -185606,6 +188190,7 @@ exports[`adjective 35956 1`] = `
       "kubične",
     ],
   },
+  "short": "kubičėn",
   "singular": {
     "acc": [
       "kubičnogo / kubičny",
@@ -185675,6 +188260,7 @@ exports[`adjective 35964 1`] = `
       "kompetentne",
     ],
   },
+  "short": "kompetentėn",
   "singular": {
     "acc": [
       "kompetentnogo / kompetentny",
@@ -185744,6 +188330,7 @@ exports[`adjective 35973 1`] = `
       "tipologične",
     ],
   },
+  "short": "tipologičėn",
   "singular": {
     "acc": [
       "tipologičnogo / tipologičny",
@@ -185779,66 +188366,67 @@ exports[`adjective 35974 1`] = `
 {
   "comparison": {
     "comparative": [
-      "eksponencialnějši",
-      "eksponencialněje",
+      "eksponenciaľnějši",
+      "eksponenciaľněje",
     ],
     "positive": [
-      "eksponencialny",
-      "eksponencialno",
+      "eksponenciaľny",
+      "eksponenciaľno",
     ],
     "superlative": [
-      "najeksponencialnějši",
-      "najeksponencialněje",
+      "najeksponenciaľnějši",
+      "najeksponenciaľněje",
     ],
   },
   "plural": {
     "acc": [
-      "eksponencialnyh / eksponencialne",
-      "eksponencialne",
+      "eksponenciaľnyh / eksponenciaľne",
+      "eksponenciaľne",
     ],
     "dat": [
-      "eksponencialnym",
+      "eksponenciaľnym",
     ],
     "gen": [
-      "eksponencialnyh",
+      "eksponenciaľnyh",
     ],
     "ins": [
-      "eksponencialnymi",
+      "eksponenciaľnymi",
     ],
     "loc": [
-      "eksponencialnyh",
+      "eksponenciaľnyh",
     ],
     "nom": [
-      "eksponencialni / eksponencialne",
-      "eksponencialne",
+      "eksponenciaľni / eksponenciaľne",
+      "eksponenciaľne",
     ],
   },
+  "short": "eksponenciaľėn",
   "singular": {
     "acc": [
-      "eksponencialnogo / eksponencialny",
-      "eksponencialno",
-      "eksponencialnų",
+      "eksponenciaľnogo / eksponenciaľny",
+      "eksponenciaľno",
+      "eksponenciaľnų",
     ],
     "dat": [
-      "eksponencialnomu",
-      "eksponencialnoj",
+      "eksponenciaľnomu",
+      "eksponenciaľnoj",
     ],
     "gen": [
-      "eksponencialnogo",
-      "eksponencialnoj",
+      "eksponenciaľnogo",
+      "eksponenciaľnoj",
     ],
     "ins": [
-      "eksponencialnym",
-      "eksponencialnojų",
+      "eksponenciaľnym",
+      "eksponenciaľnojų",
     ],
     "loc": [
-      "eksponencialnom",
-      "eksponencialnoj",
+      "eksponenciaľnom",
+      "eksponenciaľnoj",
     ],
     "nom": [
-      "eksponencialny",
-      "eksponencialno",
-      "eksponencialna",
+      "eksponenciaľny",
+      "eksponenciaľno",
+      "eksponenciaľna",
     ],
   },
 }
@@ -185882,6 +188470,7 @@ exports[`adjective 36080 1`] = `
       "neporušime",
     ],
   },
+  "short": "neporušim",
   "singular": {
     "acc": [
       "neporušimogo / neporušimy",
@@ -185951,6 +188540,7 @@ exports[`adjective 36082 1`] = `
       "nedotykajeme",
     ],
   },
+  "short": "nedotykajem",
   "singular": {
     "acc": [
       "nedotykajemogo / nedotykajemy",
@@ -186020,6 +188610,7 @@ exports[`adjective 36108 1`] = `
       "považene",
     ],
   },
+  "short": "považen",
   "singular": {
     "acc": [
       "považenogo / považeny",
@@ -186089,6 +188680,7 @@ exports[`adjective 36114 1`] = `
       "nedopustime",
     ],
   },
+  "short": "nedopustim",
   "singular": {
     "acc": [
       "nedopustimogo / nedopustimy",
@@ -186158,6 +188750,7 @@ exports[`adjective 36118 1`] = `
       "vseznajųće",
     ],
   },
+  "short": "vseznajųć",
   "singular": {
     "acc": [
       "vseznajųćego / vseznajųći",
@@ -186227,6 +188820,7 @@ exports[`adjective 36119 1`] = `
       "vsevědųće",
     ],
   },
+  "short": "vsevědųć",
   "singular": {
     "acc": [
       "vsevědųćego / vsevědųći",
@@ -186296,6 +188890,7 @@ exports[`adjective 36128 1`] = `
       "rituaľne",
     ],
   },
+  "short": "rituaľėn",
   "singular": {
     "acc": [
       "rituaľnogo / rituaľny",
@@ -186365,6 +188960,7 @@ exports[`adjective 36130 1`] = `
       "satirične",
     ],
   },
+  "short": "satiričėn",
   "singular": {
     "acc": [
       "satiričnogo / satiričny",
@@ -186434,6 +189030,7 @@ exports[`adjective 36133 1`] = `
       "ekvivalentne",
     ],
   },
+  "short": "ekvivalentėn",
   "singular": {
     "acc": [
       "ekvivalentnogo / ekvivalentny",
@@ -186503,6 +189100,7 @@ exports[`adjective 36134 1`] = `
       "råvnoznačne",
     ],
   },
+  "short": "råvnoznačėn",
   "singular": {
     "acc": [
       "råvnoznačnogo / råvnoznačny",
@@ -186572,6 +189170,7 @@ exports[`adjective 36135 1`] = `
       "samoubijne",
     ],
   },
+  "short": "samoubijėn",
   "singular": {
     "acc": [
       "samoubijnogo / samoubijny",
@@ -186641,6 +189240,7 @@ exports[`adjective 36160 1`] = `
       "žestoke",
     ],
   },
+  "short": "žestok",
   "singular": {
     "acc": [
       "žestokogo / žestoky",
@@ -186710,6 +189310,7 @@ exports[`adjective 36170 1`] = `
       "diskretne",
     ],
   },
+  "short": "diskretėn",
   "singular": {
     "acc": [
       "diskretnogo / diskretny",
@@ -186779,6 +189380,7 @@ exports[`adjective 36175 1`] = `
       "bezmytne",
     ],
   },
+  "short": "bezmytėn",
   "singular": {
     "acc": [
       "bezmytnogo / bezmytny",
@@ -186848,6 +189450,7 @@ exports[`adjective 36183 1`] = `
       "depresivne",
     ],
   },
+  "short": "depresivėn",
   "singular": {
     "acc": [
       "depresivnogo / depresivny",
@@ -186917,6 +189520,7 @@ exports[`adjective 36184 1`] = `
       "deprimovane",
     ],
   },
+  "short": "deprimovan",
   "singular": {
     "acc": [
       "deprimovanogo / deprimovany",
@@ -186986,6 +189590,7 @@ exports[`adjective 36196 1`] = `
       "dodatne",
     ],
   },
+  "short": "dodatėn",
   "singular": {
     "acc": [
       "dodatnogo / dodatny",
@@ -187055,6 +189660,7 @@ exports[`adjective 36209 1`] = `
       "baskijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "baskijskogo / baskijsky",
@@ -187124,6 +189730,7 @@ exports[`adjective 36240 1`] = `
       "narcistične",
     ],
   },
+  "short": "narcističėn",
   "singular": {
     "acc": [
       "narcističnogo / narcističny",
@@ -187193,6 +189800,7 @@ exports[`adjective 36241 1`] = `
       "roditeljske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "roditeljskogo / roditeljsky",
@@ -187262,6 +189870,7 @@ exports[`adjective 36242 1`] = `
       "dopȯlniteljne",
     ],
   },
+  "short": "dopȯlniteljėn",
   "singular": {
     "acc": [
       "dopȯlniteljnogo / dopȯlniteljny",
@@ -187331,6 +189940,7 @@ exports[`adjective 36247 1`] = `
       "metalične",
     ],
   },
+  "short": "metaličėn",
   "singular": {
     "acc": [
       "metaličnogo / metaličny",
@@ -187400,6 +190010,7 @@ exports[`adjective 36258 1`] = `
       "iglaste",
     ],
   },
+  "short": "iglast",
   "singular": {
     "acc": [
       "iglastogo / iglasty",
@@ -187434,18 +190045,9 @@ exports[`adjective 36258 1`] = `
 exports[`adjective 36271 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "po svaťbě povęzanějši",
-      "po svaťbě povęzaněje",
-    ],
-    "positive": [
-      "po svaťbě povęzany",
-      "po svaťbě povęzano",
-    ],
-    "superlative": [
-      "najpo svaťbě povęzanějši",
-      "najpo svaťbě povęzaněje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
@@ -187469,6 +190071,7 @@ exports[`adjective 36271 1`] = `
       "po svaťbě povęzane",
     ],
   },
+  "short": "po svaťbě povęzan",
   "singular": {
     "acc": [
       "po svaťbě povęzanogo / po svaťbě povęzany",
@@ -187538,6 +190141,7 @@ exports[`adjective 36307 1`] = `
       "strukturne",
     ],
   },
+  "short": "strukturėn",
   "singular": {
     "acc": [
       "strukturnogo / strukturny",
@@ -187607,6 +190211,7 @@ exports[`adjective 36310 1`] = `
       "nadprirodne",
     ],
   },
+  "short": "nadprirodėn",
   "singular": {
     "acc": [
       "nadprirodnogo / nadprirodny",
@@ -187676,6 +190281,7 @@ exports[`adjective 36315 1`] = `
       "apokaliptične",
     ],
   },
+  "short": "apokaliptičėn",
   "singular": {
     "acc": [
       "apokaliptičnogo / apokaliptičny",
@@ -187745,6 +190351,7 @@ exports[`adjective 36335 1`] = `
       "lesbijske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lesbijskogo / lesbijsky",
@@ -187814,6 +190421,7 @@ exports[`adjective 36348 1`] = `
       "aerodinamične",
     ],
   },
+  "short": "aerodinamičėn",
   "singular": {
     "acc": [
       "aerodinamičnogo / aerodinamičny",
@@ -187883,6 +190491,7 @@ exports[`adjective 36351 1`] = `
       "racionalizovane",
     ],
   },
+  "short": "racionalizovan",
   "singular": {
     "acc": [
       "racionalizovanogo / racionalizovany",
@@ -187952,6 +190561,7 @@ exports[`adjective 36355 1`] = `
       "minimalistične",
     ],
   },
+  "short": "minimalističėn",
   "singular": {
     "acc": [
       "minimalističnogo / minimalističny",
@@ -188021,6 +190631,7 @@ exports[`adjective 36363 1`] = `
       "idiomatične",
     ],
   },
+  "short": "idiomatičėn",
   "singular": {
     "acc": [
       "idiomatičnogo / idiomatičny",
@@ -188090,6 +190701,7 @@ exports[`adjective 36380 1`] = `
       "jugoiztočne",
     ],
   },
+  "short": "jugoiztočėn",
   "singular": {
     "acc": [
       "jugoiztočnogo / jugoiztočny",
@@ -188159,6 +190771,7 @@ exports[`adjective 36383 1`] = `
       "jugovȯzhodne",
     ],
   },
+  "short": "jugovȯzhodėn",
   "singular": {
     "acc": [
       "jugovȯzhodnogo / jugovȯzhodny",
@@ -188228,6 +190841,7 @@ exports[`adjective 36385 1`] = `
       "jugozapadne",
     ],
   },
+  "short": "jugozapadėn",
   "singular": {
     "acc": [
       "jugozapadnogo / jugozapadny",
@@ -188297,6 +190911,7 @@ exports[`adjective 36416 1`] = `
       "fonologične",
     ],
   },
+  "short": "fonologičėn",
   "singular": {
     "acc": [
       "fonologičnogo / fonologičny",
@@ -188366,6 +190981,7 @@ exports[`adjective 36418 1`] = `
       "neizměnjene",
     ],
   },
+  "short": "neizměnjen",
   "singular": {
     "acc": [
       "neizměnjenogo / neizměnjeny",
@@ -188435,6 +191051,7 @@ exports[`adjective 36440 1`] = `
       "aztečske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "aztečskogo / aztečsky",
@@ -188504,6 +191121,7 @@ exports[`adjective 36441 1`] = `
       "deprimujųće",
     ],
   },
+  "short": "deprimujųć",
   "singular": {
     "acc": [
       "deprimujųćego / deprimujųći",
@@ -188573,6 +191191,7 @@ exports[`adjective 36442 1`] = `
       "filozofske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "filozofskogo / filozofsky",
@@ -188642,6 +191261,7 @@ exports[`adjective 36444 1`] = `
       "pogranične",
     ],
   },
+  "short": "pograničėn",
   "singular": {
     "acc": [
       "pograničnogo / pograničny",
@@ -188711,6 +191331,7 @@ exports[`adjective 36449 1`] = `
       "novogrėčske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "novogrėčskogo / novogrėčsky",
@@ -188780,6 +191401,7 @@ exports[`adjective 36450 1`] = `
       "starogrėčske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "starogrėčskogo / starogrėčsky",
@@ -188849,6 +191471,7 @@ exports[`adjective 36453 1`] = `
       "prostačske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "prostačskogo / prostačsky",
@@ -188918,6 +191541,7 @@ exports[`adjective 36454 1`] = `
       "råzpoznavajeme",
     ],
   },
+  "short": "råzpoznavajem",
   "singular": {
     "acc": [
       "råzpoznavajemogo / råzpoznavajemy",
@@ -188987,6 +191611,7 @@ exports[`adjective 36461 1`] = `
       "utilitarne",
     ],
   },
+  "short": "utilitarėn",
   "singular": {
     "acc": [
       "utilitarnogo / utilitarny",
@@ -189056,6 +191681,7 @@ exports[`adjective 36463 1`] = `
       "fragmentarne",
     ],
   },
+  "short": "fragmentarėn",
   "singular": {
     "acc": [
       "fragmentarnogo / fragmentarny",
@@ -189125,6 +191751,7 @@ exports[`adjective 36468 1`] = `
       "skandaľne",
     ],
   },
+  "short": "skandaľėn",
   "singular": {
     "acc": [
       "skandaľnogo / skandaľny",
@@ -189194,6 +191821,7 @@ exports[`adjective 36478 1`] = `
       "komfortne",
     ],
   },
+  "short": "komfortėn",
   "singular": {
     "acc": [
       "komfortnogo / komfortny",
@@ -189263,6 +191891,7 @@ exports[`adjective 36481 1`] = `
       "javanske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "javanskogo / javansky",
@@ -189332,6 +191961,7 @@ exports[`adjective 36483 1`] = `
       "grenlandske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "grenlandskogo / grenlandsky",
@@ -189401,6 +192031,7 @@ exports[`adjective 36485 1`] = `
       "farerske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "farerskogo / farersky",
@@ -189470,6 +192101,7 @@ exports[`adjective 36487 1`] = `
       "filipinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "filipinskogo / filipinsky",
@@ -189539,6 +192171,7 @@ exports[`adjective 36490 1`] = `
       "topografične",
     ],
   },
+  "short": "topografičėn",
   "singular": {
     "acc": [
       "topografičnogo / topografičny",
@@ -189608,6 +192241,7 @@ exports[`adjective 36526 1`] = `
       "světove",
     ],
   },
+  "short": "světov",
   "singular": {
     "acc": [
       "světovogo / světovy",
@@ -189677,6 +192311,7 @@ exports[`adjective 36528 1`] = `
       "fiskaľne",
     ],
   },
+  "short": "fiskaľėn",
   "singular": {
     "acc": [
       "fiskaľnogo / fiskaľny",
@@ -189746,6 +192381,7 @@ exports[`adjective 36544 1`] = `
       "ozdobne",
     ],
   },
+  "short": "ozdobėn",
   "singular": {
     "acc": [
       "ozdobnogo / ozdobny",
@@ -189815,6 +192451,7 @@ exports[`adjective 36562 1`] = `
       "osetinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "osetinskogo / osetinsky",
@@ -189884,6 +192521,7 @@ exports[`adjective 36564 1`] = `
       "pridněstrovske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pridněstrovskogo / pridněstrovsky",
@@ -189953,6 +192591,7 @@ exports[`adjective 36565 1`] = `
       "abhazske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "abhazskogo / abhazsky",
@@ -190022,6 +192661,7 @@ exports[`adjective 36568 1`] = `
       "tatarske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "tatarskogo / tatarsky",
@@ -190091,6 +192731,7 @@ exports[`adjective 36569 1`] = `
       "baškirske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "baškirskogo / baškirsky",
@@ -190160,6 +192801,7 @@ exports[`adjective 36588 1`] = `
       "zaležne",
     ],
   },
+  "short": "zaležėn",
   "singular": {
     "acc": [
       "zaležnogo / zaležny",
@@ -190229,6 +192871,7 @@ exports[`adjective 36592 1`] = `
       "brjušne",
     ],
   },
+  "short": "brjušėn",
   "singular": {
     "acc": [
       "brjušnogo / brjušny",
@@ -190298,6 +192941,7 @@ exports[`adjective 36602 1`] = `
       "matematične",
     ],
   },
+  "short": "matematičėn",
   "singular": {
     "acc": [
       "matematičnogo / matematičny",
@@ -190367,6 +193011,7 @@ exports[`adjective 36604 1`] = `
       "člověkoljubive",
     ],
   },
+  "short": "člověkoljubiv",
   "singular": {
     "acc": [
       "člověkoljubivogo / člověkoljubivy",
@@ -190436,6 +193081,7 @@ exports[`adjective 36606 1`] = `
       "filantropične",
     ],
   },
+  "short": "filantropičėn",
   "singular": {
     "acc": [
       "filantropičnogo / filantropičny",
@@ -190505,6 +193151,7 @@ exports[`adjective 36626 1`] = `
       "povtorne",
     ],
   },
+  "short": "povtorėn",
   "singular": {
     "acc": [
       "povtornogo / povtorny",
@@ -190574,6 +193221,7 @@ exports[`adjective 36639 1`] = `
       "bezrodne",
     ],
   },
+  "short": "bezrodėn",
   "singular": {
     "acc": [
       "bezrodnogo / bezrodny",
@@ -190643,6 +193291,7 @@ exports[`adjective 36643 1`] = `
       "nonšalantne",
     ],
   },
+  "short": "nonšalantėn",
   "singular": {
     "acc": [
       "nonšalantnogo / nonšalantny",
@@ -190712,6 +193361,7 @@ exports[`adjective 36672 1`] = `
       "naględne",
     ],
   },
+  "short": "naględėn",
   "singular": {
     "acc": [
       "naględnogo / naględny",
@@ -190781,6 +193431,7 @@ exports[`adjective 36680 1`] = `
       "kosmetične",
     ],
   },
+  "short": "kosmetičėn",
   "singular": {
     "acc": [
       "kosmetičnogo / kosmetičny",
@@ -190850,6 +193501,7 @@ exports[`adjective 36683 1`] = `
       "aktorske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "aktorskogo / aktorsky",
@@ -190919,6 +193571,7 @@ exports[`adjective 36686 1`] = `
       "nedozvoljene",
     ],
   },
+  "short": "nedozvoljen",
   "singular": {
     "acc": [
       "nedozvoljenogo / nedozvoljeny",
@@ -190988,6 +193641,7 @@ exports[`adjective 36687 1`] = `
       "nepozvoljene",
     ],
   },
+  "short": "nepozvoljen",
   "singular": {
     "acc": [
       "nepozvoljenogo / nepozvoljeny",
@@ -191057,6 +193711,7 @@ exports[`adjective 36691 1`] = `
       "hvoroblive",
     ],
   },
+  "short": "hvorobliv",
   "singular": {
     "acc": [
       "hvoroblivogo / hvoroblivy",
@@ -191126,6 +193781,7 @@ exports[`adjective 36704 1`] = `
       "proklęte",
     ],
   },
+  "short": "proklęt",
   "singular": {
     "acc": [
       "proklętogo / proklęty",
@@ -191195,6 +193851,7 @@ exports[`adjective 36706 1`] = `
       "sųsrědotočene",
     ],
   },
+  "short": "sųsrědotočen",
   "singular": {
     "acc": [
       "sųsrědotočenogo / sųsrědotočeny",
@@ -191264,6 +193921,7 @@ exports[`adjective 36743 1`] = `
       "alergične",
     ],
   },
+  "short": "alergičėn",
   "singular": {
     "acc": [
       "alergičnogo / alergičny",
@@ -191333,6 +193991,7 @@ exports[`adjective 36749 1`] = `
       "autistične",
     ],
   },
+  "short": "autističėn",
   "singular": {
     "acc": [
       "autističnogo / autističny",
@@ -191402,6 +194061,7 @@ exports[`adjective 36750 1`] = `
       "råzsějane",
     ],
   },
+  "short": "råzsějan",
   "singular": {
     "acc": [
       "råzsějanogo / råzsějany",
@@ -191471,6 +194131,7 @@ exports[`adjective 36755 1`] = `
       "dopustime",
     ],
   },
+  "short": "dopustim",
   "singular": {
     "acc": [
       "dopustimogo / dopustimy",
@@ -191540,6 +194201,7 @@ exports[`adjective 36758 1`] = `
       "ambivalentne",
     ],
   },
+  "short": "ambivalentėn",
   "singular": {
     "acc": [
       "ambivalentnogo / ambivalentny",
@@ -191609,6 +194271,7 @@ exports[`adjective 36762 1`] = `
       "asimetrične",
     ],
   },
+  "short": "asimetričėn",
   "singular": {
     "acc": [
       "asimetričnogo / asimetričny",
@@ -191678,6 +194341,7 @@ exports[`adjective 36766 1`] = `
       "životinske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "životinskogo / životinsky",
@@ -191747,6 +194411,7 @@ exports[`adjective 36769 1`] = `
       "vodne",
     ],
   },
+  "short": "vodėn",
   "singular": {
     "acc": [
       "vodnogo / vodny",
@@ -191816,6 +194481,7 @@ exports[`adjective 36770 1`] = `
       "televizijne",
     ],
   },
+  "short": "televizijėn",
   "singular": {
     "acc": [
       "televizijnogo / televizijny",
@@ -191885,6 +194551,7 @@ exports[`adjective 36795 1`] = `
       "vnimateljne",
     ],
   },
+  "short": "vnimateljėn",
   "singular": {
     "acc": [
       "vnimateljnogo / vnimateljny",
@@ -191954,6 +194621,7 @@ exports[`adjective 36806 1`] = `
       "rogate",
     ],
   },
+  "short": "rogat",
   "singular": {
     "acc": [
       "rogatogo / rogaty",
@@ -192023,6 +194691,7 @@ exports[`adjective 36807 1`] = `
       "napaljene",
     ],
   },
+  "short": "napaljen",
   "singular": {
     "acc": [
       "napaljenogo / napaljeny",
@@ -192092,6 +194761,7 @@ exports[`adjective 36817 1`] = `
       "maltejske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "maltejskogo / maltejsky",
@@ -192161,6 +194831,7 @@ exports[`adjective 36827 1`] = `
       "zajedlive",
     ],
   },
+  "short": "zajedliv",
   "singular": {
     "acc": [
       "zajedlivogo / zajedlivy",
@@ -192230,6 +194901,7 @@ exports[`adjective 36829 1`] = `
       "histerične",
     ],
   },
+  "short": "histeričėn",
   "singular": {
     "acc": [
       "histeričnogo / histeričny",
@@ -192299,6 +194971,7 @@ exports[`adjective 36830 1`] = `
       "hromatične",
     ],
   },
+  "short": "hromatičėn",
   "singular": {
     "acc": [
       "hromatičnogo / hromatičny",
@@ -192368,6 +195041,7 @@ exports[`adjective 36831 1`] = `
       "diatonične",
     ],
   },
+  "short": "diatoničėn",
   "singular": {
     "acc": [
       "diatoničnogo / diatoničny",
@@ -192437,6 +195111,7 @@ exports[`adjective 36857 1`] = `
       "impotentne",
     ],
   },
+  "short": "impotentėn",
   "singular": {
     "acc": [
       "impotentnogo / impotentny",
@@ -192506,6 +195181,7 @@ exports[`adjective 36881 1`] = `
       "nadějne",
     ],
   },
+  "short": "nadějėn",
   "singular": {
     "acc": [
       "nadějnogo / nadějny",
@@ -192540,67 +195216,59 @@ exports[`adjective 36881 1`] = `
 exports[`adjective 36883 1`] = `
 {
   "comparison": {
-    "comparative": [
-      "ši",
-      "je",
-    ],
-    "positive": [
-      "y",
-      "o",
-    ],
-    "superlative": [
-      "najši",
-      "najje",
-    ],
+    "comparative": [],
+    "positive": [],
+    "superlative": [],
   },
   "plural": {
     "acc": [
-      "yh / e",
-      "e",
+      "pȯlnyh naděje / pȯlne naděje",
+      "pȯlne naděje",
     ],
     "dat": [
-      "ym",
+      "pȯlnym naděje",
     ],
     "gen": [
-      "yh",
+      "pȯlnyh naděje",
     ],
     "ins": [
-      "ymi",
+      "pȯlnymi naděje",
     ],
     "loc": [
-      "yh",
+      "pȯlnyh naděje",
     ],
     "nom": [
-      "i / e",
-      "e",
+      "pȯlni naděje / pȯlne naděje",
+      "pȯlne naděje",
     ],
   },
+  "short": "pȯln",
   "singular": {
     "acc": [
-      "ogo / pȯlny naděje",
-      "o",
-      "ų",
+      "pȯlnogo naděje / pȯlny naděje",
+      "pȯlno naděje",
+      "pȯlnų naděje",
     ],
     "dat": [
-      "omu",
-      "oj",
+      "pȯlnomu naděje",
+      "pȯlnoj naděje",
     ],
     "gen": [
-      "ogo",
-      "oj",
+      "pȯlnogo naděje",
+      "pȯlnoj naděje",
     ],
     "ins": [
-      "ym",
-      "ojų",
+      "pȯlnym naděje",
+      "pȯlnojų naděje",
     ],
     "loc": [
-      "om",
-      "oj",
+      "pȯlnom naděje",
+      "pȯlnoj naděje",
     ],
     "nom": [
-      "y",
-      "o",
-      "a",
+      "pȯlny naděje",
+      "pȯlno naděje",
+      "pȯlna naděje",
     ],
   },
 }
@@ -192644,6 +195312,7 @@ exports[`adjective 36884 1`] = `
       "očekyvane",
     ],
   },
+  "short": "očekyvan",
   "singular": {
     "acc": [
       "očekyvanogo / očekyvany",
@@ -192713,6 +195382,7 @@ exports[`adjective 36933 1`] = `
       "matove",
     ],
   },
+  "short": "matov",
   "singular": {
     "acc": [
       "matovogo / matovy",
@@ -192782,6 +195452,7 @@ exports[`adjective 36943 1`] = `
       "zadumlive",
     ],
   },
+  "short": "zadumliv",
   "singular": {
     "acc": [
       "zadumlivogo / zadumlivy",
@@ -192851,6 +195522,7 @@ exports[`adjective 36946 1`] = `
       "rodinne",
     ],
   },
+  "short": "rodinėn",
   "singular": {
     "acc": [
       "rodinnogo / rodinny",
@@ -192920,6 +195592,7 @@ exports[`adjective 36947 1`] = `
       "sěmėjne",
     ],
   },
+  "short": "sěmėjėn",
   "singular": {
     "acc": [
       "sěmėjnogo / sěmėjny",
@@ -192989,6 +195662,7 @@ exports[`adjective 36951 1`] = `
       "råstlinne",
     ],
   },
+  "short": "råstlinėn",
   "singular": {
     "acc": [
       "råstlinnogo / råstlinny",
@@ -193058,6 +195732,7 @@ exports[`adjective 36954 1`] = `
       "sųprųžske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "sųprųžskogo / sųprųžsky",
@@ -193127,6 +195802,7 @@ exports[`adjective 36955 1`] = `
       "gazove",
     ],
   },
+  "short": "gazov",
   "singular": {
     "acc": [
       "gazovogo / gazovy",
@@ -193196,6 +195872,7 @@ exports[`adjective 36957 1`] = `
       "sněžne",
     ],
   },
+  "short": "sněžėn",
   "singular": {
     "acc": [
       "sněžnogo / sněžny",
@@ -193265,6 +195942,7 @@ exports[`adjective 36960 1`] = `
       "drožđeve",
     ],
   },
+  "short": "drožđev",
   "singular": {
     "acc": [
       "drožđevogo / drožđevy",
@@ -193334,6 +196012,7 @@ exports[`adjective 36965 1`] = `
       "naměrne",
     ],
   },
+  "short": "naměrėn",
   "singular": {
     "acc": [
       "naměrnogo / naměrny",
@@ -193403,6 +196082,7 @@ exports[`adjective 36973 1`] = `
       "neodćuđime",
     ],
   },
+  "short": "neodćuđim",
   "singular": {
     "acc": [
       "neodćuđimogo / neodćuđimy",
@@ -193472,6 +196152,7 @@ exports[`adjective 36975 1`] = `
       "pušiste",
     ],
   },
+  "short": "pušist",
   "singular": {
     "acc": [
       "pušistogo / pušisty",
@@ -193541,6 +196222,7 @@ exports[`adjective 36982 1`] = `
       "kvasne",
     ],
   },
+  "short": "kvasėn",
   "singular": {
     "acc": [
       "kvasnogo / kvasny",
@@ -193610,6 +196292,7 @@ exports[`adjective 36991 1`] = `
       "nedråge",
     ],
   },
+  "short": "nedråg",
   "singular": {
     "acc": [
       "nedrågogo / nedrågy",
@@ -193679,6 +196362,7 @@ exports[`adjective 36998 1`] = `
       "blåžene",
     ],
   },
+  "short": "blåžen",
   "singular": {
     "acc": [
       "blåženogo / blåženy",
@@ -193748,6 +196432,7 @@ exports[`adjective 37000 1`] = `
       "kondensovane",
     ],
   },
+  "short": "kondensovan",
   "singular": {
     "acc": [
       "kondensovanogo / kondensovany",
@@ -193817,6 +196502,7 @@ exports[`adjective 37005 1`] = `
       "izotermične",
     ],
   },
+  "short": "izotermičėn",
   "singular": {
     "acc": [
       "izotermičnogo / izotermičny",
@@ -193886,6 +196572,7 @@ exports[`adjective 37019 1`] = `
       "nemŕtve",
     ],
   },
+  "short": "nemŕtv",
   "singular": {
     "acc": [
       "nemŕtvogo / nemŕtvy",
@@ -193955,6 +196642,7 @@ exports[`adjective 37024 1`] = `
       "telefonne",
     ],
   },
+  "short": "telefonėn",
   "singular": {
     "acc": [
       "telefonnogo / telefonny",
@@ -194024,6 +196712,7 @@ exports[`adjective 37110 1`] = `
       "kokosove",
     ],
   },
+  "short": "kokosov",
   "singular": {
     "acc": [
       "kokosovogo / kokosovy",
@@ -194093,6 +196782,7 @@ exports[`adjective 37112 1`] = `
       "koralove",
     ],
   },
+  "short": "koralov",
   "singular": {
     "acc": [
       "koralovogo / koralovy",
@@ -194162,6 +196852,7 @@ exports[`adjective 37116 1`] = `
       "marinovane",
     ],
   },
+  "short": "marinovan",
   "singular": {
     "acc": [
       "marinovanogo / marinovany",
@@ -194231,6 +196922,7 @@ exports[`adjective 37141 1`] = `
       "informacijne",
     ],
   },
+  "short": "informacijėn",
   "singular": {
     "acc": [
       "informacijnogo / informacijny",
@@ -194300,6 +196992,7 @@ exports[`adjective 37143 1`] = `
       "limonne",
     ],
   },
+  "short": "limonėn",
   "singular": {
     "acc": [
       "limonnogo / limonny",
@@ -194369,6 +197062,7 @@ exports[`adjective 37144 1`] = `
       "neuvěrjene",
     ],
   },
+  "short": "neuvěrjen",
   "singular": {
     "acc": [
       "neuvěrjenogo / neuvěrjeny",
@@ -194438,6 +197132,7 @@ exports[`adjective 37153 1`] = `
       "světlodiodne",
     ],
   },
+  "short": "světlodiodėn",
   "singular": {
     "acc": [
       "světlodiodnogo / světlodiodny",
@@ -194507,6 +197202,7 @@ exports[`adjective 37191 1`] = `
       "sočne",
     ],
   },
+  "short": "sočėn",
   "singular": {
     "acc": [
       "sočnogo / sočny",
@@ -194576,6 +197272,7 @@ exports[`adjective 37218 1`] = `
       "tutȯšnje",
     ],
   },
+  "short": "tutȯšėn",
   "singular": {
     "acc": [
       "tutȯšnjego / tutȯšnji",
@@ -194645,6 +197342,7 @@ exports[`adjective 37219 1`] = `
       "tamošnje",
     ],
   },
+  "short": "tamošėn",
   "singular": {
     "acc": [
       "tamošnjego / tamošnji",
@@ -194714,6 +197412,7 @@ exports[`adjective 37225 1`] = `
       "filharmonične",
     ],
   },
+  "short": "filharmoničėn",
   "singular": {
     "acc": [
       "filharmoničnogo / filharmoničny",
@@ -194783,6 +197482,7 @@ exports[`adjective 37239 1`] = `
       "operativne",
     ],
   },
+  "short": "operativėn",
   "singular": {
     "acc": [
       "operativnogo / operativny",
@@ -194852,6 +197552,7 @@ exports[`adjective 37241 1`] = `
       "modularne",
     ],
   },
+  "short": "modularėn",
   "singular": {
     "acc": [
       "modularnogo / modularny",
@@ -194921,6 +197622,7 @@ exports[`adjective 37250 1`] = `
       "zadovoliteljne",
     ],
   },
+  "short": "zadovoliteljėn",
   "singular": {
     "acc": [
       "zadovoliteljnogo / zadovoliteljny",
@@ -194990,6 +197692,7 @@ exports[`adjective 37251 1`] = `
       "nezadovoliteljne",
     ],
   },
+  "short": "nezadovoliteljėn",
   "singular": {
     "acc": [
       "nezadovoliteljnogo / nezadovoliteljny",
@@ -195059,6 +197762,7 @@ exports[`adjective 37272 1`] = `
       "melanholične",
     ],
   },
+  "short": "melanholičėn",
   "singular": {
     "acc": [
       "melanholičnogo / melanholičny",
@@ -195128,6 +197832,7 @@ exports[`adjective 37274 1`] = `
       "sangvinične",
     ],
   },
+  "short": "sangviničėn",
   "singular": {
     "acc": [
       "sangviničnogo / sangviničny",
@@ -195197,6 +197902,7 @@ exports[`adjective 37276 1`] = `
       "holerične",
     ],
   },
+  "short": "holeričėn",
   "singular": {
     "acc": [
       "holeričnogo / holeričny",
@@ -195266,6 +197972,7 @@ exports[`adjective 37280 1`] = `
       "fajne",
     ],
   },
+  "short": "fajėn",
   "singular": {
     "acc": [
       "fajnogo / fajny",
@@ -195335,6 +198042,7 @@ exports[`adjective 37284 1`] = `
       "optimistične",
     ],
   },
+  "short": "optimističėn",
   "singular": {
     "acc": [
       "optimističnogo / optimističny",
@@ -195404,6 +198112,7 @@ exports[`adjective 37285 1`] = `
       "avstro-vųgȯrske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "avstro-vųgȯrskogo / avstro-vųgȯrsky",
@@ -195473,6 +198182,7 @@ exports[`adjective 37296 1`] = `
       "korumpovane",
     ],
   },
+  "short": "korumpovan",
   "singular": {
     "acc": [
       "korumpovanogo / korumpovany",
@@ -195542,6 +198252,7 @@ exports[`adjective 37297 1`] = `
       "pričinne",
     ],
   },
+  "short": "pričinėn",
   "singular": {
     "acc": [
       "pričinnogo / pričinny",
@@ -195611,6 +198322,7 @@ exports[`adjective 37298 1`] = `
       "kauzaľne",
     ],
   },
+  "short": "kauzaľėn",
   "singular": {
     "acc": [
       "kauzaľnogo / kauzaľny",
@@ -195680,6 +198392,7 @@ exports[`adjective 37300 1`] = `
       "spoćene",
     ],
   },
+  "short": "spoćen",
   "singular": {
     "acc": [
       "spoćenogo / spoćeny",
@@ -195749,6 +198462,7 @@ exports[`adjective 37303 1`] = `
       "runne",
     ],
   },
+  "short": "runėn",
   "singular": {
     "acc": [
       "runnogo / runny",
@@ -195818,6 +198532,7 @@ exports[`adjective 37305 1`] = `
       "poganske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "poganskogo / pogansky",
@@ -195887,6 +198602,7 @@ exports[`adjective 37306 1`] = `
       "empirične",
     ],
   },
+  "short": "empiričėn",
   "singular": {
     "acc": [
       "empiričnogo / empiričny",
@@ -195956,6 +198672,7 @@ exports[`adjective 37313 1`] = `
       "kaznive",
     ],
   },
+  "short": "kazniv",
   "singular": {
     "acc": [
       "kaznivogo / kaznivy",
@@ -196025,6 +198742,7 @@ exports[`adjective 37317 1`] = `
       "socialdemokratične",
     ],
   },
+  "short": "socialdemokratičėn",
   "singular": {
     "acc": [
       "socialdemokratičnogo / socialdemokratičny",
@@ -196094,6 +198812,7 @@ exports[`adjective 37320 1`] = `
       "nacionalsocialistične",
     ],
   },
+  "short": "nacionalsocialističėn",
   "singular": {
     "acc": [
       "nacionalsocialističnogo / nacionalsocialističny",
@@ -196163,6 +198882,7 @@ exports[`adjective 37323 1`] = `
       "surrealistične",
     ],
   },
+  "short": "surrealističėn",
   "singular": {
     "acc": [
       "surrealističnogo / surrealističny",
@@ -196232,6 +198952,7 @@ exports[`adjective 37324 1`] = `
       "snizhoditeljne",
     ],
   },
+  "short": "snizhoditeljėn",
   "singular": {
     "acc": [
       "snizhoditeljnogo / snizhoditeljny",
@@ -196301,6 +199022,7 @@ exports[`adjective 37325 1`] = `
       "malostlive",
     ],
   },
+  "short": "malostliv",
   "singular": {
     "acc": [
       "malostlivogo / malostlivy",
@@ -196370,6 +199092,7 @@ exports[`adjective 37327 1`] = `
       "durove",
     ],
   },
+  "short": "durov",
   "singular": {
     "acc": [
       "durovogo / durovy",
@@ -196439,6 +199162,7 @@ exports[`adjective 37329 1`] = `
       "molove",
     ],
   },
+  "short": "molov",
   "singular": {
     "acc": [
       "molovogo / molovy",
@@ -196508,6 +199232,7 @@ exports[`adjective 37334 1`] = `
       "tonaľne",
     ],
   },
+  "short": "tonaľėn",
   "singular": {
     "acc": [
       "tonaľnogo / tonaľny",
@@ -196577,6 +199302,7 @@ exports[`adjective 37336 1`] = `
       "atonaľne",
     ],
   },
+  "short": "atonaľėn",
   "singular": {
     "acc": [
       "atonaľnogo / atonaľny",
@@ -196646,6 +199372,7 @@ exports[`adjective 37338 1`] = `
       "modaľne",
     ],
   },
+  "short": "modaľėn",
   "singular": {
     "acc": [
       "modaľnogo / modaľny",
@@ -196715,6 +199442,7 @@ exports[`adjective 37349 1`] = `
       "cinične",
     ],
   },
+  "short": "ciničėn",
   "singular": {
     "acc": [
       "ciničnogo / ciničny",
@@ -196784,6 +199512,7 @@ exports[`adjective 37352 1`] = `
       "bezråbotne",
     ],
   },
+  "short": "bezråbotėn",
   "singular": {
     "acc": [
       "bezråbotnogo / bezråbotny",
@@ -196853,6 +199582,7 @@ exports[`adjective 37356 1`] = `
       "kibernetične",
     ],
   },
+  "short": "kibernetičėn",
   "singular": {
     "acc": [
       "kibernetičnogo / kibernetičny",
@@ -196922,6 +199652,7 @@ exports[`adjective 37362 1`] = `
       "pravičaŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "pravičaŕskogo / pravičaŕsky",
@@ -196991,6 +199722,7 @@ exports[`adjective 37363 1`] = `
       "lěvičaŕske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "lěvičaŕskogo / lěvičaŕsky",
@@ -197060,6 +199792,7 @@ exports[`adjective 37373 1`] = `
       "ksenofobične",
     ],
   },
+  "short": "ksenofobičėn",
   "singular": {
     "acc": [
       "ksenofobičnogo / ksenofobičny",
@@ -197129,6 +199862,7 @@ exports[`adjective 37382 1`] = `
       "kurdske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "kurdskogo / kurdsky",
@@ -197198,6 +199932,7 @@ exports[`adjective 37385 1`] = `
       "smažene",
     ],
   },
+  "short": "smažen",
   "singular": {
     "acc": [
       "smaženogo / smaženy",
@@ -197267,6 +200002,7 @@ exports[`adjective 37393 1`] = `
       "djabȯľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "djabȯľskogo / djabȯľsky",
@@ -197336,6 +200072,7 @@ exports[`adjective 37393-1 1`] = `
       "djavȯľske",
     ],
   },
+  "short": undefined,
   "singular": {
     "acc": [
       "djavȯľskogo / djavȯľsky",
@@ -197405,6 +200142,7 @@ exports[`adjective 37394 1`] = `
       "čęstične",
     ],
   },
+  "short": "čęstičėn",
   "singular": {
     "acc": [
       "čęstičnogo / čęstičny",
@@ -197474,6 +200212,7 @@ exports[`adjective 37397 1`] = `
       "jednoročne",
     ],
   },
+  "short": "jednoročėn",
   "singular": {
     "acc": [
       "jednoročnogo / jednoročny",
@@ -197543,6 +200282,7 @@ exports[`adjective 37398 1`] = `
       "jednogodišnje",
     ],
   },
+  "short": "jednogodišėn",
   "singular": {
     "acc": [
       "jednogodišnjego / jednogodišnji",
@@ -197612,6 +200352,7 @@ exports[`adjective 37398-1 1`] = `
       "jednogodišne",
     ],
   },
+  "short": "jednogodišėn",
   "singular": {
     "acc": [
       "jednogodišnogo / jednogodišny",
@@ -197681,6 +200422,7 @@ exports[`adjective 37401 1`] = `
       "inovrěmenne",
     ],
   },
+  "short": "inovrěmenėn",
   "singular": {
     "acc": [
       "inovrěmennogo / inovrěmenny",
@@ -197750,6 +200492,7 @@ exports[`adjective 37404 1`] = `
       "mašinaľne",
     ],
   },
+  "short": "mašinaľėn",
   "singular": {
     "acc": [
       "mašinaľnogo / mašinaľny",
@@ -197819,6 +200562,7 @@ exports[`adjective 37405 1`] = `
       "međuvrěmenne",
     ],
   },
+  "short": "međuvrěmenėn",
   "singular": {
     "acc": [
       "međuvrěmennogo / međuvrěmenny",
@@ -197888,6 +200632,7 @@ exports[`adjective 37406 1`] = `
       "momentaľne",
     ],
   },
+  "short": "momentaľėn",
   "singular": {
     "acc": [
       "momentaľnogo / momentaľny",
@@ -197957,6 +200702,7 @@ exports[`adjective 37409 1`] = `
       "nedostatȯčne",
     ],
   },
+  "short": "nedostatȯčėn",
   "singular": {
     "acc": [
       "nedostatȯčnogo / nedostatȯčny",
@@ -198026,6 +200772,7 @@ exports[`adjective 37410 1`] = `
       "nerědke",
     ],
   },
+  "short": "nerědȯk",
   "singular": {
     "acc": [
       "nerědkogo / nerědky",
@@ -198095,6 +200842,7 @@ exports[`adjective 37411 1`] = `
       "poprěměnne",
     ],
   },
+  "short": "poprěměnėn",
   "singular": {
     "acc": [
       "poprěměnnogo / poprěměnny",
@@ -198164,6 +200912,7 @@ exports[`adjective 37412 1`] = `
       "pospěšne",
     ],
   },
+  "short": "pospěšėn",
   "singular": {
     "acc": [
       "pospěšnogo / pospěšny",
@@ -198233,6 +200982,7 @@ exports[`adjective 37415 1`] = `
       "povrěmenne",
     ],
   },
+  "short": "povrěmenėn",
   "singular": {
     "acc": [
       "povrěmennogo / povrěmenny",
@@ -198302,6 +201052,7 @@ exports[`adjective 37416 1`] = `
       "prědpoložiteljne",
     ],
   },
+  "short": "prědpoložiteljėn",
   "singular": {
     "acc": [
       "prědpoložiteljnogo / prědpoložiteljny",
@@ -198371,6 +201122,7 @@ exports[`adjective 37417 1`] = `
       "prěvažne",
     ],
   },
+  "short": "prěvažėn",
   "singular": {
     "acc": [
       "prěvažnogo / prěvažny",
@@ -198440,6 +201192,7 @@ exports[`adjective 37426 1`] = `
       "antropologične",
     ],
   },
+  "short": "antropologičėn",
   "singular": {
     "acc": [
       "antropologičnogo / antropologičny",
@@ -198509,6 +201262,7 @@ exports[`adjective 37427 1`] = `
       "filologične",
     ],
   },
+  "short": "filologičėn",
   "singular": {
     "acc": [
       "filologičnogo / filologičny",
@@ -198578,6 +201332,7 @@ exports[`adjective 37428 1`] = `
       "meteologične",
     ],
   },
+  "short": "meteologičėn",
   "singular": {
     "acc": [
       "meteologičnogo / meteologičny",
@@ -198647,6 +201402,7 @@ exports[`adjective 37430 1`] = `
       "morfologične",
     ],
   },
+  "short": "morfologičėn",
   "singular": {
     "acc": [
       "morfologičnogo / morfologičny",
@@ -198716,6 +201472,7 @@ exports[`adjective 37432 1`] = `
       "politologične",
     ],
   },
+  "short": "politologičėn",
   "singular": {
     "acc": [
       "politologičnogo / politologičny",
@@ -198785,6 +201542,7 @@ exports[`adjective 37434 1`] = `
       "radiologične",
     ],
   },
+  "short": "radiologičėn",
   "singular": {
     "acc": [
       "radiologičnogo / radiologičny",
@@ -198854,6 +201612,7 @@ exports[`adjective 37435 1`] = `
       "teologične",
     ],
   },
+  "short": "teologičėn",
   "singular": {
     "acc": [
       "teologičnogo / teologičny",
@@ -198923,6 +201682,7 @@ exports[`adjective 37436 1`] = `
       "virologične",
     ],
   },
+  "short": "virologičėn",
   "singular": {
     "acc": [
       "virologičnogo / virologičny",
@@ -198992,6 +201752,7 @@ exports[`adjective 37438 1`] = `
       "biografične",
     ],
   },
+  "short": "biografičėn",
   "singular": {
     "acc": [
       "biografičnogo / biografičny",
@@ -199061,6 +201822,7 @@ exports[`adjective 37443 1`] = `
       "etnografične",
     ],
   },
+  "short": "etnografičėn",
   "singular": {
     "acc": [
       "etnografičnogo / etnografičny",
@@ -199130,6 +201892,7 @@ exports[`adjective 37447 1`] = `
       "heteroseksuaľne",
     ],
   },
+  "short": "heteroseksuaľėn",
   "singular": {
     "acc": [
       "heteroseksuaľnogo / heteroseksuaľny",
@@ -199199,6 +201962,7 @@ exports[`adjective 37450 1`] = `
       "tipografične",
     ],
   },
+  "short": "tipografičėn",
   "singular": {
     "acc": [
       "tipografičnogo / tipografičny",
@@ -199268,6 +202032,7 @@ exports[`adjective 37453 1`] = `
       "kardiologične",
     ],
   },
+  "short": "kardiologičėn",
   "singular": {
     "acc": [
       "kardiologičnogo / kardiologičny",
@@ -199337,6 +202102,7 @@ exports[`adjective 37454 1`] = `
       "muzikologične",
     ],
   },
+  "short": "muzikologičėn",
   "singular": {
     "acc": [
       "muzikologičnogo / muzikologičny",
@@ -199406,6 +202172,7 @@ exports[`adjective 37462 1`] = `
       "ginekologične",
     ],
   },
+  "short": "ginekologičėn",
   "singular": {
     "acc": [
       "ginekologičnogo / ginekologičny",
@@ -199475,6 +202242,7 @@ exports[`adjective 37466 1`] = `
       "stvaŕne",
     ],
   },
+  "short": "stvaŕėn",
   "singular": {
     "acc": [
       "stvaŕnogo / stvaŕny",
@@ -199544,6 +202312,7 @@ exports[`adjective 37467 1`] = `
       "izbytȯčne",
     ],
   },
+  "short": "izbytȯčėn",
   "singular": {
     "acc": [
       "izbytȯčnogo / izbytȯčny",
@@ -199613,6 +202382,7 @@ exports[`adjective 37506 1`] = `
       "sžęte",
     ],
   },
+  "short": "sžęt",
   "singular": {
     "acc": [
       "sžętogo / sžęty",
@@ -199682,6 +202452,7 @@ exports[`adjective 37506-1 1`] = `
       "sȯžęte",
     ],
   },
+  "short": "sȯžęt",
   "singular": {
     "acc": [
       "sȯžętogo / sȯžęty",

--- a/src/adjective/__tests__/integrity.test.ts
+++ b/src/adjective/__tests__/integrity.test.ts
@@ -8,7 +8,7 @@ test('declensionAdjectiveFlat integrity', () => {
 
   // No empty strings expected
   expect(joint.filter(Boolean).length).toBe(joint.length);
-  expect(positive.length).toBe(18);
+  expect(positive.length).toBe(19);
   expect(comparative.length).toBe(14);
   expect(superlative.length).toBe(12);
 });

--- a/src/substitutions.ts
+++ b/src/substitutions.ts
@@ -1,16 +1,24 @@
-export const ALL_LETTERS = new Set(
+class LetterSet extends Set<string> {
+  toString() {
+    return [...this].join('');
+  }
+}
+
+export const ALL_LETTERS = new LetterSet(
   'aáàăâåąāæbcćçčdďđḓeéèĕêěëėęēǝfghiíìĭîīıjĵklĺľļłŀǉmnńňñņǌoóòŏôöȯǫœpqrŕṙřsśšŠtťṱuúùŭûůũųūvwxyýzźżž',
 );
 
-export const ALL_CONSONANTS = new Set(
+export const ALL_CONSONANTS = new LetterSet(
   'bcćçčdďđḓfghklĺľļłŀǉmnńňñņǌpqrŕṙřsśštťṱvwxzźżž',
 );
 
-export const ALL_VOWELS = new Set(
+export const ALL_VOWELS = new LetterSet(
   'aáàăâåąāæeéèĕêěëėęēǝiíìĭîīıoóòŏôöȯǫœuúùŭûůũųūyý',
 );
 
-export const VOWELS = new Set('aåeęěėioȯuųy');
+export const SOFT_CONSONANTS = new LetterSet('jcćčšžŕĺľťśď');
+
+export const VOWELS = new LetterSet('aåeęěėioȯuųy');
 
 export const LJ_NJ = ['lj', 'nj'];
 export const LJj_NJj = ['lj', 'ĺj', 'ľj', 'ǉ', 'nj', 'ńj', 'ňj', 'ñj', 'ǌ'];


### PR DESCRIPTION
Adds an optional `short` field to adjective paradigms, e.g.:

* bystr
* brz
* dȯlg
* mękȯk
* pȯln
* sinj
* tęžėk