### PR TITLE
fix(verb): passive past particples for syllabic r verbs

### DIFF
--- a/src/verb/conjugationVerb.ts
+++ b/src/verb/conjugationVerb.ts
@@ -829,6 +829,8 @@ function build_pfpp(pref: string, is: string, psi: string): string {
     } else {
       ppps = pref + psi + 'en';
     }
+  } else if (is.charAt(i) == 'r' || is.charAt(i) == 'ŕ') {
+    ppps = pref + is + 't';
   } else {
     ppps = pref + is + 'en';
   }


### PR DESCRIPTION
Ranmaru piše:

> Ako imamo
> trěti/tŕti...
> Dlja tŕti, žrti, itp.
> tŕty, ne treny
> tŕťje, ne treńje
> Ale:
> trěti, žrěti, itd.
> Dajųt trěny i trěńje