### PR TITLE
fix(noun): refine -ec and -enj declension

### DIFF
--- a/src/common/fleetingVowels.ts
+++ b/src/common/fleetingVowels.ts
@@ -98,7 +98,10 @@ function canOmitYerInEc(word: string, i: number): boolean {
     ? [word[i - 3], word[i - 2]]
     : [word[i - 2], word[i - 1]];
 
-  return (isNonLetter(c2) || VOCALIZED.has(c2)) && c1 !== word[i + 1];
+  return (
+    (isNonLetter(c2) || VOCALIZED.has(c1) || VOCALIZED.has(c2)) &&
+    c1 !== word[i + 1]
+  );
 }
 
 /**

--- a/src/common/fleetingVowels.ts
+++ b/src/common/fleetingVowels.ts
@@ -40,10 +40,14 @@ export function inferFleetingVowel(word: string): string {
       continue;
     }
 
-    if (YERS.has(char) || isEC(word, i, end)) {
-      if (isLastSyllable(word, i, end) && canOmitYer(word, i)) {
-        result = replaceFleetingVowel(result, i);
-      }
+    if (isEC(word, i, end)) {
+      result = canOmitYerInEc(word, i)
+        ? replaceFleetingVowel(result, i)
+        : result;
+    } else if (YERS.has(char) && isLastSyllable(word, i, end)) {
+      result = canOmitYerInLastSyllable(word, i)
+        ? replaceFleetingVowel(result, i)
+        : result;
     }
   }
 
@@ -83,18 +87,31 @@ function isLastSyllable(word: string, i: number, end: number): boolean {
 }
 
 /**
- * Checks if the yer can be omitted in the word.
+ * Checks if the yer can be omitted in the word with -ec.
  *
  * @param word - The word to check.
  * @param i - The index of the yer.
  * @returns True if the yer can be omitted.
  */
-function canOmitYer(word: string, i: number): boolean {
+function canOmitYerInEc(word: string, i: number): boolean {
   const [c2, c1] = isLJNJ(word, i - 2)
     ? [word[i - 3], word[i - 2]]
     : [word[i - 2], word[i - 1]];
 
   return (isNonLetter(c2) || VOCALIZED.has(c2)) && c1 !== word[i + 1];
+}
+
+/**
+ * Checks if the yer can be omitted in the last syllable.
+ *
+ * @param word - The word to check.
+ * @param i - The index of the yer.
+ * @returns True if the yer can be omitted.
+ */
+function canOmitYerInLastSyllable(word: string, i: number): boolean {
+  const c1 = isLJNJ(word, i - 2) ? word[i - 2] : word[i - 1];
+
+  return c1 !== word[i + 1];
 }
 
 function isNonLetter(char: string): boolean {
@@ -111,5 +128,7 @@ function isLN(word: string, i: number): boolean {
 }
 
 function isEC(word: string, i: number, end: number): boolean {
-  return i > 0 && word[i] === 'e' && word[i + 1] === 'c' && i === end - 2;
+  return (
+    i > 0 && SOFT_YER_LOOSE.has(word[i]) && word[i + 1] === 'c' && i === end - 2
+  );
 }

--- a/src/noun/__tests__/__snapshots__/masculine.test.ts.snap
+++ b/src/noun/__tests__/__snapshots__/masculine.test.ts.snap
@@ -26494,31 +26494,31 @@ exports[`noun masculine 10850 1`] = `
 {
   "acc": [
     "poldėnj",
-    "poldėnje",
+    "poldnje",
   ],
   "dat": [
-    "poldėnju",
-    "poldėnjam",
+    "poldnju",
+    "poldnjam",
   ],
   "gen": [
-    "poldėnja",
-    "poldėnjev",
+    "poldnja",
+    "poldnjev",
   ],
   "ins": [
-    "poldėnjem",
-    "poldėnjami",
+    "poldnjem",
+    "poldnjami",
   ],
   "loc": [
-    "poldėnju",
-    "poldėnjah",
+    "poldnju",
+    "poldnjah",
   ],
   "nom": [
     "poldėnj",
-    "poldėnje",
+    "poldnje",
   ],
   "voc": [
-    "poldėnju",
-    "poldėnje",
+    "poldnju",
+    "poldnje",
   ],
 }
 `;
@@ -26560,31 +26560,31 @@ exports[`noun masculine 10918 1`] = `
 {
   "acc": [
     "popoldėnj",
-    "popoldėnje",
+    "popoldnje",
   ],
   "dat": [
-    "popoldėnju",
-    "popoldėnjam",
+    "popoldnju",
+    "popoldnjam",
   ],
   "gen": [
-    "popoldėnja",
-    "popoldėnjev",
+    "popoldnja",
+    "popoldnjev",
   ],
   "ins": [
-    "popoldėnjem",
-    "popoldėnjami",
+    "popoldnjem",
+    "popoldnjami",
   ],
   "loc": [
-    "popoldėnju",
-    "popoldėnjah",
+    "popoldnju",
+    "popoldnjah",
   ],
   "nom": [
     "popoldėnj",
-    "popoldėnje",
+    "popoldnje",
   ],
   "voc": [
-    "popoldėnju",
-    "popoldėnje",
+    "popoldnju",
+    "popoldnje",
   ],
 }
 `;
@@ -30083,31 +30083,31 @@ exports[`noun masculine 16373 1`] = `
 {
   "acc": [
     "Velikdėnj",
-    "Velikdėnje",
+    "Velikdnje",
   ],
   "dat": [
-    "Velikdėnju",
-    "Velikdėnjam",
+    "Velikdnju",
+    "Velikdnjam",
   ],
   "gen": [
-    "Velikdėnja",
-    "Velikdėnjev",
+    "Velikdnja",
+    "Velikdnjev",
   ],
   "ins": [
-    "Velikdėnjem",
-    "Velikdėnjami",
+    "Velikdnjem",
+    "Velikdnjami",
   ],
   "loc": [
-    "Velikdėnju",
-    "Velikdėnjah",
+    "Velikdnju",
+    "Velikdnjah",
   ],
   "nom": [
     "Velikdėnj",
-    "Velikdėnje",
+    "Velikdnje",
   ],
   "voc": [
-    "Velikdėnju",
-    "Velikdėnje",
+    "Velikdnju",
+    "Velikdnje",
   ],
 }
 `;

--- a/src/noun/__tests__/__snapshots__/miscellaneous.test.ts.snap
+++ b/src/noun/__tests__/__snapshots__/miscellaneous.test.ts.snap
@@ -268,31 +268,31 @@ exports[`noun miscellaneous 3749 (as feminine): feminine 1`] = `
 {
   "acc": [
     "uråvėnj",
-    "uråvėnji",
+    "uråvnji",
   ],
   "dat": [
-    "uråvėnji",
-    "uråvėnjam",
+    "uråvnji",
+    "uråvnjam",
   ],
   "gen": [
-    "uråvėnji",
-    "uråvėnjij",
+    "uråvnji",
+    "uråvnjij",
   ],
   "ins": [
-    "uråvėńjų",
-    "uråvėnjami",
+    "uråvńjų",
+    "uråvnjami",
   ],
   "loc": [
-    "uråvėnji",
-    "uråvėnjah",
+    "uråvnji",
+    "uråvnjah",
   ],
   "nom": [
     "uråvėnj",
-    "uråvėnji",
+    "uråvnji",
   ],
   "voc": [
-    "uråvėnji",
-    "uråvėnji",
+    "uråvnji",
+    "uråvnji",
   ],
 }
 `;

--- a/src/noun/declensionNoun.ts
+++ b/src/noun/declensionNoun.ts
@@ -107,7 +107,7 @@ export function declensionNoun(
 
   if (add && noun !== add) {
     noun = markFleetingVowel(noun, add);
-  } else if (originGender === 'masculine') {
+  } else if (originGender === 'masculine' || originGender === 'feminine') {
     noun = inferFleetingVowel(noun);
   }
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of fleeting vowels in the codebase, particularly focusing on the conditions for omitting 'yer' in different contexts and updating test snapshots accordingly:

* uravėnj (f.)
* Velikdėnj (m.)
* poldėnj (m.)